### PR TITLE
fix(subscriber): count dual-stack sessions by address presence

### DIFF
--- a/internal/subscriber/component.go
+++ b/internal/subscriber/component.go
@@ -240,13 +240,16 @@ func (c *Component) GetStats(ctx context.Context) (map[string]uint32, error) {
 			stats["total"]++
 
 			accessType, _ := sessionData["AccessType"].(string)
-			protocol, _ := sessionData["Protocol"].(string)
 			state, _ := sessionData["State"].(string)
 
 			if accessType == "ipoe" {
-				if protocol == "dhcpv4" {
+				v4Addr, _ := sessionData["IPv4Address"].(string)
+				v6Addr, _ := sessionData["IPv6Address"].(string)
+				v6Prefix, _ := sessionData["IPv6Prefix"].(string)
+				if v4Addr != "" {
 					stats["ipoe_v4"]++
-				} else if protocol == "dhcpv6" {
+				}
+				if v6Addr != "" || v6Prefix != "" {
 					stats["ipoe_v6"]++
 				}
 			} else if accessType == "pppoe" {

--- a/pkg/cache/memory/memory.go
+++ b/pkg/cache/memory/memory.go
@@ -99,21 +99,9 @@ func (c *Cache) Scan(ctx context.Context, cursor uint64, pattern string, count i
 	defer c.mu.RUnlock()
 
 	keys := make([]string, 0)
-	matched := 0
-	skipped := 0
-
 	for key := range c.items {
-		if uint64(skipped) < cursor {
-			skipped++
-			continue
-		}
-
 		if matchPattern(pattern, key) {
 			keys = append(keys, key)
-			matched++
-			if int64(matched) >= count {
-				return keys, cursor + uint64(matched), nil
-			}
 		}
 	}
 


### PR DESCRIPTION
We previously counted by protocol but this doesn't work in unified dual-stack mode (where v4 and v6 combine into a single subscriber session, the protocol determines the initial subscriber setup.