### PR TITLE
fix(dataplane): default QinQ outer TPID to 802.1ad

### DIFF
--- a/internal/dataplane/component.go
+++ b/internal/dataplane/component.go
@@ -256,6 +256,7 @@ func (c *Component) handleEgress(event models.Event) error {
 		SrcMAC:    srcMAC,
 		OuterVLAN: payload.OuterVLAN,
 		InnerVLAN: payload.InnerVLAN,
+		OuterTPID: payload.OuterTPID,
 		EtherType: etherType,
 		Payload:   payload.RawData,
 	}

--- a/internal/pppoe/session.go
+++ b/internal/pppoe/session.go
@@ -723,6 +723,7 @@ func (s *SessionState) sendPPPPacket(proto uint16, code, id uint8, data []byte) 
 		SrcMAC:    srcMAC,
 		OuterVLAN: s.OuterVLAN,
 		InnerVLAN: s.InnerVLAN,
+		OuterTPID: s.component.getSessionOuterTPID(s),
 		SwIfIndex: parentSwIfIndex,
 		RawData:   buf.Bytes(),
 	}

--- a/pkg/config/subscriber/group.go
+++ b/pkg/config/subscriber/group.go
@@ -39,11 +39,19 @@ type SubscriberGroup struct {
 	IANAPool     string           `json:"iana-pool,omitempty" yaml:"iana-pool,omitempty"`
 	PDPool       string           `json:"pd-pool,omitempty" yaml:"pd-pool,omitempty"`
 	SessionMode  SessionMode      `json:"session-mode,omitempty" yaml:"session-mode,omitempty"`
+	VLANProtocol string           `json:"vlan-protocol,omitempty" yaml:"vlan-protocol,omitempty"`
 	DHCP         *SubscriberDHCP  `json:"dhcp,omitempty" yaml:"dhcp,omitempty"`
 	IPv6         *SubscriberIPv6  `json:"ipv6,omitempty" yaml:"ipv6,omitempty"`
 	BGP          *SubscriberBGP   `json:"bgp,omitempty" yaml:"bgp,omitempty"`
 	VRF          string           `json:"vrf,omitempty" yaml:"vrf,omitempty"`
 	AAAPolicy    string           `json:"aaa-policy,omitempty" yaml:"aaa-policy,omitempty"`
+}
+
+func (sg *SubscriberGroup) GetOuterTPID() uint16 {
+	if sg.VLANProtocol == "802.1q" {
+		return 0x8100
+	}
+	return 0x88A8
 }
 
 // GetSessionMode returns the configured session mode, defaulting to unified

--- a/pkg/dataplane/interface.go
+++ b/pkg/dataplane/interface.go
@@ -24,6 +24,7 @@ type EgressPacket struct {
 	SrcMAC    net.HardwareAddr
 	OuterVLAN uint16
 	InnerVLAN uint16
+	OuterTPID uint16
 	EtherType uint16
 	Payload   []byte
 }

--- a/pkg/dataplane/shm/egress.go
+++ b/pkg/dataplane/shm/egress.go
@@ -101,7 +101,13 @@ func (e *Egress) buildFrame(pkt *dataplane.EgressPacket) []byte {
 	}
 
 	if pkt.OuterVLAN > 0 && pkt.InnerVLAN > 0 {
-		frame = append(frame, 0x81, 0x00)
+		outerTPID := pkt.OuterTPID
+		if outerTPID == 0 {
+			outerTPID = 0x88A8
+		}
+		tpid := make([]byte, 2)
+		binary.BigEndian.PutUint16(tpid, outerTPID)
+		frame = append(frame, tpid...)
 		vlan := make([]byte, 2)
 		binary.BigEndian.PutUint16(vlan, pkt.OuterVLAN)
 		frame = append(frame, vlan...)

--- a/pkg/models/event.go
+++ b/pkg/models/event.go
@@ -57,6 +57,7 @@ type EgressPacketPayload struct {
 	SrcMAC    string `json:"src_mac"`
 	OuterVLAN uint16 `json:"outer_vlan"`
 	InnerVLAN uint16 `json:"inner_vlan"`
+	OuterTPID uint16 `json:"outer_tpid,omitempty"`
 	SwIfIndex uint32 `json:"sw_if_index"`
 }
 


### PR DESCRIPTION
- Allows per subscriber group override incase you're retarded and want to mis-use QinQ configurations and set to 802.1Q