### PR TITLE
feat(monitoring): add subscriber session operational metrics

### DIFF
--- a/docker/dev/grafana/provisioning/dashboards/osvbng-subscribers.json
+++ b/docker/dev/grafana/provisioning/dashboards/osvbng-subscribers.json
@@ -1,0 +1,195 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "none"
+        }
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "expr": "osvbng_subscriber_sessions_total{job=\"osvbng\"}",
+        "legendFormat": "Total"
+      }],
+      "title": "Total Sessions",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "none"
+        }
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 0 },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "expr": "osvbng_subscriber_sessions_active{job=\"osvbng\"}",
+        "legendFormat": "Active"
+      }],
+      "title": "Active Sessions",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "none",
+          "min": 0
+        }
+      },
+      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 0 },
+      "id": 3,
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showUnfilled": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "osvbng_subscriber_sessions_ipoe_v4{job=\"osvbng\"}",
+          "legendFormat": "IPoE v4"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "osvbng_subscriber_sessions_ipoe_v6{job=\"osvbng\"}",
+          "legendFormat": "IPoE v6"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "osvbng_subscriber_sessions_ppp{job=\"osvbng\"}",
+          "legendFormat": "PPP"
+        }
+      ],
+      "title": "Sessions by Type",
+      "type": "bargauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 4 },
+      "id": 10,
+      "panels": [],
+      "title": "Sessions Over Time",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "none",
+          "min": 0
+        }
+      },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 5 },
+      "id": 11,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "osvbng_subscriber_sessions_total{job=\"osvbng\"}",
+          "legendFormat": "Total"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "osvbng_subscriber_sessions_active{job=\"osvbng\"}",
+          "legendFormat": "Active"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "osvbng_subscriber_sessions_released{job=\"osvbng\"}",
+          "legendFormat": "Released"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "osvbng_subscriber_sessions_ipoe_v4{job=\"osvbng\"}",
+          "legendFormat": "IPoE v4"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "osvbng_subscriber_sessions_ipoe_v6{job=\"osvbng\"}",
+          "legendFormat": "IPoE v6"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "osvbng_subscriber_sessions_ppp{job=\"osvbng\"}",
+          "legendFormat": "PPP"
+        }
+      ],
+      "title": "Sessions Over Time",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["subscribers", "osvbng"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "osvbng Subscribers",
+  "uid": "osvbng-subscribers",
+  "version": 1
+}

--- a/pkg/handlers/show/subscriber/stats.go
+++ b/pkg/handlers/show/subscriber/stats.go
@@ -7,10 +7,14 @@ import (
 	"github.com/veesix-networks/osvbng/pkg/deps"
 	"github.com/veesix-networks/osvbng/pkg/handlers/show"
 	"github.com/veesix-networks/osvbng/pkg/handlers/show/paths"
+	"github.com/veesix-networks/osvbng/pkg/state"
+	statepaths "github.com/veesix-networks/osvbng/pkg/state/paths"
 )
 
 func init() {
 	show.RegisterFactory(NewStatsHandler)
+
+	state.RegisterMetric(statepaths.SubscriberStats, paths.SubscriberStats)
 }
 
 type StatsHandler struct {

--- a/pkg/state/paths/paths.go
+++ b/pkg/state/paths/paths.go
@@ -11,6 +11,7 @@ const (
 	ProtocolsOSPF6Neighbors Path = "protocols.ospf6.neighbors"
 	ProtocolsISISNeighbors  Path = "protocols.isis.neighbors"
 	SubscriberSessions         Path = "subscriber.sessions"
+	SubscriberStats            Path = "subscriber.stats"
 
 	SystemDataplaneSystem     Path = "system.dataplane.system"
 	SystemDataplaneMemory     Path = "system.dataplane.memory"

--- a/plugins/exporter/prometheus/metrics/subscriber_stats.go
+++ b/plugins/exporter/prometheus/metrics/subscriber_stats.go
@@ -1,0 +1,18 @@
+package metrics
+
+import (
+	"github.com/veesix-networks/osvbng/pkg/state/paths"
+)
+
+type subscriberSessionStats struct {
+	Total    uint32 `json:"total" prometheus:"name=osvbng_subscriber_sessions_total,help=Total number of subscriber sessions,type=gauge"`
+	IPoEV4   uint32 `json:"ipoe_v4" prometheus:"name=osvbng_subscriber_sessions_ipoe_v4,help=Number of IPoE IPv4 subscriber sessions,type=gauge"`
+	IPoEV6   uint32 `json:"ipoe_v6" prometheus:"name=osvbng_subscriber_sessions_ipoe_v6,help=Number of IPoE IPv6 subscriber sessions,type=gauge"`
+	PPP      uint32 `json:"ppp" prometheus:"name=osvbng_subscriber_sessions_ppp,help=Number of PPP subscriber sessions,type=gauge"`
+	Active   uint32 `json:"active" prometheus:"name=osvbng_subscriber_sessions_active,help=Number of active subscriber sessions,type=gauge"`
+	Released uint32 `json:"released" prometheus:"name=osvbng_subscriber_sessions_released,help=Number of released subscriber sessions,type=gauge"`
+}
+
+func init() {
+	RegisterMetricSingle[subscriberSessionStats](paths.SubscriberStats)
+}


### PR DESCRIPTION
Introduced a subscriber dashboard so we can provide images when doing large stress testing (eg. 42042 test). Introduced a basic metric for subscriber stats.