### PR TITLE
Introduced Local Auth provider, API example and Oper Handler

### DIFF
--- a/api/proto/bng.pb.go
+++ b/api/proto/bng.pb.go
@@ -1629,6 +1629,102 @@ func (x *GetOperationalStatsResponse) GetMetrics() map[string][]byte {
 	return nil
 }
 
+type ExecuteOperationRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Path          string                 `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+	Body          []byte                 `protobuf:"bytes,2,opt,name=body,proto3" json:"body,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ExecuteOperationRequest) Reset() {
+	*x = ExecuteOperationRequest{}
+	mi := &file_api_proto_bng_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExecuteOperationRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExecuteOperationRequest) ProtoMessage() {}
+
+func (x *ExecuteOperationRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_proto_bng_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExecuteOperationRequest.ProtoReflect.Descriptor instead.
+func (*ExecuteOperationRequest) Descriptor() ([]byte, []int) {
+	return file_api_proto_bng_proto_rawDescGZIP(), []int{30}
+}
+
+func (x *ExecuteOperationRequest) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
+func (x *ExecuteOperationRequest) GetBody() []byte {
+	if x != nil {
+		return x.Body
+	}
+	return nil
+}
+
+type ExecuteOperationResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Data          []byte                 `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ExecuteOperationResponse) Reset() {
+	*x = ExecuteOperationResponse{}
+	mi := &file_api_proto_bng_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExecuteOperationResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExecuteOperationResponse) ProtoMessage() {}
+
+func (x *ExecuteOperationResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_proto_bng_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExecuteOperationResponse.ProtoReflect.Descriptor instead.
+func (*ExecuteOperationResponse) Descriptor() ([]byte, []int) {
+	return file_api_proto_bng_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *ExecuteOperationResponse) GetData() []byte {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
 var File_api_proto_bng_proto protoreflect.FileDescriptor
 
 const file_api_proto_bng_proto_rawDesc = "" +
@@ -1752,7 +1848,12 @@ const file_api_proto_bng_proto_rawDesc = "" +
 	"\ametrics\x18\x01 \x03(\v24.openbng.v1.GetOperationalStatsResponse.MetricsEntryR\ametrics\x1a:\n" +
 	"\fMetricsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\fR\x05value:\x028\x012\xf8\b\n" +
+	"\x05value\x18\x02 \x01(\fR\x05value:\x028\x01\"A\n" +
+	"\x17ExecuteOperationRequest\x12\x12\n" +
+	"\x04path\x18\x01 \x01(\tR\x04path\x12\x12\n" +
+	"\x04body\x18\x02 \x01(\fR\x04body\".\n" +
+	"\x18ExecuteOperationResponse\x12\x12\n" +
+	"\x04data\x18\x01 \x01(\fR\x04data2\xd7\t\n" +
 	"\n" +
 	"BNGService\x12N\n" +
 	"\vGetSessions\x12\x1e.openbng.v1.GetSessionsRequest\x1a\x1f.openbng.v1.GetSessionsResponse\x12@\n" +
@@ -1760,7 +1861,8 @@ const file_api_proto_bng_proto_rawDesc = "" +
 	"GetSession\x12\x1d.openbng.v1.GetSessionRequest\x1a\x13.openbng.v1.Session\x12:\n" +
 	"\bGetStats\x12\x1b.openbng.v1.GetStatsRequest\x1a\x11.openbng.v1.Stats\x12]\n" +
 	"\x10TerminateSession\x12#.openbng.v1.TerminateSessionRequest\x1a$.openbng.v1.TerminateSessionResponse\x12f\n" +
-	"\x13GetOperationalStats\x12&.openbng.v1.GetOperationalStatsRequest\x1a'.openbng.v1.GetOperationalStatsResponse\x12S\n" +
+	"\x13GetOperationalStats\x12&.openbng.v1.GetOperationalStatsRequest\x1a'.openbng.v1.GetOperationalStatsResponse\x12]\n" +
+	"\x10ExecuteOperation\x12#.openbng.v1.ExecuteOperationRequest\x1a$.openbng.v1.ExecuteOperationResponse\x12S\n" +
 	"\x10GetRunningConfig\x12#.openbng.v1.GetRunningConfigRequest\x1a\x1a.openbng.v1.ConfigResponse\x12S\n" +
 	"\x10GetStartupConfig\x12#.openbng.v1.GetStartupConfigRequest\x1a\x1a.openbng.v1.ConfigResponse\x12Q\n" +
 	"\fListVersions\x12\x1f.openbng.v1.ListVersionsRequest\x1a .openbng.v1.ListVersionsResponse\x12H\n" +
@@ -1785,7 +1887,7 @@ func file_api_proto_bng_proto_rawDescGZIP() []byte {
 	return file_api_proto_bng_proto_rawDescData
 }
 
-var file_api_proto_bng_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
+var file_api_proto_bng_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
 var file_api_proto_bng_proto_goTypes = []any{
 	(*GetSessionsRequest)(nil),          // 0: openbng.v1.GetSessionsRequest
 	(*GetSessionsResponse)(nil),         // 1: openbng.v1.GetSessionsResponse
@@ -1817,7 +1919,9 @@ var file_api_proto_bng_proto_goTypes = []any{
 	(*DiffLine)(nil),                    // 27: openbng.v1.DiffLine
 	(*GetOperationalStatsRequest)(nil),  // 28: openbng.v1.GetOperationalStatsRequest
 	(*GetOperationalStatsResponse)(nil), // 29: openbng.v1.GetOperationalStatsResponse
-	nil,                                 // 30: openbng.v1.GetOperationalStatsResponse.MetricsEntry
+	(*ExecuteOperationRequest)(nil),     // 30: openbng.v1.ExecuteOperationRequest
+	(*ExecuteOperationResponse)(nil),    // 31: openbng.v1.ExecuteOperationResponse
+	nil,                                 // 32: openbng.v1.GetOperationalStatsResponse.MetricsEntry
 }
 var file_api_proto_bng_proto_depIdxs = []int32{
 	3,  // 0: openbng.v1.GetSessionsResponse.sessions:type_name -> openbng.v1.Session
@@ -1827,37 +1931,39 @@ var file_api_proto_bng_proto_depIdxs = []int32{
 	27, // 4: openbng.v1.ConfigDiffResponse.added:type_name -> openbng.v1.DiffLine
 	27, // 5: openbng.v1.ConfigDiffResponse.deleted:type_name -> openbng.v1.DiffLine
 	27, // 6: openbng.v1.ConfigDiffResponse.modified:type_name -> openbng.v1.DiffLine
-	30, // 7: openbng.v1.GetOperationalStatsResponse.metrics:type_name -> openbng.v1.GetOperationalStatsResponse.MetricsEntry
+	32, // 7: openbng.v1.GetOperationalStatsResponse.metrics:type_name -> openbng.v1.GetOperationalStatsResponse.MetricsEntry
 	0,  // 8: openbng.v1.BNGService.GetSessions:input_type -> openbng.v1.GetSessionsRequest
 	2,  // 9: openbng.v1.BNGService.GetSession:input_type -> openbng.v1.GetSessionRequest
 	4,  // 10: openbng.v1.BNGService.GetStats:input_type -> openbng.v1.GetStatsRequest
 	6,  // 11: openbng.v1.BNGService.TerminateSession:input_type -> openbng.v1.TerminateSessionRequest
 	28, // 12: openbng.v1.BNGService.GetOperationalStats:input_type -> openbng.v1.GetOperationalStatsRequest
-	8,  // 13: openbng.v1.BNGService.GetRunningConfig:input_type -> openbng.v1.GetRunningConfigRequest
-	9,  // 14: openbng.v1.BNGService.GetStartupConfig:input_type -> openbng.v1.GetStartupConfigRequest
-	11, // 15: openbng.v1.BNGService.ListVersions:input_type -> openbng.v1.ListVersionsRequest
-	13, // 16: openbng.v1.BNGService.GetVersion:input_type -> openbng.v1.GetVersionRequest
-	17, // 17: openbng.v1.BNGService.ConfigEnter:input_type -> openbng.v1.ConfigEnterRequest
-	19, // 18: openbng.v1.BNGService.ConfigSet:input_type -> openbng.v1.ConfigSetRequest
-	21, // 19: openbng.v1.BNGService.ConfigCommit:input_type -> openbng.v1.ConfigCommitRequest
-	23, // 20: openbng.v1.BNGService.ConfigDiscard:input_type -> openbng.v1.ConfigDiscardRequest
-	25, // 21: openbng.v1.BNGService.ConfigDiff:input_type -> openbng.v1.ConfigDiffRequest
-	1,  // 22: openbng.v1.BNGService.GetSessions:output_type -> openbng.v1.GetSessionsResponse
-	3,  // 23: openbng.v1.BNGService.GetSession:output_type -> openbng.v1.Session
-	5,  // 24: openbng.v1.BNGService.GetStats:output_type -> openbng.v1.Stats
-	7,  // 25: openbng.v1.BNGService.TerminateSession:output_type -> openbng.v1.TerminateSessionResponse
-	29, // 26: openbng.v1.BNGService.GetOperationalStats:output_type -> openbng.v1.GetOperationalStatsResponse
-	10, // 27: openbng.v1.BNGService.GetRunningConfig:output_type -> openbng.v1.ConfigResponse
-	10, // 28: openbng.v1.BNGService.GetStartupConfig:output_type -> openbng.v1.ConfigResponse
-	12, // 29: openbng.v1.BNGService.ListVersions:output_type -> openbng.v1.ListVersionsResponse
-	14, // 30: openbng.v1.BNGService.GetVersion:output_type -> openbng.v1.VersionResponse
-	18, // 31: openbng.v1.BNGService.ConfigEnter:output_type -> openbng.v1.ConfigEnterResponse
-	20, // 32: openbng.v1.BNGService.ConfigSet:output_type -> openbng.v1.ConfigSetResponse
-	22, // 33: openbng.v1.BNGService.ConfigCommit:output_type -> openbng.v1.ConfigCommitResponse
-	24, // 34: openbng.v1.BNGService.ConfigDiscard:output_type -> openbng.v1.ConfigDiscardResponse
-	26, // 35: openbng.v1.BNGService.ConfigDiff:output_type -> openbng.v1.ConfigDiffResponse
-	22, // [22:36] is the sub-list for method output_type
-	8,  // [8:22] is the sub-list for method input_type
+	30, // 13: openbng.v1.BNGService.ExecuteOperation:input_type -> openbng.v1.ExecuteOperationRequest
+	8,  // 14: openbng.v1.BNGService.GetRunningConfig:input_type -> openbng.v1.GetRunningConfigRequest
+	9,  // 15: openbng.v1.BNGService.GetStartupConfig:input_type -> openbng.v1.GetStartupConfigRequest
+	11, // 16: openbng.v1.BNGService.ListVersions:input_type -> openbng.v1.ListVersionsRequest
+	13, // 17: openbng.v1.BNGService.GetVersion:input_type -> openbng.v1.GetVersionRequest
+	17, // 18: openbng.v1.BNGService.ConfigEnter:input_type -> openbng.v1.ConfigEnterRequest
+	19, // 19: openbng.v1.BNGService.ConfigSet:input_type -> openbng.v1.ConfigSetRequest
+	21, // 20: openbng.v1.BNGService.ConfigCommit:input_type -> openbng.v1.ConfigCommitRequest
+	23, // 21: openbng.v1.BNGService.ConfigDiscard:input_type -> openbng.v1.ConfigDiscardRequest
+	25, // 22: openbng.v1.BNGService.ConfigDiff:input_type -> openbng.v1.ConfigDiffRequest
+	1,  // 23: openbng.v1.BNGService.GetSessions:output_type -> openbng.v1.GetSessionsResponse
+	3,  // 24: openbng.v1.BNGService.GetSession:output_type -> openbng.v1.Session
+	5,  // 25: openbng.v1.BNGService.GetStats:output_type -> openbng.v1.Stats
+	7,  // 26: openbng.v1.BNGService.TerminateSession:output_type -> openbng.v1.TerminateSessionResponse
+	29, // 27: openbng.v1.BNGService.GetOperationalStats:output_type -> openbng.v1.GetOperationalStatsResponse
+	31, // 28: openbng.v1.BNGService.ExecuteOperation:output_type -> openbng.v1.ExecuteOperationResponse
+	10, // 29: openbng.v1.BNGService.GetRunningConfig:output_type -> openbng.v1.ConfigResponse
+	10, // 30: openbng.v1.BNGService.GetStartupConfig:output_type -> openbng.v1.ConfigResponse
+	12, // 31: openbng.v1.BNGService.ListVersions:output_type -> openbng.v1.ListVersionsResponse
+	14, // 32: openbng.v1.BNGService.GetVersion:output_type -> openbng.v1.VersionResponse
+	18, // 33: openbng.v1.BNGService.ConfigEnter:output_type -> openbng.v1.ConfigEnterResponse
+	20, // 34: openbng.v1.BNGService.ConfigSet:output_type -> openbng.v1.ConfigSetResponse
+	22, // 35: openbng.v1.BNGService.ConfigCommit:output_type -> openbng.v1.ConfigCommitResponse
+	24, // 36: openbng.v1.BNGService.ConfigDiscard:output_type -> openbng.v1.ConfigDiscardResponse
+	26, // 37: openbng.v1.BNGService.ConfigDiff:output_type -> openbng.v1.ConfigDiffResponse
+	23, // [23:38] is the sub-list for method output_type
+	8,  // [8:23] is the sub-list for method input_type
 	8,  // [8:8] is the sub-list for extension type_name
 	8,  // [8:8] is the sub-list for extension extendee
 	0,  // [0:8] is the sub-list for field type_name
@@ -1874,7 +1980,7 @@ func file_api_proto_bng_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_proto_bng_proto_rawDesc), len(file_api_proto_bng_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   31,
+			NumMessages:   33,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/proto/bng.proto
+++ b/api/proto/bng.proto
@@ -14,6 +14,9 @@ service BNGService {
   // Show operational data (generic handler-based)
   rpc GetOperationalStats(GetOperationalStatsRequest) returns (GetOperationalStatsResponse);
 
+  // Operational commands (generic handler-based)
+  rpc ExecuteOperation(ExecuteOperationRequest) returns (ExecuteOperationResponse);
+
   // Configuration management
   rpc GetRunningConfig(GetRunningConfigRequest) returns (ConfigResponse);
   rpc GetStartupConfig(GetStartupConfigRequest) returns (ConfigResponse);
@@ -176,4 +179,13 @@ message GetOperationalStatsRequest {
 
 message GetOperationalStatsResponse {
   map<string, bytes> metrics = 1;
+}
+
+message ExecuteOperationRequest {
+  string path = 1;
+  bytes body = 2;
+}
+
+message ExecuteOperationResponse {
+  bytes data = 1;
 }

--- a/api/proto/bng_grpc.pb.go
+++ b/api/proto/bng_grpc.pb.go
@@ -24,6 +24,7 @@ const (
 	BNGService_GetStats_FullMethodName            = "/openbng.v1.BNGService/GetStats"
 	BNGService_TerminateSession_FullMethodName    = "/openbng.v1.BNGService/TerminateSession"
 	BNGService_GetOperationalStats_FullMethodName = "/openbng.v1.BNGService/GetOperationalStats"
+	BNGService_ExecuteOperation_FullMethodName    = "/openbng.v1.BNGService/ExecuteOperation"
 	BNGService_GetRunningConfig_FullMethodName    = "/openbng.v1.BNGService/GetRunningConfig"
 	BNGService_GetStartupConfig_FullMethodName    = "/openbng.v1.BNGService/GetStartupConfig"
 	BNGService_ListVersions_FullMethodName        = "/openbng.v1.BNGService/ListVersions"
@@ -46,6 +47,8 @@ type BNGServiceClient interface {
 	TerminateSession(ctx context.Context, in *TerminateSessionRequest, opts ...grpc.CallOption) (*TerminateSessionResponse, error)
 	// Show operational data (generic handler-based)
 	GetOperationalStats(ctx context.Context, in *GetOperationalStatsRequest, opts ...grpc.CallOption) (*GetOperationalStatsResponse, error)
+	// Operational commands (generic handler-based)
+	ExecuteOperation(ctx context.Context, in *ExecuteOperationRequest, opts ...grpc.CallOption) (*ExecuteOperationResponse, error)
 	// Configuration management
 	GetRunningConfig(ctx context.Context, in *GetRunningConfigRequest, opts ...grpc.CallOption) (*ConfigResponse, error)
 	GetStartupConfig(ctx context.Context, in *GetStartupConfigRequest, opts ...grpc.CallOption) (*ConfigResponse, error)
@@ -110,6 +113,16 @@ func (c *bNGServiceClient) GetOperationalStats(ctx context.Context, in *GetOpera
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetOperationalStatsResponse)
 	err := c.cc.Invoke(ctx, BNGService_GetOperationalStats_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *bNGServiceClient) ExecuteOperation(ctx context.Context, in *ExecuteOperationRequest, opts ...grpc.CallOption) (*ExecuteOperationResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ExecuteOperationResponse)
+	err := c.cc.Invoke(ctx, BNGService_ExecuteOperation_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -217,6 +230,8 @@ type BNGServiceServer interface {
 	TerminateSession(context.Context, *TerminateSessionRequest) (*TerminateSessionResponse, error)
 	// Show operational data (generic handler-based)
 	GetOperationalStats(context.Context, *GetOperationalStatsRequest) (*GetOperationalStatsResponse, error)
+	// Operational commands (generic handler-based)
+	ExecuteOperation(context.Context, *ExecuteOperationRequest) (*ExecuteOperationResponse, error)
 	// Configuration management
 	GetRunningConfig(context.Context, *GetRunningConfigRequest) (*ConfigResponse, error)
 	GetStartupConfig(context.Context, *GetStartupConfigRequest) (*ConfigResponse, error)
@@ -251,6 +266,9 @@ func (UnimplementedBNGServiceServer) TerminateSession(context.Context, *Terminat
 }
 func (UnimplementedBNGServiceServer) GetOperationalStats(context.Context, *GetOperationalStatsRequest) (*GetOperationalStatsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetOperationalStats not implemented")
+}
+func (UnimplementedBNGServiceServer) ExecuteOperation(context.Context, *ExecuteOperationRequest) (*ExecuteOperationResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ExecuteOperation not implemented")
 }
 func (UnimplementedBNGServiceServer) GetRunningConfig(context.Context, *GetRunningConfigRequest) (*ConfigResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetRunningConfig not implemented")
@@ -386,6 +404,24 @@ func _BNGService_GetOperationalStats_Handler(srv interface{}, ctx context.Contex
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(BNGServiceServer).GetOperationalStats(ctx, req.(*GetOperationalStatsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _BNGService_ExecuteOperation_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ExecuteOperationRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BNGServiceServer).ExecuteOperation(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BNGService_ExecuteOperation_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BNGServiceServer).ExecuteOperation(ctx, req.(*ExecuteOperationRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -578,6 +614,10 @@ var BNGService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetOperationalStats",
 			Handler:    _BNGService_GetOperationalStats_Handler,
+		},
+		{
+			MethodName: "ExecuteOperation",
+			Handler:    _BNGService_ExecuteOperation_Handler,
 		},
 		{
 			MethodName: "GetRunningConfig",

--- a/cmd/osvbngcli/commands/system/handlers.go
+++ b/cmd/osvbngcli/commands/system/handlers.go
@@ -1,0 +1,27 @@
+package system
+
+import (
+	"github.com/veesix-networks/osvbng/cmd/osvbngcli/commands"
+	"github.com/veesix-networks/osvbng/pkg/cli"
+	"github.com/veesix-networks/osvbng/pkg/show/paths"
+)
+
+func init() {
+	cli.Register("core", &cli.Command{
+		Path:        []string{"show", "system", "handlers", "conf"},
+		Description: "Display registered configuration handlers",
+		Handler:     commands.ShowHandlerFunc(paths.SystemConfHandlers),
+	})
+
+	cli.Register("core", &cli.Command{
+		Path:        []string{"show", "system", "handlers", "show"},
+		Description: "Display registered show handlers",
+		Handler:     commands.ShowHandlerFunc(paths.SystemShowHandlers),
+	})
+
+	cli.Register("core", &cli.Command{
+		Path:        []string{"show", "system", "handlers", "oper"},
+		Description: "Display registered oper handlers",
+		Handler:     commands.ShowHandlerFunc(paths.SystemOperHandlers),
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/lunixbochs/struc v0.0.0-20200521075829-a4cb8d33dbbe // indirect
+	github.com/mattn/go-sqlite3 v1.14.33 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lunixbochs/struc v0.0.0-20200521075829-a4cb8d33dbbe h1:ewr1srjRCmcQogPQ/NCx6XCk6LGVmsVCc9Y3vvPZj+Y=
 github.com/lunixbochs/struc v0.0.0-20200521075829-a4cb8d33dbbe/go.mod h1:vy1vK6wD6j7xX6O6hXe621WabdtNkou2h7uRtTfRMyg=
+github.com/mattn/go-sqlite3 v1.14.33 h1:A5blZ5ulQo2AtayQ9/limgHEkFreKj1Dv226a1K73s0=
+github.com/mattn/go-sqlite3 v1.14.33/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/veesix-networks/osvbng/pkg/conf/handlers"
+	"github.com/veesix-networks/osvbng/pkg/conf/paths"
 	"github.com/veesix-networks/osvbng/pkg/conf/types"
 	"github.com/veesix-networks/osvbng/pkg/frr"
 )
@@ -52,6 +53,17 @@ func (cd *ConfigDaemon) AutoRegisterHandlers(deps *handlers.ConfDeps) {
 	defer cd.mu.Unlock()
 
 	cd.registry.AutoRegisterAll(deps)
+}
+
+func (cd *ConfigDaemon) GetRegistry() *handlers.Registry {
+	return cd.registry
+}
+
+func (cd *ConfigDaemon) GetAllConfPaths() []paths.Path {
+	cd.mu.RLock()
+	defer cd.mu.RUnlock()
+
+	return cd.registry.GetAllPaths()
 }
 
 func (cd *ConfigDaemon) CreateCandidateSession() (types.SessionID, error) {
@@ -110,7 +122,7 @@ func (cd *ConfigDaemon) Set(id types.SessionID, path string, value interface{}) 
 
 	oldValue, err := getValueFromConfig(sess.config, path)
 	if err != nil {
-		return fmt.Errorf("failed to get old value: %w", err)
+		oldValue = nil
 	}
 
 	hctx := &handlers.HandlerContext{

--- a/pkg/conf/handlers/handler_test.go
+++ b/pkg/conf/handlers/handler_test.go
@@ -1,0 +1,44 @@
+package handlers
+
+import "testing"
+
+func TestMatchPattern(t *testing.T) {
+	tests := []struct {
+		pattern string
+		path    string
+		want    bool
+	}{
+		{
+			pattern: "subscriber:auth:local:user:*:enabled",
+			path:    "subscriber:auth:local:user:example@veesix-networks.co.uk:enabled",
+			want:    true,
+		},
+		{
+			pattern: "subscriber:auth:local:user:*:password",
+			path:    "subscriber:auth:local:user:alice:password",
+			want:    true,
+		},
+		{
+			pattern: "interfaces:*:enabled",
+			path:    "interfaces:eth0:enabled",
+			want:    true,
+		},
+		{
+			pattern: "interfaces:*:enabled",
+			path:    "interfaces:eth0:description",
+			want:    false,
+		},
+		{
+			pattern: "subscriber:*:*:user",
+			path:    "subscriber:auth:local:user",
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		got := matchPattern(tt.pattern, tt.path)
+		if got != tt.want {
+			t.Errorf("matchPattern(%q, %q) = %v, want %v", tt.pattern, tt.path, got, tt.want)
+		}
+	}
+}

--- a/pkg/conf/handlers/interface/address.go
+++ b/pkg/conf/handlers/interface/address.go
@@ -61,7 +61,7 @@ func (h *IPv4AddressHandler) PathPattern() paths.Path {
 }
 
 func (h *IPv4AddressHandler) Dependencies() []paths.Path {
-	return []paths.Path{"interfaces.*"}
+	return []paths.Path{paths.Interface}
 }
 
 func (h *IPv4AddressHandler) Callbacks() *handlers.Callbacks {
@@ -113,7 +113,7 @@ func (h *IPv6AddressHandler) PathPattern() paths.Path {
 }
 
 func (h *IPv6AddressHandler) Dependencies() []paths.Path {
-	return []paths.Path{"interfaces.*"}
+	return []paths.Path{paths.Interface}
 }
 
 func (h *IPv6AddressHandler) Callbacks() *handlers.Callbacks {

--- a/pkg/conf/handlers/interface/description.go
+++ b/pkg/conf/handlers/interface/description.go
@@ -56,7 +56,7 @@ func (h *DescriptionHandler) PathPattern() paths.Path {
 }
 
 func (h *DescriptionHandler) Dependencies() []paths.Path {
-	return []paths.Path{"interfaces.*"}
+	return []paths.Path{paths.Interface}
 }
 
 func (h *DescriptionHandler) Callbacks() *handlers.Callbacks {

--- a/pkg/conf/handlers/interface/enabled.go
+++ b/pkg/conf/handlers/interface/enabled.go
@@ -52,7 +52,7 @@ func (h *EnabledHandler) PathPattern() paths.Path {
 }
 
 func (h *EnabledHandler) Dependencies() []paths.Path {
-	return []paths.Path{"interfaces.*"}
+	return []paths.Path{paths.Interface}
 }
 
 func (h *EnabledHandler) Callbacks() *handlers.Callbacks {

--- a/pkg/conf/handlers/interface/interface.go
+++ b/pkg/conf/handlers/interface/interface.go
@@ -41,7 +41,7 @@ func (h *InterfaceHandler) Rollback(ctx context.Context, hctx *handlers.HandlerC
 }
 
 func (h *InterfaceHandler) PathPattern() paths.Path {
-	return "interfaces.*"
+	return paths.Interface
 }
 
 func (h *InterfaceHandler) Dependencies() []paths.Path {

--- a/pkg/conf/handlers/interface/mtu.go
+++ b/pkg/conf/handlers/interface/mtu.go
@@ -82,7 +82,7 @@ func (h *MTUHandler) PathPattern() paths.Path {
 }
 
 func (h *MTUHandler) Dependencies() []paths.Path {
-	return []paths.Path{"interfaces.*"}
+	return []paths.Path{paths.Interface}
 }
 
 func (h *MTUHandler) Callbacks() *handlers.Callbacks {

--- a/pkg/conf/handlers/protocols/bgp/asn.go
+++ b/pkg/conf/handlers/protocols/bgp/asn.go
@@ -52,7 +52,7 @@ func (h *BGPASNHandler) Rollback(ctx context.Context, hctx *handlers.HandlerCont
 }
 
 func (h *BGPASNHandler) PathPattern() paths.Path {
-	return "protocols.bgp.asn"
+	return paths.ProtocolsBGPASN
 }
 
 func (h *BGPASNHandler) Dependencies() []paths.Path {

--- a/pkg/conf/handlers/protocols/bgp/instance.go
+++ b/pkg/conf/handlers/protocols/bgp/instance.go
@@ -66,7 +66,7 @@ func extractASNFromPath(path string) (uint32, error) {
 }
 
 func (h *BGPInstanceHandler) PathPattern() paths.Path {
-	return "protocols.bgp.*"
+	return paths.ProtocolsBGPInstance
 }
 
 func (h *BGPInstanceHandler) Dependencies() []paths.Path {

--- a/pkg/conf/handlers/protocols/static/route.go
+++ b/pkg/conf/handlers/protocols/static/route.go
@@ -23,14 +23,14 @@ type RouteHandler struct {
 func NewIPv4RouteHandler(daemons *handlers.ConfDeps) handlers.Handler {
 	return &RouteHandler{
 		dataplane:   daemons.Dataplane,
-		pathPattern: "protocols.static.ipv4.*",
+		pathPattern: paths.ProtocolsStaticIPv4Route,
 	}
 }
 
 func NewIPv6RouteHandler(daemons *handlers.ConfDeps) handlers.Handler {
 	return &RouteHandler{
 		dataplane:   daemons.Dataplane,
-		pathPattern: "protocols.static.ipv6.*",
+		pathPattern: paths.ProtocolsStaticIPv6Route,
 	}
 }
 

--- a/pkg/conf/handlers/vrfs/vrfs.go
+++ b/pkg/conf/handlers/vrfs/vrfs.go
@@ -45,7 +45,7 @@ func (h *VRFHandler) Rollback(ctx context.Context, hctx *handlers.HandlerContext
 }
 
 func (h *VRFHandler) PathPattern() paths.Path {
-	return "vrfs.*"
+	return paths.VRFS
 }
 
 func (h *VRFHandler) Dependencies() []paths.Path {

--- a/pkg/conf/path.go
+++ b/pkg/conf/path.go
@@ -34,74 +34,60 @@ func getValueFromConfig(config *types.Config, path string) (interface{}, error) 
 		return nil, fmt.Errorf("empty path")
 	}
 
-	if parts[0] == "plugins" && len(parts) >= 2 && config.Plugins != nil {
-		namespace := ""
-		fieldStartIdx := -1
-
+	if config.Plugins != nil {
 		for ns := range config.Plugins {
 			nsParts := strings.Split(ns, ".")
-			if len(parts) >= len(nsParts)+1 {
+			if len(parts) >= len(nsParts) {
 				matches := true
 				for i, nsPart := range nsParts {
-					if parts[i+1] != nsPart {
+					if parts[i] != nsPart {
 						matches = false
 						break
 					}
 				}
 				if matches {
-					namespace = ns
-					fieldStartIdx = len(nsParts) + 1
-					break
+					pluginCfg := config.Plugins[ns]
+
+					if len(parts) == len(nsParts) {
+						return pluginCfg, nil
+					}
+
+					current := pluginCfg
+					for _, part := range parts[len(nsParts):] {
+						v := reflect.ValueOf(current)
+
+						if v.Kind() == reflect.Ptr {
+							if v.IsNil() {
+								return nil, nil
+							}
+							v = v.Elem()
+						}
+
+						switch v.Kind() {
+						case reflect.Struct:
+							field := findFieldByPath(v, part)
+							if !field.IsValid() {
+								return nil, fmt.Errorf("field not found: %s", part)
+							}
+							current = field.Interface()
+
+						case reflect.Map:
+							key := reflect.ValueOf(part)
+							value := v.MapIndex(key)
+							if !value.IsValid() {
+								return nil, nil
+							}
+							current = value.Interface()
+
+						default:
+							return nil, fmt.Errorf("cannot navigate into type %s at %s", v.Kind(), part)
+						}
+					}
+
+					return current, nil
 				}
 			}
 		}
-
-		if namespace == "" {
-			return nil, nil
-		}
-
-		pluginCfg, ok := config.Plugins[namespace]
-		if !ok {
-			return nil, nil
-		}
-
-		if fieldStartIdx >= len(parts) {
-			return pluginCfg, nil
-		}
-
-		current := pluginCfg
-		for _, part := range parts[fieldStartIdx:] {
-			v := reflect.ValueOf(current)
-
-			if v.Kind() == reflect.Ptr {
-				if v.IsNil() {
-					return nil, nil
-				}
-				v = v.Elem()
-			}
-
-			switch v.Kind() {
-			case reflect.Struct:
-				field := findFieldByPath(v, part)
-				if !field.IsValid() {
-					return nil, fmt.Errorf("field not found: %s", part)
-				}
-				current = field.Interface()
-
-			case reflect.Map:
-				key := reflect.ValueOf(part)
-				value := v.MapIndex(key)
-				if !value.IsValid() {
-					return nil, nil
-				}
-				current = value.Interface()
-
-			default:
-				return nil, fmt.Errorf("cannot navigate into type %s at %s", v.Kind(), part)
-			}
-		}
-
-		return current, nil
 	}
 
 	var current interface{} = config
@@ -146,140 +132,124 @@ func setValueInConfig(config *types.Config, path string, value interface{}) erro
 		return fmt.Errorf("empty path")
 	}
 
-	if parts[0] == "plugins" && len(parts) >= 3 {
-		if config.Plugins == nil {
-			config.Plugins = make(map[string]interface{})
-		}
+	if config.Plugins == nil {
+		config.Plugins = make(map[string]interface{})
+	}
 
-		namespace := ""
-		fieldStartIdx := -1
-
-		for ns := range config.Plugins {
-			nsParts := strings.Split(ns, ".")
-			if len(parts) >= len(nsParts)+2 {
-				matches := true
-				for i, nsPart := range nsParts {
-					if parts[i+1] != nsPart {
-						matches = false
-						break
-					}
-				}
-				if matches {
-					namespace = ns
-					fieldStartIdx = len(nsParts) + 1
+	for ns := range config.Plugins {
+		nsParts := strings.Split(ns, ".")
+		if len(parts) > len(nsParts) {
+			matches := true
+			for i, nsPart := range nsParts {
+				if parts[i] != nsPart {
+					matches = false
 					break
 				}
 			}
-		}
+			if matches {
+				pluginCfg := config.Plugins[ns]
 
-		if namespace == "" {
-			return fmt.Errorf("plugin config not found in path: %s", path)
-		}
-
-		pluginCfg, ok := config.Plugins[namespace]
-		if !ok {
-			return fmt.Errorf("plugin config not found: %s", namespace)
-		}
-
-		current := reflect.ValueOf(pluginCfg)
-		if current.Kind() == reflect.Ptr {
-			if current.IsNil() {
-				return fmt.Errorf("plugin config is nil: %s", namespace)
-			}
-			current = current.Elem()
-		}
-
-		for i := fieldStartIdx; i < len(parts)-1; i++ {
-			part := parts[i]
-
-			switch current.Kind() {
-			case reflect.Struct:
-				field := findFieldByPath(current, part)
-				if !field.IsValid() {
-					return fmt.Errorf("field not found: %s", part)
-				}
-				if !field.CanSet() {
-					return fmt.Errorf("field not settable: %s", part)
-				}
-				current = field
-
-			case reflect.Map:
-				if current.IsNil() {
-					current.Set(reflect.MakeMap(current.Type()))
+				current := reflect.ValueOf(pluginCfg)
+				if current.Kind() == reflect.Ptr {
+					if current.IsNil() {
+						return fmt.Errorf("plugin config is nil: %s", ns)
+					}
+					current = current.Elem()
 				}
 
-				key := reflect.ValueOf(part)
-				mapValue := current.MapIndex(key)
+				for i := len(nsParts); i < len(parts)-1; i++ {
+					part := parts[i]
 
-				if !mapValue.IsValid() {
-					elemType := current.Type().Elem()
-					if elemType.Kind() == reflect.Ptr {
-						newElem := reflect.New(elemType.Elem())
-						current.SetMapIndex(key, newElem)
-						current = newElem
+					switch current.Kind() {
+					case reflect.Struct:
+						field := findFieldByPath(current, part)
+						if !field.IsValid() {
+							return fmt.Errorf("field not found: %s", part)
+						}
+						if !field.CanSet() {
+							return fmt.Errorf("field not settable: %s", part)
+						}
+						current = field
+
+					case reflect.Map:
+						if current.IsNil() {
+							current.Set(reflect.MakeMap(current.Type()))
+						}
+
+						key := reflect.ValueOf(part)
+						mapValue := current.MapIndex(key)
+
+						if !mapValue.IsValid() {
+							elemType := current.Type().Elem()
+							if elemType.Kind() == reflect.Ptr {
+								newElem := reflect.New(elemType.Elem())
+								current.SetMapIndex(key, newElem)
+								current = newElem
+							} else {
+								newElem := reflect.New(elemType)
+								current.SetMapIndex(key, newElem.Elem())
+								current = newElem
+							}
+						} else {
+							if mapValue.Kind() == reflect.Ptr {
+								current = mapValue
+							} else {
+								newElem := reflect.New(mapValue.Type())
+								newElem.Elem().Set(mapValue)
+								current = newElem
+							}
+						}
+
+					default:
+						return fmt.Errorf("cannot navigate into type %s at %s", current.Kind(), part)
+					}
+				}
+
+				lastPart := parts[len(parts)-1]
+
+				if current.Kind() == reflect.Struct {
+					field := findFieldByPath(current, lastPart)
+					if !field.IsValid() {
+						return fmt.Errorf("field not found: %s", lastPart)
+					}
+					if !field.CanSet() {
+						return fmt.Errorf("field not settable: %s", lastPart)
+					}
+
+					newValue := reflect.ValueOf(value)
+					if newValue.Type().AssignableTo(field.Type()) {
+						field.Set(newValue)
 					} else {
-						newElem := reflect.New(elemType)
-						current.SetMapIndex(key, newElem.Elem())
-						current = newElem
+						convertedValue, err := convertValue(value, field.Type())
+						if err != nil {
+							return fmt.Errorf("cannot convert value: %w", err)
+						}
+						field.Set(reflect.ValueOf(convertedValue))
+					}
+				} else if current.Kind() == reflect.Map {
+					if current.IsNil() {
+						current.Set(reflect.MakeMap(current.Type()))
+					}
+					key := reflect.ValueOf(lastPart)
+					val := reflect.ValueOf(value)
+
+					elemType := current.Type().Elem()
+					if val.Type().AssignableTo(elemType) {
+						current.SetMapIndex(key, val)
+					} else {
+						convertedValue, err := convertValue(value, elemType)
+						if err != nil {
+							return fmt.Errorf("cannot convert value: %w", err)
+						}
+						current.SetMapIndex(key, reflect.ValueOf(convertedValue))
 					}
 				} else {
-					if mapValue.Kind() == reflect.Ptr {
-						current = mapValue
-					} else {
-						newElem := reflect.New(mapValue.Type())
-						newElem.Elem().Set(mapValue)
-						current = newElem
-					}
+					return fmt.Errorf("cannot set value on type %s", current.Kind())
 				}
 
-			default:
-				return fmt.Errorf("cannot navigate into type %s at %s", current.Kind(), part)
+				return nil
 			}
 		}
-
-		lastPart := parts[len(parts)-1]
-
-		if current.Kind() == reflect.Struct {
-			field := findFieldByPath(current, lastPart)
-			if !field.IsValid() {
-				return fmt.Errorf("field not found: %s", lastPart)
-			}
-			if !field.CanSet() {
-				return fmt.Errorf("field not settable: %s", lastPart)
-			}
-
-			newValue := reflect.ValueOf(value)
-			if newValue.Type().AssignableTo(field.Type()) {
-				field.Set(newValue)
-			} else {
-				convertedValue, err := convertValue(value, field.Type())
-				if err != nil {
-					return fmt.Errorf("cannot convert value: %w", err)
-				}
-				field.Set(reflect.ValueOf(convertedValue))
-			}
-		} else if current.Kind() == reflect.Map {
-			if current.IsNil() {
-				current.Set(reflect.MakeMap(current.Type()))
-			}
-			key := reflect.ValueOf(lastPart)
-			val := reflect.ValueOf(value)
-
-			elemType := current.Type().Elem()
-			if val.Type().AssignableTo(elemType) {
-				current.SetMapIndex(key, val)
-			} else {
-				convertedValue, err := convertValue(value, elemType)
-				if err != nil {
-					return fmt.Errorf("cannot convert value: %w", err)
-				}
-				current.SetMapIndex(key, reflect.ValueOf(convertedValue))
-			}
-		} else {
-			return fmt.Errorf("cannot set value on type %s", current.Kind())
-		}
-
-		return nil
 	}
 
 	var current reflect.Value = reflect.ValueOf(config)

--- a/pkg/conf/paths/paths.go
+++ b/pkg/conf/paths/paths.go
@@ -1,5 +1,10 @@
 package paths
 
+import (
+	"fmt"
+	"strings"
+)
+
 type Path string
 
 const (
@@ -30,7 +35,8 @@ const (
 	ProtocolsBGPNeighborBFD  Path = "protocols.bgp.neighbors.*.bfd"
 	ProtocolsBGPNeighborPeer Path = "protocols.bgp.neighbors.*.peer"
 
-	ProtocolsStaticRoute Path = "protocols.static"
+	ProtocolsStaticIPv4Route Path = "protocols.static.ipv4.*"
+	ProtocolsStaticIPv6Route Path = "protocols.static.ipv6.*"
 
 	AAARADIUSServer  Path = "aaa.radius.servers.*"
 	AAARADIUSGroup   Path = "aaa.radius.groups.*"
@@ -40,4 +46,26 @@ const (
 
 func (p Path) String() string {
 	return string(p)
+}
+
+func (p Path) ExtractWildcards(path string, expectedCount int) ([]string, error) {
+	patternParts := strings.Split(string(p), ".")
+	pathParts := strings.Split(path, ".")
+
+	if len(patternParts) != len(pathParts) {
+		return nil, fmt.Errorf("path format mismatch")
+	}
+
+	wildcards := make([]string, 0, expectedCount)
+	for i := range patternParts {
+		if patternParts[i] == "*" {
+			wildcards = append(wildcards, pathParts[i])
+		}
+	}
+
+	if len(wildcards) != expectedCount {
+		return nil, fmt.Errorf("expected %d wildcards, got %d", expectedCount, len(wildcards))
+	}
+
+	return wildcards, nil
 }

--- a/pkg/northbound/adapter.go
+++ b/pkg/northbound/adapter.go
@@ -1,0 +1,123 @@
+package northbound
+
+import (
+	"context"
+	"fmt"
+
+	confhandlers "github.com/veesix-networks/osvbng/pkg/conf/handlers"
+	"github.com/veesix-networks/osvbng/pkg/conf/paths"
+	conftypes "github.com/veesix-networks/osvbng/pkg/conf/types"
+	"github.com/veesix-networks/osvbng/pkg/oper"
+	operhandlers "github.com/veesix-networks/osvbng/pkg/oper/handlers"
+	operpaths "github.com/veesix-networks/osvbng/pkg/oper/paths"
+	"github.com/veesix-networks/osvbng/pkg/show"
+	showhandlers "github.com/veesix-networks/osvbng/pkg/show/handlers"
+	showpaths "github.com/veesix-networks/osvbng/pkg/show/paths"
+)
+
+type Adapter struct {
+	showRegistry *showhandlers.Registry
+	confRegistry *confhandlers.Registry
+	operRegistry *operhandlers.Registry
+}
+
+func NewAdapter(showReg *showhandlers.Registry, confReg *confhandlers.Registry, operReg *operhandlers.Registry) *Adapter {
+	return &Adapter{
+		showRegistry: showReg,
+		confRegistry: confReg,
+		operRegistry: operReg,
+	}
+}
+
+func (a *Adapter) GetAllShowPaths() []showpaths.Path {
+	return a.showRegistry.GetAllPaths()
+}
+
+func (a *Adapter) GetAllConfPaths() []paths.Path {
+	return a.confRegistry.GetAllPaths()
+}
+
+func (a *Adapter) GetAllOperPaths() []operpaths.Path {
+	return a.operRegistry.GetAllPaths()
+}
+
+func (a *Adapter) ExecuteOper(ctx context.Context, path string, body []byte, options map[string]string) (interface{}, error) {
+	handler, err := a.operRegistry.GetHandler(path)
+	if err != nil {
+		return nil, fmt.Errorf("oper handler not found for path %s: %w", path, err)
+	}
+
+	req := &oper.Request{
+		Path:    path,
+		Body:    body,
+		Options: options,
+	}
+
+	return handler.Execute(ctx, req)
+}
+
+func (a *Adapter) ExecuteShow(ctx context.Context, path string, options map[string]string) (interface{}, error) {
+	handler, err := a.showRegistry.GetHandler(path)
+	if err != nil {
+		return nil, fmt.Errorf("show handler not found for path %s: %w", path, err)
+	}
+
+	req := &show.Request{
+		Path:    path,
+		Options: options,
+	}
+
+	return handler.Collect(ctx, req)
+}
+
+func (a *Adapter) ValidateConfig(ctx context.Context, sessionID conftypes.SessionID, path string, value interface{}) error {
+	handler, err := a.confRegistry.GetHandler(path)
+	if err != nil {
+		return fmt.Errorf("config handler not found for path %s: %w", path, err)
+	}
+
+	hctx := &confhandlers.HandlerContext{
+		SessionID: sessionID,
+		Path:      path,
+		NewValue:  value,
+	}
+
+	return a.confRegistry.ValidateWithCallbacks(ctx, handler, hctx)
+}
+
+func (a *Adapter) ApplyConfig(ctx context.Context, sessionID conftypes.SessionID, path string, oldValue, newValue interface{}) error {
+	handler, err := a.confRegistry.GetHandler(path)
+	if err != nil {
+		return fmt.Errorf("config handler not found for path %s: %w", path, err)
+	}
+
+	hctx := &confhandlers.HandlerContext{
+		SessionID: sessionID,
+		Path:      path,
+		OldValue:  oldValue,
+		NewValue:  newValue,
+	}
+
+	return a.confRegistry.ApplyWithCallbacks(ctx, handler, hctx)
+}
+
+func (a *Adapter) RollbackConfig(ctx context.Context, sessionID conftypes.SessionID, path string, oldValue, newValue interface{}) error {
+	handler, err := a.confRegistry.GetHandler(path)
+	if err != nil {
+		return fmt.Errorf("config handler not found for path %s: %w", path, err)
+	}
+
+	hctx := &confhandlers.HandlerContext{
+		SessionID: sessionID,
+		Path:      path,
+		OldValue:  oldValue,
+		NewValue:  newValue,
+	}
+
+	return a.confRegistry.RollbackWithCallbacks(ctx, handler, hctx)
+}
+
+func (a *Adapter) HasOperHandler(path string) bool {
+	_, err := a.operRegistry.GetHandler(path)
+	return err == nil
+}

--- a/pkg/oper/handlers/handler.go
+++ b/pkg/oper/handlers/handler.go
@@ -1,0 +1,119 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/veesix-networks/osvbng/pkg/component"
+	"github.com/veesix-networks/osvbng/pkg/oper"
+	"github.com/veesix-networks/osvbng/pkg/oper/paths"
+)
+
+type OperHandler interface {
+	Execute(ctx context.Context, req *oper.Request) (interface{}, error)
+	PathPattern() paths.Path
+	Dependencies() []paths.Path
+}
+
+type OperDeps struct {
+	PluginComponents map[string]component.Component
+}
+
+type HandlerFactory func(deps *OperDeps) OperHandler
+
+var factories []HandlerFactory
+
+func RegisterFactory(factory HandlerFactory) {
+	factories = append(factories, factory)
+}
+
+type Registry struct {
+	handlers map[string]OperHandler
+}
+
+func NewRegistry() *Registry {
+	return &Registry{
+		handlers: make(map[string]OperHandler),
+	}
+}
+
+func (r *Registry) AutoRegisterAll(deps *OperDeps) {
+	for _, factory := range factories {
+		handler := factory(deps)
+		path := handler.PathPattern().String()
+
+		if _, exists := r.handlers[path]; exists {
+			continue
+		}
+
+		r.MustRegister(handler)
+	}
+}
+
+func (r *Registry) Register(handler OperHandler) error {
+	path := handler.PathPattern().String()
+
+	if _, exists := r.handlers[path]; exists {
+		return fmt.Errorf("oper handler conflict: path '%s' already registered", path)
+	}
+
+	r.handlers[path] = handler
+	return nil
+}
+
+func (r *Registry) MustRegister(handler OperHandler) {
+	if err := r.Register(handler); err != nil {
+		panic(err)
+	}
+}
+
+func (r *Registry) GetHandler(path string) (oper.Handler, error) {
+	if handler, ok := r.handlers[path]; ok {
+		return &handlerAdapter{h: handler}, nil
+	}
+
+	for pattern, handler := range r.handlers {
+		if matchPattern(pattern, path) {
+			return &handlerAdapter{h: handler}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no handler registered for path: %s", path)
+}
+
+func matchPattern(pattern, path string) bool {
+	patternParts := strings.Split(pattern, ".")
+	pathParts := strings.Split(path, ".")
+
+	if len(patternParts) != len(pathParts) {
+		return false
+	}
+
+	for i := range patternParts {
+		if patternParts[i] == "*" {
+			continue
+		}
+		if patternParts[i] != pathParts[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (r *Registry) GetAllPaths() []paths.Path {
+	allPaths := make([]paths.Path, 0, len(r.handlers))
+	for _, handler := range r.handlers {
+		allPaths = append(allPaths, handler.PathPattern())
+	}
+	return allPaths
+}
+
+type handlerAdapter struct {
+	h OperHandler
+}
+
+func (a *handlerAdapter) Execute(ctx context.Context, req *oper.Request) (interface{}, error) {
+	return a.h.Execute(ctx, req)
+}

--- a/pkg/oper/oper.go
+++ b/pkg/oper/oper.go
@@ -1,0 +1,21 @@
+package oper
+
+import "context"
+
+type Handler interface {
+	Execute(ctx context.Context, req *Request) (interface{}, error)
+}
+
+type Request struct {
+	Path    string
+	Body    []byte
+	Options map[string]string
+}
+
+func (r *Request) GetPath() string {
+	return r.Path
+}
+
+type Registry interface {
+	GetHandler(path string) (Handler, error)
+}

--- a/pkg/oper/paths/paths.go
+++ b/pkg/oper/paths/paths.go
@@ -1,0 +1,34 @@
+package paths
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Path string
+
+func (p Path) String() string {
+	return string(p)
+}
+
+func (p Path) ExtractWildcards(path string, expectedCount int) ([]string, error) {
+	patternParts := strings.Split(string(p), ".")
+	pathParts := strings.Split(path, ".")
+
+	if len(patternParts) != len(pathParts) {
+		return nil, fmt.Errorf("path format mismatch")
+	}
+
+	wildcards := make([]string, 0, expectedCount)
+	for i := range patternParts {
+		if patternParts[i] == "*" {
+			wildcards = append(wildcards, pathParts[i])
+		}
+	}
+
+	if len(wildcards) != expectedCount {
+		return nil, fmt.Errorf("expected %d wildcards, got %d", expectedCount, len(wildcards))
+	}
+
+	return wildcards, nil
+}

--- a/pkg/show/handlers/handler.go
+++ b/pkg/show/handlers/handler.go
@@ -96,6 +96,14 @@ func (r *Registry) GetHandler(path string) (show.Handler, error) {
 	return nil, fmt.Errorf("no handler registered for path: %s", path)
 }
 
+func (r *Registry) GetAllPaths() []paths.Path {
+	allPaths := make([]paths.Path, 0, len(r.handlers))
+	for _, handler := range r.handlers {
+		allPaths = append(allPaths, handler.PathPattern())
+	}
+	return allPaths
+}
+
 type handlerAdapter struct {
 	h ShowHandler
 }

--- a/pkg/show/handlers/system/conf_handlers.go
+++ b/pkg/show/handlers/system/conf_handlers.go
@@ -1,0 +1,40 @@
+package system
+
+import (
+	"context"
+
+	confhandlers "github.com/veesix-networks/osvbng/pkg/conf/handlers"
+	"github.com/veesix-networks/osvbng/pkg/show/handlers"
+	"github.com/veesix-networks/osvbng/pkg/show/paths"
+)
+
+type ConfHandlersHandler struct {
+	deps *handlers.ShowDeps
+}
+
+func init() {
+	handlers.RegisterFactory(func(deps *handlers.ShowDeps) handlers.ShowHandler {
+		return &ConfHandlersHandler{deps: deps}
+	})
+}
+
+func (h *ConfHandlersHandler) Collect(ctx context.Context, req *handlers.ShowRequest) (interface{}, error) {
+	registry := confhandlers.NewRegistry()
+	registry.AutoRegisterAll(&confhandlers.ConfDeps{})
+
+	allPaths := registry.GetAllPaths()
+	result := make([]string, len(allPaths))
+	for i, p := range allPaths {
+		result[i] = p.String()
+	}
+
+	return result, nil
+}
+
+func (h *ConfHandlersHandler) PathPattern() paths.Path {
+	return paths.SystemConfHandlers
+}
+
+func (h *ConfHandlersHandler) Dependencies() []paths.Path {
+	return nil
+}

--- a/pkg/show/handlers/system/oper_handlers.go
+++ b/pkg/show/handlers/system/oper_handlers.go
@@ -1,0 +1,40 @@
+package system
+
+import (
+	"context"
+
+	operhandlers "github.com/veesix-networks/osvbng/pkg/oper/handlers"
+	"github.com/veesix-networks/osvbng/pkg/show/handlers"
+	showpaths "github.com/veesix-networks/osvbng/pkg/show/paths"
+)
+
+type OperHandlersHandler struct {
+	deps *handlers.ShowDeps
+}
+
+func init() {
+	handlers.RegisterFactory(func(deps *handlers.ShowDeps) handlers.ShowHandler {
+		return &OperHandlersHandler{deps: deps}
+	})
+}
+
+func (h *OperHandlersHandler) Collect(ctx context.Context, req *handlers.ShowRequest) (interface{}, error) {
+	registry := operhandlers.NewRegistry()
+	registry.AutoRegisterAll(&operhandlers.OperDeps{})
+
+	allPaths := registry.GetAllPaths()
+	result := make([]string, len(allPaths))
+	for i, p := range allPaths {
+		result[i] = p.String()
+	}
+
+	return result, nil
+}
+
+func (h *OperHandlersHandler) PathPattern() showpaths.Path {
+	return showpaths.SystemOperHandlers
+}
+
+func (h *OperHandlersHandler) Dependencies() []showpaths.Path {
+	return nil
+}

--- a/pkg/show/handlers/system/show_handlers.go
+++ b/pkg/show/handlers/system/show_handlers.go
@@ -1,0 +1,39 @@
+package system
+
+import (
+	"context"
+
+	"github.com/veesix-networks/osvbng/pkg/show/handlers"
+	"github.com/veesix-networks/osvbng/pkg/show/paths"
+)
+
+type ShowHandlersHandler struct {
+	deps *handlers.ShowDeps
+}
+
+func init() {
+	handlers.RegisterFactory(func(deps *handlers.ShowDeps) handlers.ShowHandler {
+		return &ShowHandlersHandler{deps: deps}
+	})
+}
+
+func (h *ShowHandlersHandler) Collect(ctx context.Context, req *handlers.ShowRequest) (interface{}, error) {
+	registry := handlers.NewRegistry()
+	registry.AutoRegisterAll(&handlers.ShowDeps{})
+
+	allPaths := registry.GetAllPaths()
+	result := make([]string, len(allPaths))
+	for i, p := range allPaths {
+		result[i] = p.String()
+	}
+
+	return result, nil
+}
+
+func (h *ShowHandlersHandler) PathPattern() paths.Path {
+	return paths.SystemShowHandlers
+}
+
+func (h *ShowHandlersHandler) Dependencies() []paths.Path {
+	return nil
+}

--- a/pkg/show/paths/paths.go
+++ b/pkg/show/paths/paths.go
@@ -1,5 +1,10 @@
 package paths
 
+import (
+	"fmt"
+	"strings"
+)
+
 type Path string
 
 const (
@@ -15,10 +20,35 @@ const (
 	SystemCacheStatistics      Path = "system.cache.statistics"
 	SystemCacheKeys            Path = "system.cache.keys"
 	SystemCacheKey             Path = "system.cache.key"
+	SystemConfHandlers         Path = "system.conf_handlers"
+	SystemShowHandlers         Path = "system.show_handlers"
+	SystemOperHandlers         Path = "system.oper_handlers"
 
 	VRFS Path = "vrfs"
 )
 
 func (p Path) String() string {
 	return string(p)
+}
+
+func (p Path) ExtractWildcards(path string, expectedCount int) ([]string, error) {
+	patternParts := strings.Split(string(p), ".")
+	pathParts := strings.Split(path, ".")
+
+	if len(patternParts) != len(pathParts) {
+		return nil, fmt.Errorf("path format mismatch")
+	}
+
+	wildcards := make([]string, 0, expectedCount)
+	for i := range patternParts {
+		if patternParts[i] == "*" {
+			wildcards = append(wildcards, pathParts[i])
+		}
+	}
+
+	if len(wildcards) != expectedCount {
+		return nil, fmt.Errorf("expected %d wildcards, got %d", expectedCount, len(wildcards))
+	}
+
+	return wildcards, nil
 }

--- a/plugins/all/all.go
+++ b/plugins/all/all.go
@@ -5,4 +5,5 @@ import (
 	_ "github.com/veesix-networks/osvbng/plugins/community/all"
 	_ "github.com/veesix-networks/osvbng/plugins/dhcp4/all"
 	_ "github.com/veesix-networks/osvbng/plugins/exporter/all"
+	_ "github.com/veesix-networks/osvbng/plugins/northbound/all"
 )

--- a/plugins/auth/all/all.go
+++ b/plugins/auth/all/all.go
@@ -1,5 +1,1 @@
 package all
-
-import (
-	_ "github.com/veesix-networks/osvbng/plugins/auth/local"
-)

--- a/plugins/auth/all/local.go
+++ b/plugins/auth/all/local.go
@@ -1,3 +1,9 @@
 package all
 
-import _ "github.com/veesix-networks/osvbng/plugins/auth/local"
+import (
+	_ "github.com/veesix-networks/osvbng/plugins/auth/local"
+	_ "github.com/veesix-networks/osvbng/plugins/auth/local/oper/attribute"
+	_ "github.com/veesix-networks/osvbng/plugins/auth/local/oper/service"
+	_ "github.com/veesix-networks/osvbng/plugins/auth/local/oper/user"
+	_ "github.com/veesix-networks/osvbng/plugins/auth/local/show"
+)

--- a/plugins/auth/local/commands_cli.go
+++ b/plugins/auth/local/commands_cli.go
@@ -1,0 +1,272 @@
+package local
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/veesix-networks/osvbng/cmd/osvbngcli/commands"
+	"github.com/veesix-networks/osvbng/pkg/cli"
+	operpaths "github.com/veesix-networks/osvbng/pkg/oper/paths"
+)
+
+func init() {
+	cli.RegisterRoot(Namespace, &cli.RootCommand{
+		Path:        []string{"show", "subscriber", "auth", "local"},
+		Description: "Local authentication status",
+	})
+
+	cli.Register(Namespace, &cli.Command{
+		Path:        []string{"show", "subscriber", "auth", "local", "users"},
+		Description: "Display all local users",
+		Handler:     commands.ShowHandlerFunc(ShowUsersPath),
+	})
+
+	cli.Register(Namespace, &cli.Command{
+		Path:        []string{"show", "subscriber", "auth", "local", "services"},
+		Description: "Display all local services",
+		Handler:     commands.ShowHandlerFunc(ShowServicesPath),
+	})
+
+	cli.RegisterRoot(Namespace, &cli.RootCommand{
+		Path:        []string{"exec", "subscriber", "auth", "local"},
+		Description: "Local authentication operations",
+	})
+
+	cli.Register(Namespace, &cli.Command{
+		Path:        []string{"exec", "subscriber", "auth", "local", "user", "create"},
+		Description: "Create a new user",
+		Handler:     cmdCreateUser,
+		Arguments: []*cli.Argument{
+			{Name: "username", Description: "Username", Type: cli.ArgUserInput},
+			{Name: "password", Description: "Password (optional)", Type: cli.ArgUserInput},
+		},
+	})
+
+	cli.Register(Namespace, &cli.Command{
+		Path:        []string{"exec", "subscriber", "auth", "local", "user", "password"},
+		Description: "Set user password",
+		Handler:     cmdSetUserPassword,
+		Arguments: []*cli.Argument{
+			{Name: "user_id", Description: "User ID", Type: cli.ArgUserInput},
+			{Name: "password", Description: "Password", Type: cli.ArgUserInput},
+		},
+	})
+
+	cli.Register(Namespace, &cli.Command{
+		Path:        []string{"exec", "subscriber", "auth", "local", "user", "enabled"},
+		Description: "Enable or disable user",
+		Handler:     cmdSetUserEnabled,
+		Arguments: []*cli.Argument{
+			{Name: "user_id", Description: "User ID", Type: cli.ArgUserInput},
+			{Name: "enabled", Description: "Enable (true/false)", Type: cli.ArgUserInput},
+		},
+	})
+
+	cli.Register(Namespace, &cli.Command{
+		Path:        []string{"exec", "subscriber", "auth", "local", "user", "service"},
+		Description: "Assign service to user with priority",
+		Handler:     cmdSetUserService,
+		Arguments: []*cli.Argument{
+			{Name: "user_id", Description: "User ID", Type: cli.ArgUserInput},
+			{Name: "service", Description: "Service name", Type: cli.ArgUserInput},
+			{Name: "priority", Description: "Priority (lower = higher precedence)", Type: cli.ArgUserInput},
+		},
+	})
+
+	cli.Register(Namespace, &cli.Command{
+		Path:        []string{"exec", "subscriber", "auth", "local", "user", "attribute"},
+		Description: "Set user attribute",
+		Handler:     cmdSetUserAttribute,
+		Arguments: []*cli.Argument{
+			{Name: "username", Description: "Username", Type: cli.ArgUserInput},
+			{Name: "attribute", Description: "Attribute name", Type: cli.ArgUserInput},
+			{Name: "value", Description: "Attribute value", Type: cli.ArgUserInput},
+			{Name: "op", Description: "Operator (=, :=, +=, etc.)", Type: cli.ArgUserInput},
+		},
+	})
+
+	cli.Register(Namespace, &cli.Command{
+		Path:        []string{"exec", "subscriber", "auth", "local", "service", "attribute"},
+		Description: "Set service attribute",
+		Handler:     cmdSetServiceAttribute,
+		Arguments: []*cli.Argument{
+			{Name: "service", Description: "Service name", Type: cli.ArgUserInput},
+			{Name: "attribute", Description: "Attribute name", Type: cli.ArgUserInput},
+			{Name: "value", Description: "Attribute value", Type: cli.ArgUserInput},
+			{Name: "op", Description: "Operator (=, :=, +=, etc.)", Type: cli.ArgUserInput},
+		},
+	})
+
+	cli.Register(Namespace, &cli.Command{
+		Path:        []string{"exec", "subscriber", "auth", "local", "service", "create"},
+		Description: "Create a new service",
+		Handler:     cmdCreateService,
+		Arguments: []*cli.Argument{
+			{Name: "name", Description: "Service name", Type: cli.ArgUserInput},
+			{Name: "description", Description: "Service description (optional)", Type: cli.ArgUserInput},
+		},
+	})
+
+	cli.Register(Namespace, &cli.Command{
+		Path:        []string{"exec", "subscriber", "auth", "local", "service", "delete"},
+		Description: "Delete a service",
+		Handler:     cmdDeleteService,
+		Arguments: []*cli.Argument{
+			{Name: "service", Description: "Service name", Type: cli.ArgUserInput},
+		},
+	})
+
+	cli.Register(Namespace, &cli.Command{
+		Path:        []string{"exec", "subscriber", "auth", "local", "user", "delete"},
+		Description: "Delete a user",
+		Handler:     cmdDeleteUser,
+		Arguments: []*cli.Argument{
+			{Name: "user_id", Description: "User ID", Type: cli.ArgUserInput},
+		},
+	})
+}
+
+func cmdCreateUser(ctx context.Context, c interface{}, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: exec subscriber auth local user create <username> [password]")
+	}
+
+	req := &CreateUserRequest{
+		Username: args[0],
+		Enabled:  true,
+	}
+	if len(args) >= 2 {
+		req.Password = &args[1]
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("failed to encode user request: %w", err)
+	}
+
+	return commands.ExecuteOper(ctx, c, OperCreateUserPath, string(body))
+}
+
+func cmdSetUserPassword(ctx context.Context, c interface{}, args []string) error {
+	if len(args) < 2 {
+		return fmt.Errorf("usage: exec subscriber auth local user password <user_id> <password>")
+	}
+
+	req := &SetUserPasswordRequest{Password: args[1]}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("failed to encode request: %w", err)
+	}
+
+	path := fmt.Sprintf("subscriber.auth.local.user.%s.password", args[0])
+	return commands.ExecuteOper(ctx, c, operpaths.Path(path), string(body))
+}
+
+func cmdSetUserEnabled(ctx context.Context, c interface{}, args []string) error {
+	if len(args) < 2 {
+		return fmt.Errorf("usage: exec subscriber auth local user enabled <user_id> <true|false>")
+	}
+
+	req := &SetUserEnabledRequest{Enabled: args[1] == "true"}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("failed to encode request: %w", err)
+	}
+
+	path := fmt.Sprintf("subscriber.auth.local.user.%s.enabled", args[0])
+	return commands.ExecuteOper(ctx, c, operpaths.Path(path), string(body))
+}
+
+func cmdSetUserService(ctx context.Context, c interface{}, args []string) error {
+	if len(args) < 3 {
+		return fmt.Errorf("usage: exec subscriber auth local user service <user_id> <service> <priority>")
+	}
+
+	priority := 0
+	fmt.Sscanf(args[2], "%d", &priority)
+	req := &SetUserServiceRequest{Priority: priority}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("failed to encode request: %w", err)
+	}
+
+	path := fmt.Sprintf("subscriber.auth.local.user.%s.service.%s", args[0], args[1])
+	return commands.ExecuteOper(ctx, c, operpaths.Path(path), string(body))
+}
+
+func cmdSetUserAttribute(ctx context.Context, c interface{}, args []string) error {
+	if len(args) < 4 {
+		return fmt.Errorf("usage: exec subscriber auth local user attribute <user_id> <attribute> <value> <op>")
+	}
+
+	req := &SetUserAttributeRequest{
+		Attribute: args[1],
+		Value:     args[2],
+		Op:        args[3],
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("failed to encode request: %w", err)
+	}
+
+	path := fmt.Sprintf("subscriber.auth.local.user.%s.attribute", args[0])
+	return commands.ExecuteOper(ctx, c, operpaths.Path(path), string(body))
+}
+
+func cmdSetServiceAttribute(ctx context.Context, c interface{}, args []string) error {
+	if len(args) < 4 {
+		return fmt.Errorf("usage: exec subscriber auth local service attribute <service> <attribute> <value> <op>")
+	}
+
+	req := &SetServiceAttributeRequest{
+		Attribute: args[1],
+		Value:     args[2],
+		Op:        args[3],
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("failed to encode request: %w", err)
+	}
+
+	path := fmt.Sprintf("subscriber.auth.local.services.%s.attribute", args[0])
+	return commands.ExecuteOper(ctx, c, operpaths.Path(path), string(body))
+}
+
+func cmdCreateService(ctx context.Context, c interface{}, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: exec subscriber auth local service create <name> [description]")
+	}
+
+	req := &CreateServiceRequest{
+		Name: args[0],
+	}
+	if len(args) >= 2 {
+		req.Description = args[1]
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("failed to encode service request: %w", err)
+	}
+
+	return commands.ExecuteOper(ctx, c, OperCreateServicePath, string(body))
+}
+
+func cmdDeleteService(ctx context.Context, c interface{}, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: exec subscriber auth local service delete <service>")
+	}
+
+	path := fmt.Sprintf("subscriber.auth.local.services.%s.delete", args[0])
+	return commands.ExecuteOper(ctx, c, operpaths.Path(path), "{}")
+}
+
+func cmdDeleteUser(ctx context.Context, c interface{}, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: exec subscriber auth local user delete <user_id>")
+	}
+
+	path := fmt.Sprintf("subscriber.auth.local.user.%s.delete", args[0])
+	return commands.ExecuteOper(ctx, c, operpaths.Path(path), "{}")
+}

--- a/plugins/auth/local/config.go
+++ b/plugins/auth/local/config.go
@@ -1,0 +1,17 @@
+package local
+
+import (
+	"github.com/veesix-networks/osvbng/pkg/auth"
+	"github.com/veesix-networks/osvbng/pkg/conf"
+)
+
+const Namespace = "subscriber.auth.local"
+
+type Config struct {
+	DatabasePath string `json:"database_path" yaml:"database_path"`
+}
+
+func init() {
+	conf.RegisterPluginConfig(Namespace, Config{})
+	auth.Register("local", New)
+}

--- a/plugins/auth/local/database.go
+++ b/plugins/auth/local/database.go
@@ -1,0 +1,545 @@
+package local
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+type EntityType string
+type AttributeType string
+
+const (
+	EntityTypeUser    EntityType = "user"
+	EntityTypeService EntityType = "service"
+
+	AttributeTypeRequest  AttributeType = "request"
+	AttributeTypeResponse AttributeType = "response"
+)
+
+type User struct {
+	ID        int64
+	Username  string
+	Password  *string
+	Enabled   bool
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+type Service struct {
+	ID          int64
+	Name        string
+	Description string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+type UserService struct {
+	ID        int64
+	UserID    int64
+	ServiceID int64
+	Priority  int
+	CreatedAt time.Time
+}
+
+type Attribute struct {
+	ID             int64
+	EntityType     EntityType
+	EntityID       int64
+	AttributeType  AttributeType
+	AttributeName  string
+	AttributeValue string
+	Op             string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+func initSchema(db *sql.DB) error {
+	schema := `
+	CREATE TABLE IF NOT EXISTS users (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		username TEXT NOT NULL UNIQUE,
+		password TEXT,
+		enabled BOOLEAN NOT NULL DEFAULT 1,
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
+	CREATE INDEX IF NOT EXISTS idx_users_enabled ON users(enabled);
+
+	CREATE TABLE IF NOT EXISTS services (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		name TEXT NOT NULL UNIQUE,
+		description TEXT,
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_services_name ON services(name);
+
+	CREATE TABLE IF NOT EXISTS user_services (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		user_id INTEGER NOT NULL,
+		service_id INTEGER NOT NULL,
+		priority INTEGER NOT NULL DEFAULT 0,
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+		FOREIGN KEY (service_id) REFERENCES services(id) ON DELETE CASCADE,
+		UNIQUE(user_id, service_id)
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_user_services_user ON user_services(user_id);
+	CREATE INDEX IF NOT EXISTS idx_user_services_service ON user_services(service_id);
+	CREATE INDEX IF NOT EXISTS idx_user_services_priority ON user_services(user_id, priority);
+
+	CREATE TABLE IF NOT EXISTS attributes (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		entity_type TEXT NOT NULL CHECK(entity_type IN ('user', 'service')),
+		entity_id INTEGER NOT NULL,
+		attribute_type TEXT NOT NULL CHECK(attribute_type IN ('request', 'response')),
+		attribute_name TEXT NOT NULL,
+		attribute_value TEXT NOT NULL,
+		op TEXT DEFAULT '=',
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		UNIQUE(entity_type, entity_id, attribute_type, attribute_name)
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_attributes_entity ON attributes(entity_type, entity_id);
+	CREATE INDEX IF NOT EXISTS idx_attributes_lookup ON attributes(entity_type, entity_id, attribute_type);
+	CREATE INDEX IF NOT EXISTS idx_attributes_name ON attributes(attribute_name);
+	`
+
+	_, err := db.Exec(schema)
+	return err
+}
+
+func getUserByUsername(db *sql.DB, username string) (*User, error) {
+	query := `SELECT id, username, password, enabled, created_at, updated_at
+	          FROM users WHERE username = ?`
+
+	var user User
+	var password sql.NullString
+
+	err := db.QueryRow(query, username).Scan(
+		&user.ID,
+		&user.Username,
+		&password,
+		&user.Enabled,
+		&user.CreatedAt,
+		&user.UpdatedAt,
+	)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("user not found: %s", username)
+		}
+		return nil, err
+	}
+
+	if password.Valid {
+		user.Password = &password.String
+	}
+
+	return &user, nil
+}
+
+func GetUserByID(db *sql.DB, userID int64) (*User, error) {
+	query := `SELECT id, username, password, enabled, created_at, updated_at
+	          FROM users WHERE id = ?`
+
+	var user User
+	var password sql.NullString
+
+	err := db.QueryRow(query, userID).Scan(
+		&user.ID,
+		&user.Username,
+		&password,
+		&user.Enabled,
+		&user.CreatedAt,
+		&user.UpdatedAt,
+	)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("user not found: %s", userID)
+		}
+		return nil, err
+	}
+
+	if password.Valid {
+		user.Password = &password.String
+	}
+
+	return &user, nil
+}
+
+func loadMergedAttributes(db *sql.DB, userID int64) (map[string]string, error) {
+	result := make(map[string]string)
+
+	serviceQuery := `
+		SELECT a.attribute_name, a.attribute_value
+		FROM attributes a
+		INNER JOIN user_services us ON a.entity_id = us.service_id
+		WHERE us.user_id = ?
+		  AND a.entity_type = ?
+		  AND a.attribute_type = ?
+		ORDER BY us.priority ASC, us.id ASC
+	`
+
+	rows, err := db.Query(serviceQuery, userID, EntityTypeService, AttributeTypeResponse)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load service attributes: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var name, value string
+		if err := rows.Scan(&name, &value); err != nil {
+			return nil, err
+		}
+		if _, exists := result[name]; !exists {
+			result[name] = value
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	userQuery := `
+		SELECT attribute_name, attribute_value
+		FROM attributes
+		WHERE entity_type = ?
+		  AND entity_id = ?
+		  AND attribute_type = ?
+	`
+
+	rows, err = db.Query(userQuery, EntityTypeUser, userID, AttributeTypeResponse)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load user attributes: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var name, value string
+		if err := rows.Scan(&name, &value); err != nil {
+			return nil, err
+		}
+		result[name] = value
+	}
+
+	return result, rows.Err()
+}
+
+func CreateUser(db *sql.DB, username string, password *string, enabled bool) (int64, error) {
+	query := `INSERT INTO users (username, password, enabled) VALUES (?, ?, ?)`
+	result, err := db.Exec(query, username, password, enabled)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create user: %w", err)
+	}
+	return result.LastInsertId()
+}
+
+func UpdateUserPasswordByID(db *sql.DB, userID int64, password *string) error {
+	query := `UPDATE users SET password = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`
+	result, err := db.Exec(query, password, userID)
+	if err != nil {
+		return fmt.Errorf("failed to update password: %w", err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return fmt.Errorf("user not found with ID: %d", userID)
+	}
+
+	return nil
+}
+
+func UpdateUserEnabledByID(db *sql.DB, userID int64, enabled bool) error {
+	query := `UPDATE users SET enabled = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`
+	result, err := db.Exec(query, enabled, userID)
+	if err != nil {
+		return fmt.Errorf("failed to update enabled status: %w", err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return fmt.Errorf("user not found with ID: %d", userID)
+	}
+
+	return nil
+}
+
+func DeleteUserByID(db *sql.DB, userID int64) error {
+	query := `DELETE FROM users WHERE id = ?`
+	result, err := db.Exec(query, userID)
+	if err != nil {
+		return fmt.Errorf("failed to delete user: %w", err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return fmt.Errorf("user not found with ID: %s", userID)
+	}
+
+	return nil
+}
+
+func ListUsers(db *sql.DB) ([]User, error) {
+	query := `SELECT id, username, password, enabled, created_at, updated_at FROM users ORDER BY username`
+
+	rows, err := db.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list users: %w", err)
+	}
+	defer rows.Close()
+
+	var users []User
+	for rows.Next() {
+		var user User
+		var password sql.NullString
+
+		if err := rows.Scan(&user.ID, &user.Username, &password, &user.Enabled, &user.CreatedAt, &user.UpdatedAt); err != nil {
+			return nil, err
+		}
+
+		if password.Valid {
+			user.Password = &password.String
+		}
+
+		users = append(users, user)
+	}
+
+	return users, rows.Err()
+}
+
+func CreateService(db *sql.DB, name, description string) (int64, error) {
+	query := `INSERT INTO services (name, description) VALUES (?, ?)`
+	result, err := db.Exec(query, name, description)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create service: %w", err)
+	}
+	return result.LastInsertId()
+}
+
+func GetServiceByName(db *sql.DB, name string) (*Service, error) {
+	query := `SELECT id, name, description, created_at, updated_at FROM services WHERE name = ?`
+
+	var service Service
+	err := db.QueryRow(query, name).Scan(
+		&service.ID,
+		&service.Name,
+		&service.Description,
+		&service.CreatedAt,
+		&service.UpdatedAt,
+	)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("service not found: %s", name)
+		}
+		return nil, err
+	}
+
+	return &service, nil
+}
+
+func GetServiceByID(db *sql.DB, id int64) (*Service, error) {
+	query := `SELECT id, name, description, created_at, updated_at FROM services WHERE id = ?`
+
+	var service Service
+	err := db.QueryRow(query, id).Scan(
+		&service.ID,
+		&service.Name,
+		&service.Description,
+		&service.CreatedAt,
+		&service.UpdatedAt,
+	)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("service not found: %d", id)
+		}
+		return nil, err
+	}
+
+	return &service, nil
+}
+
+func DeleteService(db *sql.DB, name string) error {
+	query := `DELETE FROM services WHERE name = ?`
+	result, err := db.Exec(query, name)
+	if err != nil {
+		return fmt.Errorf("failed to delete service: %w", err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return fmt.Errorf("service not found: %s", name)
+	}
+
+	return nil
+}
+
+func ListServices(db *sql.DB) ([]Service, error) {
+	query := `SELECT id, name, description, created_at, updated_at FROM services ORDER BY name`
+
+	rows, err := db.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list services: %w", err)
+	}
+	defer rows.Close()
+
+	var services []Service
+	for rows.Next() {
+		var service Service
+		if err := rows.Scan(&service.ID, &service.Name, &service.Description, &service.CreatedAt, &service.UpdatedAt); err != nil {
+			return nil, err
+		}
+		services = append(services, service)
+	}
+
+	return services, rows.Err()
+}
+
+func AssignUserServiceByID(db *sql.DB, userID int64, serviceName string, priority int) error {
+	service, err := GetServiceByName(db, serviceName)
+	if err != nil {
+		return err
+	}
+
+	query := `
+		INSERT INTO user_services (user_id, service_id, priority)
+		VALUES (?, ?, ?)
+		ON CONFLICT(user_id, service_id) DO UPDATE SET priority = excluded.priority
+	`
+
+	_, err = db.Exec(query, userID, service.ID, priority)
+	if err != nil {
+		return fmt.Errorf("failed to assign service to user: %w", err)
+	}
+
+	return nil
+}
+
+func GetUserServices(db *sql.DB, username string) ([]UserService, error) {
+	user, err := getUserByUsername(db, username)
+	if err != nil {
+		return nil, err
+	}
+
+	query := `
+		SELECT id, user_id, service_id, priority, created_at
+		FROM user_services
+		WHERE user_id = ?
+		ORDER BY priority ASC
+	`
+
+	rows, err := db.Query(query, user.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user services: %w", err)
+	}
+	defer rows.Close()
+
+	var userServices []UserService
+	for rows.Next() {
+		var us UserService
+		if err := rows.Scan(&us.ID, &us.UserID, &us.ServiceID, &us.Priority, &us.CreatedAt); err != nil {
+			return nil, err
+		}
+		userServices = append(userServices, us)
+	}
+
+	return userServices, rows.Err()
+}
+
+func SetAttributeByID(db *sql.DB, entityType EntityType, entityID int64, attributeType AttributeType, attributeName string, attributeValue string, op string) error {
+	query := `
+		INSERT INTO attributes (entity_type, entity_id, attribute_type, attribute_name, attribute_value, op)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(entity_type, entity_id, attribute_type, attribute_name)
+		DO UPDATE SET attribute_value = excluded.attribute_value, op = excluded.op, updated_at = CURRENT_TIMESTAMP
+	`
+
+	_, err := db.Exec(query, entityType, entityID, attributeType, attributeName, attributeValue, op)
+	if err != nil {
+		return fmt.Errorf("failed to set attribute: %w", err)
+	}
+
+	return nil
+}
+
+func GetAttributes(db *sql.DB, entityType EntityType, entityName string, attributeType AttributeType) ([]Attribute, error) {
+	var entityID int64
+
+	if entityType == EntityTypeUser {
+		user, err := getUserByUsername(db, entityName)
+		if err != nil {
+			return nil, err
+		}
+		entityID = user.ID
+	} else if entityType == EntityTypeService {
+		service, err := GetServiceByName(db, entityName)
+		if err != nil {
+			return nil, err
+		}
+		entityID = service.ID
+	} else {
+		return nil, fmt.Errorf("invalid entity type: %s", entityType)
+	}
+
+	query := `
+		SELECT id, entity_type, entity_id, attribute_type, attribute_name, attribute_value, op, created_at, updated_at
+		FROM attributes
+		WHERE entity_type = ? AND entity_id = ? AND attribute_type = ?
+		ORDER BY attribute_name
+	`
+
+	rows, err := db.Query(query, entityType, entityID, attributeType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get attributes: %w", err)
+	}
+	defer rows.Close()
+
+	var attributes []Attribute
+	for rows.Next() {
+		var attr Attribute
+		var entityTypeStr, attributeTypeStr string
+
+		if err := rows.Scan(
+			&attr.ID,
+			&entityTypeStr,
+			&attr.EntityID,
+			&attributeTypeStr,
+			&attr.AttributeName,
+			&attr.AttributeValue,
+			&attr.Op,
+			&attr.CreatedAt,
+			&attr.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+
+		attr.EntityType = EntityType(entityTypeStr)
+		attr.AttributeType = AttributeType(attributeTypeStr)
+		attributes = append(attributes, attr)
+	}
+
+	return attributes, rows.Err()
+}

--- a/plugins/auth/local/models.go
+++ b/plugins/auth/local/models.go
@@ -1,0 +1,52 @@
+package local
+
+type CreateUserRequest struct {
+	Username string  `json:"username"`
+	Password *string `json:"password,omitempty"`
+	Enabled  bool    `json:"enabled"`
+}
+
+type CreateUserResponse struct {
+	UserID   int64  `json:"user_id"`
+	Username string `json:"username"`
+	Message  string `json:"message"`
+}
+
+type SetUserPasswordRequest struct {
+	Password string `json:"password"`
+}
+
+type SetUserEnabledRequest struct {
+	Enabled bool `json:"enabled"`
+}
+
+type SetUserServiceRequest struct {
+	Priority int `json:"priority"`
+}
+
+type SetUserAttributeRequest struct {
+	Attribute string `json:"attribute"`
+	Value     string `json:"value"`
+	Op        string `json:"op"`
+}
+
+type SetServiceAttributeRequest struct {
+	Attribute string `json:"attribute"`
+	Value     string `json:"value"`
+	Op        string `json:"op"`
+}
+
+type CreateServiceRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+type CreateServiceResponse struct {
+	ServiceID   int64  `json:"service_id"`
+	Name        string `json:"name"`
+	Message     string `json:"message"`
+}
+
+type OperResponse struct {
+	Message string `json:"message"`
+}

--- a/plugins/auth/local/oper/attribute/service.go
+++ b/plugins/auth/local/oper/attribute/service.go
@@ -1,0 +1,79 @@
+package attribute
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/veesix-networks/osvbng/pkg/logger"
+	"github.com/veesix-networks/osvbng/pkg/oper"
+	"github.com/veesix-networks/osvbng/pkg/oper/handlers"
+	operpaths "github.com/veesix-networks/osvbng/pkg/oper/paths"
+	"github.com/veesix-networks/osvbng/plugins/auth/local"
+)
+
+func init() {
+	handlers.RegisterFactory(NewSetServiceAttributeHandler)
+}
+
+type SetServiceAttributeHandler struct {
+	deps   *handlers.OperDeps
+	logger *slog.Logger
+}
+
+
+
+func NewSetServiceAttributeHandler(deps *handlers.OperDeps) handlers.OperHandler {
+	return &SetServiceAttributeHandler{
+		deps:   deps,
+		logger: logger.Component(local.Namespace + ".oper"),
+	}
+}
+
+func (h *SetServiceAttributeHandler) Execute(ctx context.Context, req *oper.Request) (interface{}, error) {
+	provider := local.GetProvider()
+	if provider == nil {
+		return nil, fmt.Errorf("local auth provider not initialized")
+	}
+
+	db := provider.GetDB()
+
+	wildcards, err := h.PathPattern().ExtractWildcards(req.Path, 1)
+	if err != nil {
+		return nil, err
+	}
+	serviceName := wildcards[0]
+
+	var setReq local.SetServiceAttributeRequest
+	if err := json.Unmarshal(req.Body, &setReq); err != nil {
+		return nil, fmt.Errorf("invalid request body: %w", err)
+	}
+
+	if setReq.Attribute == "" || setReq.Value == "" || setReq.Op == "" {
+		return nil, fmt.Errorf("attribute, value and op are required")
+	}
+
+	service, err := local.GetServiceByName(db, serviceName)
+	if err != nil {
+		return nil, fmt.Errorf("service not found: %w", err)
+	}
+
+	if err := local.SetAttributeByID(db, local.EntityTypeService, service.ID, local.AttributeTypeResponse, setReq.Attribute, setReq.Value, setReq.Op); err != nil {
+		return nil, fmt.Errorf("failed to set service attribute: %w", err)
+	}
+
+	h.logger.Info("Service attribute set", "service", serviceName, "attribute", setReq.Attribute, "value", setReq.Value, "op", setReq.Op)
+
+	return &local.OperResponse{
+		Message: fmt.Sprintf("Attribute '%s' set for service '%s'", setReq.Attribute, serviceName),
+	}, nil
+}
+
+func (h *SetServiceAttributeHandler) PathPattern() operpaths.Path {
+	return operpaths.Path(local.OperSetServiceAttributePath)
+}
+
+func (h *SetServiceAttributeHandler) Dependencies() []operpaths.Path {
+	return nil
+}

--- a/plugins/auth/local/oper/attribute/user.go
+++ b/plugins/auth/local/oper/attribute/user.go
@@ -1,0 +1,80 @@
+package attribute
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strconv"
+
+	"github.com/veesix-networks/osvbng/pkg/logger"
+	"github.com/veesix-networks/osvbng/pkg/oper"
+	"github.com/veesix-networks/osvbng/pkg/oper/handlers"
+	operpaths "github.com/veesix-networks/osvbng/pkg/oper/paths"
+	"github.com/veesix-networks/osvbng/plugins/auth/local"
+)
+
+func init() {
+	handlers.RegisterFactory(NewSetUserAttributeHandler)
+}
+
+type SetUserAttributeHandler struct {
+	deps   *handlers.OperDeps
+	logger *slog.Logger
+}
+
+
+
+func NewSetUserAttributeHandler(deps *handlers.OperDeps) handlers.OperHandler {
+	return &SetUserAttributeHandler{
+		deps:   deps,
+		logger: logger.Component(local.Namespace + ".oper"),
+	}
+}
+
+func (h *SetUserAttributeHandler) Execute(ctx context.Context, req *oper.Request) (interface{}, error) {
+	provider := local.GetProvider()
+	if provider == nil {
+		return nil, fmt.Errorf("local auth provider not initialized")
+	}
+
+	db := provider.GetDB()
+
+	wildcards, err := h.PathPattern().ExtractWildcards(req.Path, 1)
+	if err != nil {
+		return nil, err
+	}
+	userIDStr := wildcards[0]
+
+	userID, err := strconv.ParseInt(userIDStr, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid user ID: %s", userIDStr)
+	}
+
+	var setReq local.SetUserAttributeRequest
+	if err := json.Unmarshal(req.Body, &setReq); err != nil {
+		return nil, fmt.Errorf("invalid request body: %w", err)
+	}
+
+	if setReq.Attribute == "" || setReq.Value == "" || setReq.Op == "" {
+		return nil, fmt.Errorf("attribute, value and op are required")
+	}
+
+	if err := local.SetAttributeByID(db, local.EntityTypeUser, userID, local.AttributeTypeResponse, setReq.Attribute, setReq.Value, setReq.Op); err != nil {
+		return nil, fmt.Errorf("failed to set user attribute: %w", err)
+	}
+
+	h.logger.Info("User attribute set", "user_id", userID, "attribute", setReq.Attribute, "value", setReq.Value, "op", setReq.Op)
+
+	return &local.OperResponse{
+		Message: fmt.Sprintf("Attribute '%s' set for user %d", setReq.Attribute, userID),
+	}, nil
+}
+
+func (h *SetUserAttributeHandler) PathPattern() operpaths.Path {
+	return operpaths.Path(local.OperSetUserAttributePath)
+}
+
+func (h *SetUserAttributeHandler) Dependencies() []operpaths.Path {
+	return nil
+}

--- a/plugins/auth/local/oper/service/create.go
+++ b/plugins/auth/local/oper/service/create.go
@@ -1,0 +1,74 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/veesix-networks/osvbng/pkg/logger"
+	"github.com/veesix-networks/osvbng/pkg/oper"
+	"github.com/veesix-networks/osvbng/pkg/oper/handlers"
+	operpaths "github.com/veesix-networks/osvbng/pkg/oper/paths"
+	"github.com/veesix-networks/osvbng/plugins/auth/local"
+)
+
+func init() {
+	handlers.RegisterFactory(NewCreateServiceHandler)
+}
+
+type CreateServiceHandler struct {
+	deps   *handlers.OperDeps
+	logger *slog.Logger
+}
+
+func NewCreateServiceHandler(deps *handlers.OperDeps) handlers.OperHandler {
+	return &CreateServiceHandler{
+		deps:   deps,
+		logger: logger.Component(local.Namespace + ".oper"),
+	}
+}
+
+func (h *CreateServiceHandler) Execute(ctx context.Context, req *oper.Request) (interface{}, error) {
+	provider := local.GetProvider()
+	if provider == nil {
+		return nil, fmt.Errorf("local auth provider not initialized")
+	}
+
+	db := provider.GetDB()
+
+	var createReq local.CreateServiceRequest
+	if err := json.Unmarshal(req.Body, &createReq); err != nil {
+		return nil, fmt.Errorf("invalid request body: %w", err)
+	}
+
+	if createReq.Name == "" {
+		return nil, fmt.Errorf("service name is required")
+	}
+
+	serviceID, err := local.CreateService(db, createReq.Name, createReq.Description)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create service: %w", err)
+	}
+
+	service, err := local.GetServiceByID(db, serviceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get created service: %w", err)
+	}
+
+	h.logger.Info("Service created", "name", createReq.Name, "service_id", service.ID)
+
+	return &local.CreateServiceResponse{
+		ServiceID: service.ID,
+		Name:      service.Name,
+		Message:   "Service created successfully",
+	}, nil
+}
+
+func (h *CreateServiceHandler) PathPattern() operpaths.Path {
+	return operpaths.Path(local.OperCreateServicePath)
+}
+
+func (h *CreateServiceHandler) Dependencies() []operpaths.Path {
+	return nil
+}

--- a/plugins/auth/local/oper/service/delete.go
+++ b/plugins/auth/local/oper/service/delete.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/veesix-networks/osvbng/pkg/logger"
+	"github.com/veesix-networks/osvbng/pkg/oper"
+	"github.com/veesix-networks/osvbng/pkg/oper/handlers"
+	operpaths "github.com/veesix-networks/osvbng/pkg/oper/paths"
+	"github.com/veesix-networks/osvbng/plugins/auth/local"
+)
+
+func init() {
+	handlers.RegisterFactory(NewDeleteServiceHandler)
+}
+
+type DeleteServiceHandler struct {
+	deps   *handlers.OperDeps
+	logger *slog.Logger
+}
+
+func NewDeleteServiceHandler(deps *handlers.OperDeps) handlers.OperHandler {
+	return &DeleteServiceHandler{
+		deps:   deps,
+		logger: logger.Component(local.Namespace + ".oper"),
+	}
+}
+
+func (h *DeleteServiceHandler) Execute(ctx context.Context, req *oper.Request) (interface{}, error) {
+	provider := local.GetProvider()
+	if provider == nil {
+		return nil, fmt.Errorf("local auth provider not initialized")
+	}
+
+	db := provider.GetDB()
+
+	wildcards, err := h.PathPattern().ExtractWildcards(req.Path, 1)
+	if err != nil {
+		return nil, err
+	}
+	serviceName := wildcards[0]
+
+	if err := local.DeleteService(db, serviceName); err != nil {
+		return nil, fmt.Errorf("failed to delete service: %w", err)
+	}
+
+	h.logger.Info("Service deleted", "name", serviceName)
+
+	return &local.OperResponse{
+		Message: fmt.Sprintf("Service '%s' deleted successfully", serviceName),
+	}, nil
+}
+
+func (h *DeleteServiceHandler) PathPattern() operpaths.Path {
+	return operpaths.Path(local.OperDeleteServicePath)
+}
+
+func (h *DeleteServiceHandler) Dependencies() []operpaths.Path {
+	return nil
+}

--- a/plugins/auth/local/oper/service/user.go
+++ b/plugins/auth/local/oper/service/user.go
@@ -1,0 +1,77 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strconv"
+
+	"github.com/veesix-networks/osvbng/pkg/logger"
+	"github.com/veesix-networks/osvbng/pkg/oper"
+	"github.com/veesix-networks/osvbng/pkg/oper/handlers"
+	operpaths "github.com/veesix-networks/osvbng/pkg/oper/paths"
+	"github.com/veesix-networks/osvbng/plugins/auth/local"
+)
+
+func init() {
+	handlers.RegisterFactory(NewSetUserServiceHandler)
+}
+
+type SetUserServiceHandler struct {
+	deps   *handlers.OperDeps
+	logger *slog.Logger
+}
+
+
+
+func NewSetUserServiceHandler(deps *handlers.OperDeps) handlers.OperHandler {
+	return &SetUserServiceHandler{
+		deps:   deps,
+		logger: logger.Component(local.Namespace + ".oper"),
+	}
+}
+
+func (h *SetUserServiceHandler) Execute(ctx context.Context, req *oper.Request) (interface{}, error) {
+	provider := local.GetProvider()
+	if provider == nil {
+		return nil, fmt.Errorf("local auth provider not initialized")
+	}
+
+	db := provider.GetDB()
+
+	wildcards, err := h.PathPattern().ExtractWildcards(req.Path, 2)
+	if err != nil {
+		return nil, err
+	}
+	userIDStr := wildcards[0]
+	service := wildcards[1]
+
+	userID, err := strconv.ParseInt(userIDStr, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid user ID: %s", userIDStr)
+	}
+
+	var setReq local.SetUserServiceRequest
+	if err := json.Unmarshal(req.Body, &setReq); err != nil {
+		return nil, fmt.Errorf("invalid request body: %w", err)
+	}
+
+	if err := local.AssignUserServiceByID(db, userID, service, setReq.Priority); err != nil {
+		return nil, fmt.Errorf("failed to set user service: %w", err)
+	}
+
+	h.logger.Info("User service assigned", "user_id", userID, "service", service, "priority", setReq.Priority)
+
+	return &local.OperResponse{
+		Message: fmt.Sprintf("Service '%s' assigned to user %d with priority %d", service, userID, setReq.Priority),
+	}, nil
+}
+
+func (h *SetUserServiceHandler) PathPattern() operpaths.Path {
+	return operpaths.Path(local.OperSetUserServicePath)
+}
+
+func (h *SetUserServiceHandler) Dependencies() []operpaths.Path {
+	return nil
+}

--- a/plugins/auth/local/oper/user/create.go
+++ b/plugins/auth/local/oper/user/create.go
@@ -1,0 +1,75 @@
+package user
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/veesix-networks/osvbng/pkg/logger"
+	"github.com/veesix-networks/osvbng/pkg/oper"
+	"github.com/veesix-networks/osvbng/pkg/oper/handlers"
+	"github.com/veesix-networks/osvbng/pkg/oper/paths"
+	"github.com/veesix-networks/osvbng/plugins/auth/local"
+)
+
+func init() {
+	handlers.RegisterFactory(NewCreateUserHandler)
+}
+
+type CreateUserHandler struct {
+	deps   *handlers.OperDeps
+	logger *slog.Logger
+}
+
+
+func NewCreateUserHandler(deps *handlers.OperDeps) handlers.OperHandler {
+	return &CreateUserHandler{
+		deps:   deps,
+		logger: logger.Component(local.Namespace + ".oper"),
+	}
+}
+
+func (h *CreateUserHandler) Execute(ctx context.Context, req *oper.Request) (interface{}, error) {
+	provider := local.GetProvider()
+	if provider == nil {
+		return nil, fmt.Errorf("local auth provider not initialized")
+	}
+
+	db := provider.GetDB()
+
+	var createReq local.CreateUserRequest
+	if err := json.Unmarshal(req.Body, &createReq); err != nil {
+		return nil, fmt.Errorf("invalid request body: %w", err)
+	}
+
+	if createReq.Username == "" {
+		return nil, fmt.Errorf("username is required")
+	}
+
+	userID, err := local.CreateUser(db, createReq.Username, createReq.Password, createReq.Enabled)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create user: %w", err)
+	}
+
+	user, err := local.GetUserByID(db, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get created user: %w", err)
+	}
+
+	h.logger.Info("User created", "username", createReq.Username, "user_id", user.ID)
+
+	return &local.CreateUserResponse{
+		UserID:   user.ID,
+		Username: user.Username,
+		Message:  "User created successfully",
+	}, nil
+}
+
+func (h *CreateUserHandler) PathPattern() paths.Path {
+	return paths.Path(local.OperCreateUserPath)
+}
+
+func (h *CreateUserHandler) Dependencies() []paths.Path {
+	return nil
+}

--- a/plugins/auth/local/oper/user/delete.go
+++ b/plugins/auth/local/oper/user/delete.go
@@ -1,0 +1,69 @@
+package user
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+
+	"github.com/veesix-networks/osvbng/pkg/logger"
+	"github.com/veesix-networks/osvbng/pkg/oper"
+	"github.com/veesix-networks/osvbng/pkg/oper/handlers"
+	operpaths "github.com/veesix-networks/osvbng/pkg/oper/paths"
+	"github.com/veesix-networks/osvbng/plugins/auth/local"
+)
+
+func init() {
+	handlers.RegisterFactory(NewDeleteUserHandler)
+}
+
+type DeleteUserHandler struct {
+	deps   *handlers.OperDeps
+	logger *slog.Logger
+}
+
+
+func NewDeleteUserHandler(deps *handlers.OperDeps) handlers.OperHandler {
+	return &DeleteUserHandler{
+		deps:   deps,
+		logger: logger.Component(local.Namespace + ".oper"),
+	}
+}
+
+func (h *DeleteUserHandler) Execute(ctx context.Context, req *oper.Request) (interface{}, error) {
+	provider := local.GetProvider()
+	if provider == nil {
+		return nil, fmt.Errorf("local auth provider not initialized")
+	}
+
+	db := provider.GetDB()
+
+	wildcards, err := h.PathPattern().ExtractWildcards(req.Path, 1)
+	if err != nil {
+		return nil, err
+	}
+	userIDStr := wildcards[0]
+
+	userID, err := strconv.ParseInt(userIDStr, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid user ID: %s", userIDStr)
+	}
+
+	if err := local.DeleteUserByID(db, userID); err != nil {
+		return nil, fmt.Errorf("failed to delete user: %w", err)
+	}
+
+	h.logger.Info("User deleted", "user_id", userID)
+
+	return &local.OperResponse{
+		Message: fmt.Sprintf("User %d deleted successfully", userID),
+	}, nil
+}
+
+func (h *DeleteUserHandler) PathPattern() operpaths.Path {
+	return operpaths.Path(local.OperDeleteUserPath)
+}
+
+func (h *DeleteUserHandler) Dependencies() []operpaths.Path {
+	return nil
+}

--- a/plugins/auth/local/oper/user/enabled.go
+++ b/plugins/auth/local/oper/user/enabled.go
@@ -1,0 +1,76 @@
+package user
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strconv"
+
+	"github.com/veesix-networks/osvbng/pkg/logger"
+	"github.com/veesix-networks/osvbng/pkg/oper"
+	"github.com/veesix-networks/osvbng/pkg/oper/handlers"
+	operpaths "github.com/veesix-networks/osvbng/pkg/oper/paths"
+	"github.com/veesix-networks/osvbng/plugins/auth/local"
+)
+
+func init() {
+	handlers.RegisterFactory(NewSetUserEnabledHandler)
+}
+
+type SetUserEnabledHandler struct {
+	deps   *handlers.OperDeps
+	logger *slog.Logger
+}
+
+
+
+func NewSetUserEnabledHandler(deps *handlers.OperDeps) handlers.OperHandler {
+	return &SetUserEnabledHandler{
+		deps:   deps,
+		logger: logger.Component(local.Namespace + ".oper"),
+	}
+}
+
+func (h *SetUserEnabledHandler) Execute(ctx context.Context, req *oper.Request) (interface{}, error) {
+	provider := local.GetProvider()
+	if provider == nil {
+		return nil, fmt.Errorf("local auth provider not initialized")
+	}
+
+	db := provider.GetDB()
+
+	wildcards, err := h.PathPattern().ExtractWildcards(req.Path, 1)
+	if err != nil {
+		return nil, err
+	}
+	userIDStr := wildcards[0]
+
+	userID, err := strconv.ParseInt(userIDStr, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid user ID: %s", userIDStr)
+	}
+
+	var setReq local.SetUserEnabledRequest
+	if err := json.Unmarshal(req.Body, &setReq); err != nil {
+		return nil, fmt.Errorf("invalid request body: %w", err)
+	}
+
+	if err := local.UpdateUserEnabledByID(db, userID, setReq.Enabled); err != nil {
+		return nil, fmt.Errorf("failed to set enabled: %w", err)
+	}
+
+	h.logger.Info("User enabled status updated", "user_id", userID, "enabled", setReq.Enabled)
+
+	return &local.OperResponse{
+		Message: fmt.Sprintf("User %d enabled status set to %v", userID, setReq.Enabled),
+	}, nil
+}
+
+func (h *SetUserEnabledHandler) PathPattern() operpaths.Path {
+	return operpaths.Path(local.OperSetUserEnabledPath)
+}
+
+func (h *SetUserEnabledHandler) Dependencies() []operpaths.Path {
+	return nil
+}

--- a/plugins/auth/local/oper/user/password.go
+++ b/plugins/auth/local/oper/user/password.go
@@ -1,0 +1,80 @@
+package user
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strconv"
+
+	"github.com/veesix-networks/osvbng/pkg/logger"
+	"github.com/veesix-networks/osvbng/pkg/oper"
+	"github.com/veesix-networks/osvbng/pkg/oper/handlers"
+	operpaths "github.com/veesix-networks/osvbng/pkg/oper/paths"
+	"github.com/veesix-networks/osvbng/plugins/auth/local"
+)
+
+func init() {
+	handlers.RegisterFactory(NewSetUserPasswordHandler)
+}
+
+type SetUserPasswordHandler struct {
+	deps   *handlers.OperDeps
+	logger *slog.Logger
+}
+
+
+
+func NewSetUserPasswordHandler(deps *handlers.OperDeps) handlers.OperHandler {
+	return &SetUserPasswordHandler{
+		deps:   deps,
+		logger: logger.Component(local.Namespace + ".oper"),
+	}
+}
+
+func (h *SetUserPasswordHandler) Execute(ctx context.Context, req *oper.Request) (interface{}, error) {
+	provider := local.GetProvider()
+	if provider == nil {
+		return nil, fmt.Errorf("local auth provider not initialized")
+	}
+
+	db := provider.GetDB()
+
+	wildcards, err := h.PathPattern().ExtractWildcards(req.Path, 1)
+	if err != nil {
+		return nil, err
+	}
+	userIDStr := wildcards[0]
+
+	userID, err := strconv.ParseInt(userIDStr, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid user ID: %s", userIDStr)
+	}
+
+	var setReq local.SetUserPasswordRequest
+	if err := json.Unmarshal(req.Body, &setReq); err != nil {
+		return nil, fmt.Errorf("invalid request body: %w", err)
+	}
+
+	if setReq.Password == "" {
+		return nil, fmt.Errorf("password is required")
+	}
+
+	if err := local.UpdateUserPasswordByID(db, userID, &setReq.Password); err != nil {
+		return nil, fmt.Errorf("failed to set password: %w", err)
+	}
+
+	h.logger.Info("User password updated", "user_id", userID)
+
+	return &local.OperResponse{
+		Message: fmt.Sprintf("Password updated for user %d", userID),
+	}, nil
+}
+
+func (h *SetUserPasswordHandler) PathPattern() operpaths.Path {
+	return operpaths.Path(local.OperSetUserPasswordPath)
+}
+
+func (h *SetUserPasswordHandler) Dependencies() []operpaths.Path {
+	return nil
+}

--- a/plugins/auth/local/paths.go
+++ b/plugins/auth/local/paths.go
@@ -1,0 +1,34 @@
+package local
+
+import (
+	confpaths "github.com/veesix-networks/osvbng/pkg/conf/paths"
+	operpaths "github.com/veesix-networks/osvbng/pkg/oper/paths"
+	showpaths "github.com/veesix-networks/osvbng/pkg/show/paths"
+)
+
+const (
+	ShowUsersPath    = showpaths.Path("subscriber.auth.local.users")
+	ShowUserPath     = showpaths.Path("subscriber.auth.local.users.*")
+	ShowServicesPath = showpaths.Path("subscriber.auth.local.services")
+	ShowServicePath  = showpaths.Path("subscriber.auth.local.services.*")
+
+	OperCreateUserPath          = operpaths.Path("subscriber.auth.local.users.create")
+	OperDeleteUserPath          = operpaths.Path("subscriber.auth.local.user.*.delete")
+	OperSetUserPasswordPath     = operpaths.Path("subscriber.auth.local.user.*.password")
+	OperSetUserEnabledPath      = operpaths.Path("subscriber.auth.local.user.*.enabled")
+	OperSetUserServicePath      = operpaths.Path("subscriber.auth.local.user.*.service.*")
+	OperSetUserAttributePath    = operpaths.Path("subscriber.auth.local.user.*.attribute")
+	OperCreateServicePath       = operpaths.Path("subscriber.auth.local.services.create")
+	OperDeleteServicePath       = operpaths.Path("subscriber.auth.local.services.*.delete")
+	OperSetServiceAttributePath = operpaths.Path("subscriber.auth.local.services.*.attribute")
+
+	ConfUsersPath            = confpaths.Path("subscriber.auth.local.users")
+	ConfUserPath             = confpaths.Path("subscriber.auth.local.users.*")
+	ConfUserPasswordPath     = confpaths.Path("subscriber.auth.local.users.*.password")
+	ConfUserEnabledPath      = confpaths.Path("subscriber.auth.local.users.*.enabled")
+	ConfUserServicePath      = confpaths.Path("subscriber.auth.local.users.*.service.*")
+	ConfUserAttributePath    = confpaths.Path("subscriber.auth.local.users.*.attribute.*")
+	ConfServicesPath         = confpaths.Path("subscriber.auth.local.services")
+	ConfServicePath          = confpaths.Path("subscriber.auth.local.services.*")
+	ConfServiceAttributePath = confpaths.Path("subscriber.auth.local.services.*.attribute.*")
+)

--- a/plugins/auth/local/provider.go
+++ b/plugins/auth/local/provider.go
@@ -2,19 +2,58 @@ package local
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
 
 	"github.com/veesix-networks/osvbng/pkg/auth"
+	"github.com/veesix-networks/osvbng/pkg/conf"
+	"github.com/veesix-networks/osvbng/pkg/logger"
 	"github.com/veesix-networks/osvbng/pkg/provider"
 )
 
-func init() {
-	auth.Register("local", New)
+var globalProvider *Provider
+
+type Provider struct {
+	db     *sql.DB
+	logger *slog.Logger
 }
 
-type Provider struct{}
+func New() (auth.AuthProvider, error) {
+	pluginCfgRaw, ok := conf.GetPluginConfig(Namespace)
+	if !ok {
+		return nil, nil
+	}
 
-func New(cfg map[string]string) (auth.AuthProvider, error) {
-	return &Provider{}, nil
+	pluginCfg, ok := pluginCfgRaw.(*Config)
+	if !ok {
+		return nil, fmt.Errorf("invalid config type for %s", Namespace)
+	}
+
+	dbPath := pluginCfg.DatabasePath
+	if dbPath == "" {
+		dbPath = "/var/lib/osvbng/local-auth.db"
+	}
+
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open database: %w", err)
+	}
+
+	if err := initSchema(db); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("failed to initialize schema: %w", err)
+	}
+
+	p := &Provider{
+		db:     db,
+		logger: logger.Component(Namespace),
+	}
+
+	globalProvider = p
+
+	p.logger.Info("Local auth provider initialized", "database", dbPath)
+	return p, nil
 }
 
 func (p *Provider) Info() provider.Info {
@@ -26,9 +65,34 @@ func (p *Provider) Info() provider.Info {
 }
 
 func (p *Provider) Authenticate(ctx context.Context, req *auth.AuthRequest) (*auth.AuthResponse, error) {
+	user, err := getUserByUsername(p.db, req.Username)
+	if err != nil {
+		p.logger.Debug("User not found", "username", req.Username, "error", err)
+		return &auth.AuthResponse{Allowed: false}, nil
+	}
+
+	if !user.Enabled {
+		p.logger.Debug("User disabled", "username", req.Username)
+		return &auth.AuthResponse{Allowed: false}, nil
+	}
+
+	if user.Password != nil {
+		reqPassword, ok := req.Attributes["password"]
+		if !ok || reqPassword != *user.Password {
+			p.logger.Debug("Password mismatch", "username", req.Username)
+			return &auth.AuthResponse{Allowed: false}, nil
+		}
+	}
+
+	attrs, err := loadMergedAttributes(p.db, user.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load attributes: %w", err)
+	}
+
+	p.logger.Info("User authenticated", "username", req.Username, "attributes", len(attrs))
 	return &auth.AuthResponse{
 		Allowed:    true,
-		Attributes: make(map[string]string),
+		Attributes: attrs,
 	}, nil
 }
 
@@ -42,4 +106,19 @@ func (p *Provider) UpdateAccounting(ctx context.Context, session *auth.Session) 
 
 func (p *Provider) StopAccounting(ctx context.Context, session *auth.Session) error {
 	return nil
+}
+
+func (p *Provider) Close() error {
+	if p.db != nil {
+		return p.db.Close()
+	}
+	return nil
+}
+
+func GetProvider() *Provider {
+	return globalProvider
+}
+
+func (p *Provider) GetDB() *sql.DB {
+	return p.db
 }

--- a/plugins/auth/local/show/services.go
+++ b/plugins/auth/local/show/services.go
@@ -1,0 +1,119 @@
+package show
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/veesix-networks/osvbng/pkg/show/handlers"
+	"github.com/veesix-networks/osvbng/pkg/show/paths"
+	"github.com/veesix-networks/osvbng/plugins/auth/local"
+)
+
+func init() {
+	handlers.RegisterFactory(NewServicesHandler)
+	handlers.RegisterFactory(NewServiceHandler)
+}
+
+type ServicesHandler struct {
+	deps *handlers.ShowDeps
+}
+
+type ServiceHandler struct {
+	deps *handlers.ShowDeps
+}
+
+type ServicesResponse struct {
+	Services []ServiceInfo `json:"services"`
+}
+
+type ServiceInfo struct {
+	Name        string            `json:"name"`
+	Description string            `json:"description"`
+	Attributes  map[string]string `json:"attributes,omitempty"`
+	CreatedAt   string            `json:"created_at"`
+}
+
+func NewServicesHandler(deps *handlers.ShowDeps) handlers.ShowHandler {
+	return &ServicesHandler{deps: deps}
+}
+
+func NewServiceHandler(deps *handlers.ShowDeps) handlers.ShowHandler {
+	return &ServiceHandler{deps: deps}
+}
+
+func (h *ServicesHandler) Collect(ctx context.Context, req *handlers.ShowRequest) (interface{}, error) {
+	provider := local.GetProvider()
+	if provider == nil {
+		return nil, fmt.Errorf("local auth provider not initialized")
+	}
+
+	db := provider.GetDB()
+
+	services, err := local.ListServices(db)
+	if err != nil {
+		return nil, err
+	}
+
+	var serviceInfos []ServiceInfo
+	for _, service := range services {
+		serviceInfos = append(serviceInfos, ServiceInfo{
+			Name:        service.Name,
+			Description: service.Description,
+			CreatedAt:   service.CreatedAt.Format("2006-01-02 15:04:05"),
+		})
+	}
+
+	return &ServicesResponse{Services: serviceInfos}, nil
+}
+
+func (h *ServicesHandler) PathPattern() paths.Path {
+	return paths.Path(local.ShowServicesPath)
+}
+
+func (h *ServicesHandler) Dependencies() []paths.Path {
+	return nil
+}
+
+func (h *ServiceHandler) Collect(ctx context.Context, req *handlers.ShowRequest) (interface{}, error) {
+	provider := local.GetProvider()
+	if provider == nil {
+		return nil, fmt.Errorf("local auth provider not initialized")
+	}
+
+	db := provider.GetDB()
+
+	serviceName := req.Options["name"]
+	if serviceName == "" {
+		return nil, fmt.Errorf("service name required")
+	}
+
+	service, err := local.GetServiceByName(db, serviceName)
+	if err != nil {
+		return nil, err
+	}
+
+	attributes, err := local.GetAttributes(db, local.EntityTypeService, serviceName, local.AttributeTypeResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	attrs := make(map[string]string)
+	for _, attr := range attributes {
+		attrs[attr.AttributeName] = attr.AttributeValue
+	}
+
+	return &ServiceInfo{
+		Name:        service.Name,
+		Description: service.Description,
+		Attributes:  attrs,
+		CreatedAt:   service.CreatedAt.Format("2006-01-02 15:04:05"),
+	}, nil
+}
+
+func (h *ServiceHandler) PathPattern() paths.Path {
+	return paths.Path(local.ShowServicePath)
+}
+
+func (h *ServiceHandler) Dependencies() []paths.Path {
+	return nil
+}

--- a/plugins/auth/local/show/users.go
+++ b/plugins/auth/local/show/users.go
@@ -1,0 +1,156 @@
+package show
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/veesix-networks/osvbng/pkg/show/handlers"
+	"github.com/veesix-networks/osvbng/pkg/show/paths"
+	"github.com/veesix-networks/osvbng/plugins/auth/local"
+)
+
+func init() {
+	handlers.RegisterFactory(NewUsersHandler)
+	handlers.RegisterFactory(NewUserHandler)
+}
+
+type UsersHandler struct {
+	deps *handlers.ShowDeps
+}
+
+type UserHandler struct {
+	deps *handlers.ShowDeps
+}
+
+type UsersResponse struct {
+	Users []UserInfo `json:"users"`
+}
+
+type UserInfo struct {
+	ID            int64             `json:"id"`
+	Username      string            `json:"username"`
+	Enabled       bool              `json:"enabled"`
+	HasPassword   bool              `json:"has_password"`
+	Services      []string          `json:"services,omitempty"`
+	Attributes    map[string]string `json:"attributes,omitempty"`
+	CreatedAt     string            `json:"created_at"`
+}
+
+func NewUsersHandler(deps *handlers.ShowDeps) handlers.ShowHandler {
+	return &UsersHandler{deps: deps}
+}
+
+func NewUserHandler(deps *handlers.ShowDeps) handlers.ShowHandler {
+	return &UserHandler{deps: deps}
+}
+
+func (h *UsersHandler) Collect(ctx context.Context, req *handlers.ShowRequest) (interface{}, error) {
+	provider := local.GetProvider()
+	if provider == nil {
+		return nil, fmt.Errorf("local auth provider not initialized")
+	}
+
+	db := provider.GetDB()
+
+	users, err := local.ListUsers(db)
+	if err != nil {
+		return nil, err
+	}
+
+	var userInfos []UserInfo
+	for _, user := range users {
+		userInfos = append(userInfos, UserInfo{
+			ID:          user.ID,
+			Username:    user.Username,
+			Enabled:     user.Enabled,
+			HasPassword: user.Password != nil,
+			CreatedAt:   user.CreatedAt.Format("2006-01-02 15:04:05"),
+		})
+	}
+
+	return &UsersResponse{Users: userInfos}, nil
+}
+
+func (h *UsersHandler) PathPattern() paths.Path {
+	return paths.Path(local.ShowUsersPath)
+}
+
+func (h *UsersHandler) Dependencies() []paths.Path {
+	return nil
+}
+
+func (h *UserHandler) Collect(ctx context.Context, req *handlers.ShowRequest) (interface{}, error) {
+	provider := local.GetProvider()
+	if provider == nil {
+		return nil, fmt.Errorf("local auth provider not initialized")
+	}
+
+	db := provider.GetDB()
+
+	userIDStr := extractUserIDFromPath(req.Path)
+	if userIDStr == "" {
+		return nil, fmt.Errorf("user ID required")
+	}
+
+	userID, err := strconv.ParseInt(userIDStr, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid user ID: %s", userIDStr)
+	}
+
+	user, err := local.GetUserByID(db, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	userServices, err := local.GetUserServices(db, user.Username)
+	if err != nil {
+		return nil, err
+	}
+
+	var serviceNames []string
+	for _, us := range userServices {
+		service, err := local.GetServiceByID(db, us.ServiceID)
+		if err != nil {
+			continue
+		}
+		serviceNames = append(serviceNames, service.Name)
+	}
+
+	attributes, err := local.GetAttributes(db, local.EntityTypeUser, user.Username, local.AttributeTypeResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	attrs := make(map[string]string)
+	for _, attr := range attributes {
+		attrs[attr.AttributeName] = attr.AttributeValue
+	}
+
+	return &UserInfo{
+		ID:          user.ID,
+		Username:    user.Username,
+		Enabled:     user.Enabled,
+		HasPassword: user.Password != nil,
+		Services:    serviceNames,
+		Attributes:  attrs,
+		CreatedAt:   user.CreatedAt.Format("2006-01-02 15:04:05"),
+	}, nil
+}
+
+func extractUserIDFromPath(path string) string {
+	parts := strings.Split(path, ".")
+	if len(parts) >= 5 && parts[0] == "subscriber" && parts[1] == "auth" && parts[2] == "local" && parts[3] == "users" {
+		return parts[4]
+	}
+	return ""
+}
+
+func (h *UserHandler) PathPattern() paths.Path {
+	return paths.Path(local.ShowUserPath)
+}
+
+func (h *UserHandler) Dependencies() []paths.Path {
+	return nil
+}

--- a/plugins/community/hello/paths.go
+++ b/plugins/community/hello/paths.go
@@ -9,5 +9,5 @@ import (
 const (
 	ShowStatusPath  = showpaths.Path("example.hello.status")
 	StateStatusPath = statepaths.Path("example.hello.status")
-	ConfMessagePath = confpaths.Path("plugins.example.hello.message")
+	ConfMessagePath = confpaths.Path("example.hello.message")
 )

--- a/plugins/northbound/all/all.go
+++ b/plugins/northbound/all/all.go
@@ -1,0 +1,5 @@
+package all
+
+import (
+	_ "github.com/veesix-networks/osvbng/plugins/northbound/api"
+)

--- a/plugins/northbound/api/api.go
+++ b/plugins/northbound/api/api.go
@@ -1,0 +1,125 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/veesix-networks/osvbng/pkg/component"
+	"github.com/veesix-networks/osvbng/pkg/conf"
+	"github.com/veesix-networks/osvbng/pkg/logger"
+	"github.com/veesix-networks/osvbng/pkg/northbound"
+)
+
+type Component struct {
+	*component.Base
+	logger   *slog.Logger
+	adapter  *northbound.Adapter
+	addr     string
+	server   *http.Server
+	mu       sync.RWMutex
+	running  bool
+}
+
+func NewComponent(deps component.Dependencies) (component.Component, error) {
+	pluginCfgRaw, ok := conf.GetPluginConfig(Namespace)
+	if !ok {
+		return nil, nil
+	}
+
+	pluginCfg, ok := pluginCfgRaw.(*Config)
+	if !ok {
+		return nil, fmt.Errorf("invalid config type for %s", Namespace)
+	}
+
+	if !pluginCfg.Enabled {
+		return nil, nil
+	}
+
+	addr := ":8080"
+	if pluginCfg.ListenAddress != "" {
+		addr = pluginCfg.ListenAddress
+	}
+
+	return &Component{
+		Base:   component.NewBase(Namespace),
+		logger: logger.Component(Namespace),
+		addr:   addr,
+	}, nil
+}
+
+func (c *Component) SetRegistries(adapter *northbound.Adapter) {
+	c.adapter = adapter
+}
+
+func (c *Component) Start(ctx context.Context) error {
+	c.StartContext(ctx)
+	c.logger.Info("Starting API server", "addr", c.addr)
+
+	c.Go(func() {
+		c.startServer()
+	})
+
+	return nil
+}
+
+func (c *Component) Stop(ctx context.Context) error {
+	c.logger.Info("Stopping API server")
+
+	if c.server != nil {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		c.server.Shutdown(shutdownCtx)
+	}
+
+	c.mu.Lock()
+	c.running = false
+	c.mu.Unlock()
+
+	c.StopContext()
+	return nil
+}
+
+func (c *Component) GetStatus() *Status {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	state := "stopped"
+	if c.running {
+		state = "running"
+	}
+
+	return &Status{
+		State:         state,
+		ListenAddress: c.addr,
+		Running:       c.running,
+	}
+}
+
+func (c *Component) startServer() {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("GET /api/{path...}", c.handleShow)
+	mux.HandleFunc("POST /api/{path...}", c.handleConfig)
+	mux.HandleFunc("GET /api", c.handlePaths)
+
+	c.server = &http.Server{
+		Addr:    c.addr,
+		Handler: mux,
+	}
+
+	c.mu.Lock()
+	c.running = true
+	c.mu.Unlock()
+
+	c.logger.Info("API server listening", "addr", c.addr)
+	if err := c.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		c.logger.Error("API server error", "error", err)
+		c.mu.Lock()
+		c.running = false
+		c.mu.Unlock()
+	}
+}

--- a/plugins/northbound/api/config.go
+++ b/plugins/northbound/api/config.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"github.com/veesix-networks/osvbng/pkg/component"
+	"github.com/veesix-networks/osvbng/pkg/conf"
+)
+
+const Namespace = "northbound.api"
+
+type Config struct {
+	Enabled       bool   `json:"enabled" yaml:"enabled"`
+	ListenAddress string `json:"listen_address,omitempty" yaml:"listen_address,omitempty"`
+}
+
+func init() {
+	conf.RegisterPluginConfig(Namespace, Config{})
+
+	component.Register(Namespace, NewComponent,
+		component.WithAuthor("Veesix Networks"),
+		component.WithVersion("1.0.0"),
+	)
+}

--- a/plugins/northbound/api/handlers.go
+++ b/plugins/northbound/api/handlers.go
@@ -1,0 +1,143 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+)
+
+func (c *Component) handlePaths(w http.ResponseWriter, r *http.Request) {
+	showPaths := c.adapter.GetAllShowPaths()
+	confPaths := c.adapter.GetAllConfPaths()
+	operPaths := c.adapter.GetAllOperPaths()
+
+	showPathStrs := make([]string, len(showPaths))
+	for i, p := range showPaths {
+		showPathStrs[i] = p.String()
+	}
+
+	confPathStrs := make([]string, len(confPaths))
+	for i, p := range confPaths {
+		confPathStrs[i] = p.String()
+	}
+
+	operPathStrs := make([]string, len(operPaths))
+	for i, p := range operPaths {
+		operPathStrs[i] = p.String()
+	}
+
+	resp := PathsResponse{
+		ShowPaths:   showPathStrs,
+		ConfigPaths: confPathStrs,
+		OperPaths:   operPathStrs,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+func (c *Component) handleShow(w http.ResponseWriter, r *http.Request) {
+	urlPath := r.PathValue("path")
+	if urlPath == "" {
+		c.writeError(w, http.StatusBadRequest, "path required")
+		return
+	}
+
+	internalPath := strings.ReplaceAll(urlPath, "/", ".")
+
+	options := make(map[string]string)
+	for key, values := range r.URL.Query() {
+		if len(values) > 0 {
+			options[key] = values[0]
+		}
+	}
+
+	data, err := c.adapter.ExecuteShow(r.Context(), internalPath, options)
+	if err != nil {
+		c.logger.Error("show handler failed", "path", internalPath, "error", err)
+		c.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	resp := ShowResponse{
+		Path: internalPath,
+		Data: data,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+func (c *Component) handleConfig(w http.ResponseWriter, r *http.Request) {
+	path := r.PathValue("path")
+	if path == "" {
+		c.writeError(w, http.StatusBadRequest, "path required")
+		return
+	}
+
+	path = strings.ReplaceAll(path, "/", ".")
+
+	// Check if there's an oper handler for this path
+	if c.adapter.HasOperHandler(path) {
+		c.handleOper(w, r, path)
+		return
+	}
+
+	var value interface{}
+	if err := json.NewDecoder(r.Body).Decode(&value); err != nil {
+		c.writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	if err := c.adapter.ValidateConfig(r.Context(), "", path, value); err != nil {
+		c.logger.Error("config validation failed", "path", path, "error", err)
+		c.writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := c.adapter.ApplyConfig(r.Context(), "", path, nil, value); err != nil {
+		c.logger.Error("config apply failed", "path", path, "error", err)
+		c.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func (c *Component) handleOper(w http.ResponseWriter, r *http.Request, operPath string) {
+	var body []byte
+	if r.Body != nil {
+		var err error
+		body, err = io.ReadAll(r.Body)
+		if err != nil {
+			c.writeError(w, http.StatusBadRequest, "failed to read request body")
+			return
+		}
+	}
+
+	options := make(map[string]string)
+	for key, values := range r.URL.Query() {
+		if len(values) > 0 {
+			options[key] = values[0]
+		}
+	}
+
+	data, err := c.adapter.ExecuteOper(r.Context(), operPath, body, options)
+	if err != nil {
+		c.logger.Error("oper handler failed", "path", operPath, "error", err)
+		c.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(data)
+}
+
+func (c *Component) writeError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(ErrorResponse{Error: message})
+}

--- a/plugins/northbound/api/types.go
+++ b/plugins/northbound/api/types.go
@@ -1,0 +1,26 @@
+package api
+
+type Status struct {
+	State         string `json:"state"`
+	ListenAddress string `json:"listen_address"`
+	Running       bool   `json:"running"`
+}
+
+type PathsResponse struct {
+	ShowPaths   []string `json:"show_paths"`
+	ConfigPaths []string `json:"config_paths"`
+	OperPaths   []string `json:"oper_paths"`
+}
+
+type ShowResponse struct {
+	Path string      `json:"path"`
+	Data interface{} `json:"data"`
+}
+
+type ConfigRequest struct {
+	Value interface{} `json:"value"`
+}
+
+type ErrorResponse struct {
+	Error string `json:"error"`
+}

--- a/test-infra/configs/osvbng.yaml
+++ b/test-infra/configs/osvbng.yaml
@@ -131,9 +131,14 @@ monitoring:
     # - example.hello.status
 
 plugins:
+  subscriber.auth.local:
+    database_path: /tmp/osvbng.db
   exporter.prometheus:
     enabled: true
     listen_address: ":9090"
+  northbound.api:
+    enabled: true
+    listen_address: ":8080"
   example.hello:
     enabled: true
     message: "This message is displayed via a `show` handler. It can be changed with a `conf` handler and will persist after a config commit."

--- a/test-infra/docker-compose.yml
+++ b/test-infra/docker-compose.yml
@@ -50,6 +50,7 @@ services:
     ports:
       - 50050:50050
       - 9090:9090
+      - 8080:8080
 
 volumes:
   vpp-logs:


### PR DESCRIPTION
Basic working implementation for local auth handler with sqlite, which require the introduction of the oper handler (as conf handler integrates heavily with the config management/startup/running configs + versioning)

Basic auto-generate API was introduced as a plugin also so that we could demonstrate an example on how to provision local subscribers without an external RADIUS/auth database.