### PR TITLE
Added basic system cache commands, and simplified show commands

### DIFF
--- a/cmd/osvbngcli/commands/all/all.go
+++ b/cmd/osvbngcli/commands/all/all.go
@@ -3,4 +3,5 @@ package all
 import (
 	_ "github.com/veesix-networks/osvbng/cmd/osvbngcli/commands/config"
 	_ "github.com/veesix-networks/osvbng/cmd/osvbngcli/commands/subscriber"
+	_ "github.com/veesix-networks/osvbng/cmd/osvbngcli/commands/system"
 )

--- a/cmd/osvbngcli/commands/helpers.go
+++ b/cmd/osvbngcli/commands/helpers.go
@@ -57,6 +57,21 @@ func ExecuteShowHandler(ctx context.Context, c interface{}, path showpaths.Path,
 	return nil
 }
 
+func ShowHandlerFunc(path showpaths.Path) func(context.Context, interface{}, []string) error {
+	return func(ctx context.Context, c interface{}, args []string) error {
+		return ExecuteShowHandler(ctx, c, path, args)
+	}
+}
+
+func ShowHandlerFuncWithValidator(path showpaths.Path, validator func([]string) error) func(context.Context, interface{}, []string) error {
+	return func(ctx context.Context, c interface{}, args []string) error {
+		if err := validator(args); err != nil {
+			return err
+		}
+		return ExecuteShowHandler(ctx, c, path, args)
+	}
+}
+
 func ExecuteConfigSet(ctx context.Context, c interface{}, path confpaths.Path, value string) error {
 	wrapper, ok := c.(CLIWrapper)
 	if !ok {

--- a/cmd/osvbngcli/commands/subscriber/subscriber.go
+++ b/cmd/osvbngcli/commands/subscriber/subscriber.go
@@ -1,9 +1,6 @@
 package subscriber
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/veesix-networks/osvbng/cmd/osvbngcli/commands"
 	"github.com/veesix-networks/osvbng/pkg/cli"
 	"github.com/veesix-networks/osvbng/pkg/show/paths"
@@ -18,13 +15,13 @@ func init() {
 	cli.Register("core", &cli.Command{
 		Path:        []string{"show", "subscriber", "sessions"},
 		Description: "Display subscriber sessions",
-		Handler:     cmdShowSubscriberSessions,
+		Handler:     commands.ShowHandlerFunc(paths.SubscriberSessions),
 	})
 
 	cli.Register("core", &cli.Command{
 		Path:        []string{"show", "subscriber", "session"},
 		Description: "Display subscriber session details",
-		Handler:     cmdShowSubscriberSession,
+		Handler:     commands.ShowHandlerFunc(paths.SubscriberSession),
 		Arguments: []*cli.Argument{
 			{Name: "session-id", Description: "Session identifier", Type: cli.ArgUserInput},
 		},
@@ -33,21 +30,6 @@ func init() {
 	cli.Register("core", &cli.Command{
 		Path:        []string{"show", "subscriber", "stats"},
 		Description: "Display subscriber statistics",
-		Handler:     cmdShowSubscriberStats,
+		Handler:     commands.ShowHandlerFunc(paths.SubscriberStats),
 	})
-}
-
-func cmdShowSubscriberSessions(ctx context.Context, c interface{}, args []string) error {
-	return commands.ExecuteShowHandler(ctx, c, paths.SubscriberSessions, args)
-}
-
-func cmdShowSubscriberSession(ctx context.Context, c interface{}, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("session-id required")
-	}
-	return commands.ExecuteShowHandler(ctx, c, paths.SubscriberSession, args)
-}
-
-func cmdShowSubscriberStats(ctx context.Context, c interface{}, args []string) error {
-	return commands.ExecuteShowHandler(ctx, c, paths.SubscriberStats, args)
 }

--- a/cmd/osvbngcli/commands/system/cache.go
+++ b/cmd/osvbngcli/commands/system/cache.go
@@ -1,0 +1,38 @@
+package system
+
+import (
+	"github.com/veesix-networks/osvbng/cmd/osvbngcli/commands"
+	"github.com/veesix-networks/osvbng/pkg/cli"
+	"github.com/veesix-networks/osvbng/pkg/show/paths"
+)
+
+func init() {
+	cli.RegisterRoot("core", &cli.RootCommand{
+		Path:        []string{"show", "system", "cache"},
+		Description: "Internal System config and state",
+	})
+
+	cli.Register("core", &cli.Command{
+		Path:        []string{"show", "system", "cache", "statistics"},
+		Description: "Display internal cache stats",
+		Handler:     commands.ShowHandlerFunc(paths.SystemCacheStatistics),
+	})
+
+	cli.Register("core", &cli.Command{
+		Path:        []string{"show", "system", "cache", "keys"},
+		Description: "Display internal cache keys",
+		Handler:     commands.ShowHandlerFunc(paths.SystemCacheKeys),
+		Arguments: []*cli.Argument{
+			{Name: "pattern", Description: "Cache Key Pattern (default: *)", Type: cli.ArgUserInput},
+		},
+	})
+
+	cli.Register("core", &cli.Command{
+		Path:        []string{"show", "system", "cache", "key"},
+		Description: "Display internal cache key",
+		Handler:     commands.ShowHandlerFunc(paths.SystemCacheKey),
+		Arguments: []*cli.Argument{
+			{Name: "key", Description: "Cache Key", Type: cli.ArgUserInput},
+		},
+	})
+}

--- a/cmd/osvbngd/main.go
+++ b/cmd/osvbngd/main.go
@@ -288,6 +288,7 @@ func main() {
 		Subscriber:       subscriberComp.(*subscriber.Component),
 		Southbound:       deps.VPP,
 		Routing:          routingComp.(*routing.Component),
+		Cache:            cache,
 		PluginComponents: pluginComponentsMap,
 	})
 

--- a/pkg/show/handlers/handler.go
+++ b/pkg/show/handlers/handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/veesix-networks/osvbng/internal/routing"
 	"github.com/veesix-networks/osvbng/internal/subscriber"
+	"github.com/veesix-networks/osvbng/pkg/cache"
 	"github.com/veesix-networks/osvbng/pkg/component"
 	"github.com/veesix-networks/osvbng/pkg/show/paths"
 	"github.com/veesix-networks/osvbng/pkg/southbound"
@@ -35,6 +36,7 @@ type ShowDeps struct {
 	Subscriber       *subscriber.Component
 	Southbound       *southbound.VPP
 	Routing          *routing.Component
+	Cache            cache.Cache
 	PluginComponents map[string]component.Component
 }
 

--- a/pkg/show/handlers/system/cache_key.go
+++ b/pkg/show/handlers/system/cache_key.go
@@ -1,0 +1,86 @@
+package system
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/veesix-networks/osvbng/pkg/cache"
+	"github.com/veesix-networks/osvbng/pkg/show/handlers"
+	"github.com/veesix-networks/osvbng/pkg/show/paths"
+)
+
+func init() {
+	handlers.RegisterFactory(NewCacheKeyHandler)
+}
+
+type CacheKeyHandler struct {
+	cache cache.Cache
+}
+
+type CacheKeyValue struct {
+	Key       string      `json:"key"`
+	Value     interface{} `json:"value"`
+	RawValue  string      `json:"raw_value"`
+	Exists    bool        `json:"exists"`
+	ValueType string      `json:"value_type"`
+	Error     string      `json:"error,omitempty"`
+}
+
+func NewCacheKeyHandler(deps *handlers.ShowDeps) handlers.ShowHandler {
+	return &CacheKeyHandler{
+		cache: deps.Cache,
+	}
+}
+
+func (h *CacheKeyHandler) Collect(ctx context.Context, req *handlers.ShowRequest) (interface{}, error) {
+	key := req.Options["key"]
+	if key == "" {
+		return nil, fmt.Errorf("key parameter is required")
+	}
+
+	result := &CacheKeyValue{
+		Key:    key,
+		Exists: false,
+	}
+
+	value, err := h.cache.Get(ctx, key)
+	if err != nil {
+		result.Error = err.Error()
+		return result, nil
+	}
+
+	result.Exists = true
+	result.RawValue = string(value)
+
+	var jsonValue interface{}
+	if err := json.Unmarshal(value, &jsonValue); err == nil {
+		result.Value = jsonValue
+		result.ValueType = "json"
+	} else {
+		var intValue int64
+		if _, err := fmt.Sscanf(string(value), "%d", &intValue); err == nil {
+			result.Value = intValue
+			result.ValueType = "integer"
+		} else {
+			if t, err := time.Parse(time.RFC3339, string(value)); err == nil {
+				result.Value = t
+				result.ValueType = "time"
+			} else {
+				result.Value = string(value)
+				result.ValueType = "string"
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func (h *CacheKeyHandler) PathPattern() paths.Path {
+	return paths.SystemCacheKey
+}
+
+func (h *CacheKeyHandler) Dependencies() []paths.Path {
+	return nil
+}

--- a/pkg/show/handlers/system/cache_keys.go
+++ b/pkg/show/handlers/system/cache_keys.go
@@ -1,0 +1,55 @@
+package system
+
+import (
+	"context"
+
+	"github.com/veesix-networks/osvbng/pkg/cache"
+	"github.com/veesix-networks/osvbng/pkg/show/handlers"
+	"github.com/veesix-networks/osvbng/pkg/show/paths"
+)
+
+func init() {
+	handlers.RegisterFactory(NewCacheKeysHandler)
+}
+
+type CacheKeysHandler struct {
+	cache cache.Cache
+}
+
+type CacheKeys struct {
+	Pattern string   `json:"pattern"`
+	Keys    []string `json:"keys"`
+	Count   int      `json:"count"`
+}
+
+func NewCacheKeysHandler(deps *handlers.ShowDeps) handlers.ShowHandler {
+	return &CacheKeysHandler{
+		cache: deps.Cache,
+	}
+}
+
+func (h *CacheKeysHandler) Collect(ctx context.Context, req *handlers.ShowRequest) (interface{}, error) {
+	pattern := req.Options["pattern"]
+	if pattern == "" {
+		pattern = "*"
+	}
+
+	keys, _, err := h.cache.Scan(ctx, 0, pattern, 100000)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CacheKeys{
+		Pattern: pattern,
+		Keys:    keys,
+		Count:   len(keys),
+	}, nil
+}
+
+func (h *CacheKeysHandler) PathPattern() paths.Path {
+	return paths.SystemCacheKeys
+}
+
+func (h *CacheKeysHandler) Dependencies() []paths.Path {
+	return nil
+}

--- a/pkg/show/handlers/system/cache_statistics.go
+++ b/pkg/show/handlers/system/cache_statistics.go
@@ -1,0 +1,60 @@
+package system
+
+import (
+	"context"
+
+	"github.com/veesix-networks/osvbng/pkg/cache"
+	"github.com/veesix-networks/osvbng/pkg/cache/memory"
+	"github.com/veesix-networks/osvbng/pkg/show/handlers"
+	"github.com/veesix-networks/osvbng/pkg/show/paths"
+)
+
+func init() {
+	handlers.RegisterFactory(NewCacheStatisticsHandler)
+}
+
+type CacheStatisticsHandler struct {
+	cache cache.Cache
+}
+
+type CacheStatistics struct {
+	Type       string `json:"type"`
+	TotalKeys  int    `json:"total_keys"`
+	TotalItems int    `json:"total_items"`
+}
+
+func NewCacheStatisticsHandler(deps *handlers.ShowDeps) handlers.ShowHandler {
+	return &CacheStatisticsHandler{
+		cache: deps.Cache,
+	}
+}
+
+func (h *CacheStatisticsHandler) Collect(ctx context.Context, req *handlers.ShowRequest) (interface{}, error) {
+	stats := &CacheStatistics{
+		Type: "unknown",
+	}
+
+	if _, ok := h.cache.(*memory.Cache); ok {
+		stats.Type = "memory"
+	} else {
+		stats.Type = "redis"
+	}
+
+	keys, _, err := h.cache.Scan(ctx, 0, "*", 100000)
+	if err != nil {
+		return nil, err
+	}
+
+	stats.TotalKeys = len(keys)
+	stats.TotalItems = len(keys)
+
+	return stats, nil
+}
+
+func (h *CacheStatisticsHandler) PathPattern() paths.Path {
+	return paths.SystemCacheStatistics
+}
+
+func (h *CacheStatisticsHandler) Dependencies() []paths.Path {
+	return nil
+}

--- a/pkg/show/paths/paths.go
+++ b/pkg/show/paths/paths.go
@@ -11,6 +11,9 @@ const (
 	SubscriberSession          Path = "subscriber.session"
 	SubscriberStats            Path = "subscriber.stats"
 	SystemThreads              Path = "system.threads"
+	SystemCacheStatistics      Path = "system.cache.statistics"
+	SystemCacheKeys            Path = "system.cache.keys"
+	SystemCacheKey             Path = "system.cache.key"
 
 	VRFS Path = "vrfs"
 )


### PR DESCRIPTION
```
bng> show system cache statistics | json
{
  "total_items": 5,
  "total_keys": 5,
  "type": "memory"
}
bng> show system cache keys | json
{
  "count": 5,
  "keys": [
    "osvbng:sessions:35644dad-d4ef-45e6-adf9-13503f576bde",
    "osvbng:lookup:ipoe-v4:02:00:00:00:00:01:100:0",
    "osvbng:lookup:arp:7:10.1.0.10",
    "osvbng:state:subscriber.sessions",
    "osvbng:session_count:02:00:00:00:00:01:100:0"
  ],
  "pattern": "*"
}
bng>  
```