### PR TITLE
feat(svcgroup): added support for service groups

### DIFF
--- a/cmd/osvbngd/main.go
+++ b/cmd/osvbngd/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/veesix-networks/osvbng/pkg/handlers/show"
 	_ "github.com/veesix-networks/osvbng/pkg/handlers/show/all"
 	"github.com/veesix-networks/osvbng/pkg/ifmgr"
+	"github.com/veesix-networks/osvbng/pkg/svcgroup"
 	"github.com/veesix-networks/osvbng/pkg/vrfmgr"
 	"github.com/veesix-networks/osvbng/pkg/logger"
 	"github.com/veesix-networks/osvbng/pkg/northbound"
@@ -138,6 +139,8 @@ func main() {
 	vrfMgr := vrfmgr.New(vpp)
 	vppDataplane.SetVRFResolver(vrfMgr.ResolveVRF)
 
+	svcGroupResolver := svcgroup.New()
+
 	cppmManager := cppm.NewManager(cppm.DefaultConfig())
 
 	if err := configd.LoadVersions(); err != nil {
@@ -152,6 +155,7 @@ func main() {
 		CPPM:             cppmManager,
 		Routing:          nil,
 		VRFManager:       vrfMgr,
+		SvcGroupResolver: svcGroupResolver,
 		PluginComponents: nil,
 	})
 
@@ -185,6 +189,7 @@ func main() {
 		AAA:              nil,
 		Routing:          nil,
 		VRFManager:       vrfMgr,
+		SvcGroupResolver: svcGroupResolver,
 		PluginComponents: nil,
 	})
 
@@ -205,13 +210,14 @@ func main() {
 	mainLog.Info("OpDB initialized", "path", "/var/lib/osvbng/opdb.db")
 
 	coreDeps := component.Dependencies{
-		EventBus:      eventBus,
-		Cache:         cache,
-		VPP:           vpp,
-		VRFManager:    vrfMgr,
-		ConfigManager: configd,
-		OpDB:          opdbStore,
-		CPPM:          cppmManager,
+		EventBus:         eventBus,
+		Cache:            cache,
+		VPP:              vpp,
+		VRFManager:       vrfMgr,
+		SvcGroupResolver: svcGroupResolver,
+		ConfigManager:    configd,
+		OpDB:             opdbStore,
+		CPPM:             cppmManager,
 	}
 
 	dataplaneComp, err := dataplane.New(coreDeps)
@@ -376,6 +382,7 @@ func main() {
 		AAA:              aaaComp.(*aaa.Component),
 		Routing:          routingComp.(*routing.Component),
 		VRFManager:       vrfMgr,
+		SvcGroupResolver: svcGroupResolver,
 		CPPM:             cppmManager,
 		PluginComponents: pluginComponentsMap,
 	})
@@ -385,6 +392,7 @@ func main() {
 		Southbound:       coreDeps.VPP,
 		Routing:          routingComp.(*routing.Component),
 		VRFManager:       vrfMgr,
+		SvcGroupResolver: svcGroupResolver,
 		Cache:            cache,
 		OpDB:             opdbStore,
 		CPPM:             cppmManager,

--- a/internal/pppoe/component.go
+++ b/internal/pppoe/component.go
@@ -25,6 +25,7 @@ import (
 	"github.com/veesix-networks/osvbng/pkg/session"
 	"github.com/veesix-networks/osvbng/pkg/southbound"
 	"github.com/veesix-networks/osvbng/pkg/srg"
+	"github.com/veesix-networks/osvbng/pkg/svcgroup"
 	"github.com/veesix-networks/osvbng/pkg/vrfmgr"
 )
 
@@ -44,7 +45,8 @@ type Component struct {
 	ifMgr    *ifmgr.Manager
 	cfgMgr   component.ConfigManager
 	vpp      *southbound.VPP
-	vrfMgr   *vrfmgr.Manager
+	vrfMgr           *vrfmgr.Manager
+	svcGroupResolver *svcgroup.Resolver
 	cache    cache.Cache
 	opdb     opdb.Store
 
@@ -115,6 +117,7 @@ type SessionState struct {
 
 	OuterTPID uint16
 	VRF       string
+	ServiceGroup svcgroup.ServiceGroup
 
 	component *Component
 	mu        sync.Mutex
@@ -136,7 +139,8 @@ func New(deps component.Dependencies, srgMgr *srg.Manager, ifMgr *ifmgr.Manager)
 		ifMgr:         ifMgr,
 		cfgMgr:        deps.ConfigManager,
 		vpp:           deps.VPP,
-		vrfMgr:        deps.VRFManager,
+		vrfMgr:           deps.VRFManager,
+		svcGroupResolver: deps.SvcGroupResolver,
 		cache:         deps.Cache,
 		opdb:          deps.OpDB,
 		acName:        defaultACName,

--- a/pkg/component/dependencies.go
+++ b/pkg/component/dependencies.go
@@ -8,6 +8,7 @@ import (
 	"github.com/veesix-networks/osvbng/pkg/events"
 	"github.com/veesix-networks/osvbng/pkg/opdb"
 	"github.com/veesix-networks/osvbng/pkg/southbound"
+	"github.com/veesix-networks/osvbng/pkg/svcgroup"
 	"github.com/veesix-networks/osvbng/pkg/vrfmgr"
 )
 
@@ -20,7 +21,8 @@ type Dependencies struct {
 	EventBus      events.Bus
 	Cache         cache.Cache
 	VPP           *southbound.VPP
-	VRFManager    *vrfmgr.Manager
+	VRFManager       *vrfmgr.Manager
+	SvcGroupResolver *svcgroup.Resolver
 	ConfigManager ConfigManager
 	OpDB          opdb.Store
 	CPPM          *cppm.Manager

--- a/pkg/config/servicegroup/servicegroup.go
+++ b/pkg/config/servicegroup/servicegroup.go
@@ -1,0 +1,21 @@
+package servicegroup
+
+type Config struct {
+	VRF        string     `json:"vrf,omitempty" yaml:"vrf,omitempty"`
+	Unnumbered string     `json:"unnumbered,omitempty" yaml:"unnumbered,omitempty"`
+	URPF       string     `json:"urpf,omitempty" yaml:"urpf,omitempty"`
+	ACL        *ACLConfig `json:"acl,omitempty" yaml:"acl,omitempty"`
+	QoS        *QoSConfig `json:"qos,omitempty" yaml:"qos,omitempty"`
+}
+
+type ACLConfig struct {
+	Ingress string `json:"ingress,omitempty" yaml:"ingress,omitempty"`
+	Egress  string `json:"egress,omitempty" yaml:"egress,omitempty"`
+}
+
+type QoSConfig struct {
+	IngressPolicy string `json:"ingress-policy,omitempty" yaml:"ingress-policy,omitempty"`
+	EgressPolicy  string `json:"egress-policy,omitempty" yaml:"egress-policy,omitempty"`
+	UploadRate    uint64 `json:"upload-rate,omitempty" yaml:"upload-rate,omitempty"`
+	DownloadRate  uint64 `json:"download-rate,omitempty" yaml:"download-rate,omitempty"`
+}

--- a/pkg/config/subscriber/group.go
+++ b/pkg/config/subscriber/group.go
@@ -43,7 +43,8 @@ type SubscriberGroup struct {
 	DHCP         *SubscriberDHCP  `json:"dhcp,omitempty" yaml:"dhcp,omitempty"`
 	IPv6         *SubscriberIPv6  `json:"ipv6,omitempty" yaml:"ipv6,omitempty"`
 	BGP          *SubscriberBGP   `json:"bgp,omitempty" yaml:"bgp,omitempty"`
-	VRF          string           `json:"vrf,omitempty" yaml:"vrf,omitempty"`
+	VRF                 string           `json:"vrf,omitempty" yaml:"vrf,omitempty"`
+	DefaultServiceGroup string           `json:"default-service-group,omitempty" yaml:"default-service-group,omitempty"`
 	AAAPolicy    string           `json:"aaa-policy,omitempty" yaml:"aaa-policy,omitempty"`
 }
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -7,6 +7,7 @@ import (
 	"github.com/veesix-networks/osvbng/pkg/config/interfaces"
 	"github.com/veesix-networks/osvbng/pkg/config/ip"
 	"github.com/veesix-networks/osvbng/pkg/config/protocols"
+	"github.com/veesix-networks/osvbng/pkg/config/servicegroup"
 	"github.com/veesix-networks/osvbng/pkg/config/subscriber"
 	"github.com/veesix-networks/osvbng/pkg/config/system"
 )
@@ -22,6 +23,7 @@ type Config struct {
 	Interfaces       map[string]*interfaces.InterfaceConfig `json:"interfaces,omitempty" yaml:"interfaces,omitempty"`
 	Protocols        protocols.ProtocolConfig               `json:"protocols,omitempty" yaml:"protocols,omitempty"`
 	AAA              aaa.AAAConfig                          `json:"aaa,omitempty" yaml:"aaa,omitempty"`
+	ServiceGroups    map[string]*servicegroup.Config           `json:"service-groups,omitempty" yaml:"service-groups,omitempty"`
 	VRFS             map[string]*ip.VRFSConfig               `json:"vrfs,omitempty" yaml:"vrfs,omitempty"`
 	System           *SystemConfig                          `json:"system,omitempty" yaml:"system,omitempty"`
 	Plugins          map[string]interface{}                 `json:"plugins,omitempty" yaml:"plugins,omitempty"`

--- a/pkg/configmgr/conf.go
+++ b/pkg/configmgr/conf.go
@@ -660,6 +660,16 @@ func (cd *ConfigManager) LoadConfig(id conf.SessionID, config *config.Config) er
 		sess.changes = append(sess.changes, hctx)
 	}
 
+	for name, sgCfg := range config.ServiceGroups {
+		hctx := &conf.HandlerContext{
+			SessionID: id,
+			Path:      fmt.Sprintf("service-groups.%s", name),
+			OldValue:  nil,
+			NewValue:  sgCfg,
+		}
+		sess.changes = append(sess.changes, hctx)
+	}
+
 	for name, iface := range config.Interfaces {
 		hctx := &conf.HandlerContext{
 			SessionID: id,

--- a/pkg/deps/deps.go
+++ b/pkg/deps/deps.go
@@ -10,6 +10,7 @@ import (
 	"github.com/veesix-networks/osvbng/pkg/opdb"
 	"github.com/veesix-networks/osvbng/pkg/operations"
 	"github.com/veesix-networks/osvbng/pkg/southbound"
+	"github.com/veesix-networks/osvbng/pkg/svcgroup"
 	"github.com/veesix-networks/osvbng/pkg/vrfmgr"
 )
 
@@ -18,6 +19,7 @@ type ShowDeps struct {
 	Southbound       *southbound.VPP
 	Routing          *routingcomp.Component
 	VRFManager       *vrfmgr.Manager
+	SvcGroupResolver *svcgroup.Resolver
 	Cache            cache.Cache
 	OpDB             opdb.Store
 	CPPM             *cppm.Manager
@@ -36,6 +38,7 @@ type ConfDeps struct {
 	AAA              *aaacomp.Component
 	Routing          *routingcomp.Component
 	VRFManager       *vrfmgr.Manager
+	SvcGroupResolver *svcgroup.Resolver
 	CPPM             *cppm.Manager
 	PluginComponents map[string]component.Component
 }

--- a/pkg/handlers/conf/all/all.go
+++ b/pkg/handlers/conf/all/all.go
@@ -10,5 +10,6 @@ import (
 	_ "github.com/veesix-networks/osvbng/pkg/handlers/conf/protocols/ospf6"
 	_ "github.com/veesix-networks/osvbng/pkg/handlers/conf/protocols/static"
 	_ "github.com/veesix-networks/osvbng/pkg/handlers/conf/system"
+	_ "github.com/veesix-networks/osvbng/pkg/handlers/conf/servicegroups"
 	_ "github.com/veesix-networks/osvbng/pkg/handlers/conf/vrfs"
 )

--- a/pkg/handlers/conf/paths/paths.go
+++ b/pkg/handlers/conf/paths/paths.go
@@ -7,6 +7,7 @@ import (
 type Path string
 
 const (
+	ServiceGroups               Path = "service-groups.<*>"
 	VRFS                        Path = "vrfs.<*>"
 	VRFSName                    Path = "vrfs.<*>.name"
 	VRFSDescription             Path = "vrfs.<*>.description"

--- a/pkg/handlers/conf/servicegroups/servicegroups.go
+++ b/pkg/handlers/conf/servicegroups/servicegroups.go
@@ -1,0 +1,101 @@
+package servicegroups
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/veesix-networks/osvbng/pkg/config/servicegroup"
+	"github.com/veesix-networks/osvbng/pkg/deps"
+	"github.com/veesix-networks/osvbng/pkg/handlers/conf"
+	"github.com/veesix-networks/osvbng/pkg/handlers/conf/paths"
+	"github.com/veesix-networks/osvbng/pkg/svcgroup"
+)
+
+func init() {
+	conf.RegisterFactory(NewServiceGroupHandler)
+}
+
+type ServiceGroupHandler struct {
+	resolver *svcgroup.Resolver
+}
+
+func NewServiceGroupHandler(d *deps.ConfDeps) conf.Handler {
+	return &ServiceGroupHandler{resolver: d.SvcGroupResolver}
+}
+
+func (h *ServiceGroupHandler) extractName(path string) (string, error) {
+	values, err := paths.ServiceGroups.ExtractWildcards(path, 1)
+	if err != nil {
+		return "", fmt.Errorf("extract service group name from path: %w", err)
+	}
+	return values[0], nil
+}
+
+func (h *ServiceGroupHandler) Validate(ctx context.Context, hctx *conf.HandlerContext) error {
+	_, err := h.extractName(hctx.Path)
+	if err != nil {
+		return err
+	}
+
+	if hctx.NewValue == nil {
+		return nil
+	}
+
+	if _, ok := hctx.NewValue.(*servicegroup.Config); !ok {
+		return fmt.Errorf("expected *servicegroup.Config, got %T", hctx.NewValue)
+	}
+
+	return nil
+}
+
+func (h *ServiceGroupHandler) Apply(ctx context.Context, hctx *conf.HandlerContext) error {
+	name, err := h.extractName(hctx.Path)
+	if err != nil {
+		return err
+	}
+
+	if hctx.NewValue == nil {
+		h.resolver.Delete(name)
+		return nil
+	}
+
+	cfg, ok := hctx.NewValue.(*servicegroup.Config)
+	if !ok {
+		return fmt.Errorf("expected *servicegroup.Config, got %T", hctx.NewValue)
+	}
+
+	h.resolver.Set(name, cfg)
+	return nil
+}
+
+func (h *ServiceGroupHandler) Rollback(ctx context.Context, hctx *conf.HandlerContext) error {
+	name, err := h.extractName(hctx.Path)
+	if err != nil {
+		return err
+	}
+
+	if hctx.OldValue == nil {
+		h.resolver.Delete(name)
+		return nil
+	}
+
+	cfg, ok := hctx.OldValue.(*servicegroup.Config)
+	if !ok {
+		return nil
+	}
+
+	h.resolver.Set(name, cfg)
+	return nil
+}
+
+func (h *ServiceGroupHandler) PathPattern() paths.Path {
+	return paths.ServiceGroups
+}
+
+func (h *ServiceGroupHandler) Dependencies() []paths.Path {
+	return nil
+}
+
+func (h *ServiceGroupHandler) Callbacks() *conf.Callbacks {
+	return nil
+}

--- a/pkg/handlers/show/all/all.go
+++ b/pkg/handlers/show/all/all.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/veesix-networks/osvbng/pkg/handlers/show/protocols/isis"
 	_ "github.com/veesix-networks/osvbng/pkg/handlers/show/protocols/ospf"
 	_ "github.com/veesix-networks/osvbng/pkg/handlers/show/protocols/ospf6"
+	_ "github.com/veesix-networks/osvbng/pkg/handlers/show/servicegroups"
 	_ "github.com/veesix-networks/osvbng/pkg/handlers/show/subscriber"
 	_ "github.com/veesix-networks/osvbng/pkg/handlers/show/system"
 	_ "github.com/veesix-networks/osvbng/pkg/handlers/show/system/dataplane"

--- a/pkg/handlers/show/paths/paths.go
+++ b/pkg/handlers/show/paths/paths.go
@@ -32,7 +32,8 @@ const (
 	ProtocolsOSPF6Neighbors Path = "protocols.ospf6.neighbors"
 	ProtocolsISISNeighbors  Path = "protocols.isis.neighbors"
 
-	VRFS Path = "vrfs"
+	ServiceGroups Path = "service-groups"
+	VRFS          Path = "vrfs"
 
 	SystemCPPMDataplane    Path = "system.cppm.dataplane"
 	SystemCPPMControlplane Path = "system.cppm.controlplane"

--- a/pkg/handlers/show/servicegroups/servicegroups.go
+++ b/pkg/handlers/show/servicegroups/servicegroups.go
@@ -1,0 +1,32 @@
+package servicegroups
+
+import (
+	"context"
+
+	"github.com/veesix-networks/osvbng/pkg/deps"
+	"github.com/veesix-networks/osvbng/pkg/handlers/show"
+	"github.com/veesix-networks/osvbng/pkg/handlers/show/paths"
+	"github.com/veesix-networks/osvbng/pkg/svcgroup"
+)
+
+func init() {
+	show.RegisterFactory(func(d *deps.ShowDeps) show.ShowHandler {
+		return &ServiceGroupsHandler{resolver: d.SvcGroupResolver}
+	})
+}
+
+type ServiceGroupsHandler struct {
+	resolver *svcgroup.Resolver
+}
+
+func (h *ServiceGroupsHandler) Collect(ctx context.Context, req *show.Request) (interface{}, error) {
+	return h.resolver.GetAll(), nil
+}
+
+func (h *ServiceGroupsHandler) PathPattern() paths.Path {
+	return paths.ServiceGroups
+}
+
+func (h *ServiceGroupsHandler) Dependencies() []paths.Path {
+	return nil
+}

--- a/pkg/logger/names.go
+++ b/pkg/logger/names.go
@@ -18,6 +18,7 @@ const (
 	Config     = "confmgr"
 	Gateway    = "gateway"
 	Northbound = "nb"
+	SvcGroup   = "svcgroup"
 
 	IPoEDHCP4   = "dhcp4"
 	IPoEDHCP6   = "dhcp6"

--- a/pkg/models/session.go
+++ b/pkg/models/session.go
@@ -39,6 +39,7 @@ type IPoESession struct {
 	InterfaceName string
 	IfIndex       uint32
 	VRF           string
+	ServiceGroup  string
 
 	IPv4Address net.IP
 	LeaseTime   uint32
@@ -152,6 +153,7 @@ type PPPSession struct {
 	InterfaceName string
 	IfIndex       uint32
 	VRF           string
+	ServiceGroup  string
 
 	IPv4Address net.IP
 	IPv6Address net.IP

--- a/pkg/svcgroup/resolver.go
+++ b/pkg/svcgroup/resolver.go
@@ -1,0 +1,241 @@
+package svcgroup
+
+import (
+	"fmt"
+	"log/slog"
+	"strconv"
+	"sync"
+
+	"github.com/veesix-networks/osvbng/pkg/config/servicegroup"
+	"github.com/veesix-networks/osvbng/pkg/logger"
+)
+
+type ServiceGroup struct {
+	Name         string
+	VRF          string
+	Unnumbered   string
+	URPF         string
+	ACLIngress   string
+	ACLEgress    string
+	QoSIngress   string
+	QoSEgress    string
+	UploadRate   uint64
+	DownloadRate uint64
+}
+
+func (r ServiceGroup) LogAttrs() []slog.Attr {
+	var attrs []slog.Attr
+	if r.Name != "" {
+		attrs = append(attrs, slog.String("service_group", r.Name))
+	}
+	if r.VRF != "" {
+		attrs = append(attrs, slog.String("vrf", r.VRF))
+	}
+	if r.Unnumbered != "" {
+		attrs = append(attrs, slog.String("unnumbered", r.Unnumbered))
+	}
+	if r.URPF != "" {
+		attrs = append(attrs, slog.String("urpf", r.URPF))
+	}
+	if r.ACLIngress != "" {
+		attrs = append(attrs, slog.String("acl_ingress", r.ACLIngress))
+	}
+	if r.ACLEgress != "" {
+		attrs = append(attrs, slog.String("acl_egress", r.ACLEgress))
+	}
+	if r.QoSIngress != "" {
+		attrs = append(attrs, slog.String("qos_ingress", r.QoSIngress))
+	}
+	if r.QoSEgress != "" {
+		attrs = append(attrs, slog.String("qos_egress", r.QoSEgress))
+	}
+	if r.UploadRate != 0 {
+		attrs = append(attrs, slog.Uint64("upload_rate", r.UploadRate))
+	}
+	if r.DownloadRate != 0 {
+		attrs = append(attrs, slog.Uint64("download_rate", r.DownloadRate))
+	}
+	return attrs
+}
+
+type Resolver struct {
+	mu     sync.RWMutex
+	groups map[string]*servicegroup.Config
+	logger *slog.Logger
+}
+
+func New() *Resolver {
+	return &Resolver{
+		groups: make(map[string]*servicegroup.Config),
+		logger: logger.Get(logger.SvcGroup),
+	}
+}
+
+func (r *Resolver) Set(name string, cfg *servicegroup.Config) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.groups[name] = cfg
+	r.logger.Info("Set service group", "name", name, "vrf", cfg.VRF)
+}
+
+func (r *Resolver) Delete(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	delete(r.groups, name)
+	r.logger.Info("Deleted service group", "name", name)
+}
+
+func (r *Resolver) Get(name string) *servicegroup.Config {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return r.groups[name]
+}
+
+func (r *Resolver) GetAll() map[string]*servicegroup.Config {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make(map[string]*servicegroup.Config, len(r.groups))
+	for k, v := range r.groups {
+		result[k] = v
+	}
+	return result
+}
+
+// Resolve performs three-layer merge:
+// 1. Start with default service group config (if defaultSG set)
+// 2. Override with AAA service group config (if sgName set)
+// 3. Override with per-field AAA attributes
+func (r *Resolver) Resolve(sgName, defaultSG string, aaaAttrs map[string]interface{}) ServiceGroup {
+	var result ServiceGroup
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if defaultSG != "" {
+		if cfg, ok := r.groups[defaultSG]; ok {
+			result.Name = defaultSG
+			applyConfig(&result, cfg)
+		} else {
+			r.logger.Warn("Default service group not found", "name", defaultSG)
+		}
+	}
+
+	if sgName != "" {
+		if cfg, ok := r.groups[sgName]; ok {
+			result.Name = sgName
+			applyConfig(&result, cfg)
+		} else {
+			r.logger.Warn("Service group not found", "name", sgName)
+		}
+	}
+
+	applyAAAOverrides(&result, aaaAttrs)
+
+	return result
+}
+
+func applyConfig(r *ServiceGroup, cfg *servicegroup.Config) {
+	if cfg.VRF != "" {
+		r.VRF = cfg.VRF
+	}
+	if cfg.Unnumbered != "" {
+		r.Unnumbered = cfg.Unnumbered
+	}
+	if cfg.URPF != "" {
+		r.URPF = cfg.URPF
+	}
+	if cfg.ACL != nil {
+		if cfg.ACL.Ingress != "" {
+			r.ACLIngress = cfg.ACL.Ingress
+		}
+		if cfg.ACL.Egress != "" {
+			r.ACLEgress = cfg.ACL.Egress
+		}
+	}
+	if cfg.QoS != nil {
+		if cfg.QoS.IngressPolicy != "" {
+			r.QoSIngress = cfg.QoS.IngressPolicy
+		}
+		if cfg.QoS.EgressPolicy != "" {
+			r.QoSEgress = cfg.QoS.EgressPolicy
+		}
+		if cfg.QoS.UploadRate != 0 {
+			r.UploadRate = cfg.QoS.UploadRate
+		}
+		if cfg.QoS.DownloadRate != 0 {
+			r.DownloadRate = cfg.QoS.DownloadRate
+		}
+	}
+}
+
+func applyAAAOverrides(r *ServiceGroup, attrs map[string]interface{}) {
+	if attrs == nil {
+		return
+	}
+	if v := getStringAttr(attrs, "vrf"); v != "" {
+		r.VRF = v
+	}
+	if v := getStringAttr(attrs, "unnumbered"); v != "" {
+		r.Unnumbered = v
+	}
+	if v := getStringAttr(attrs, "urpf"); v != "" {
+		r.URPF = v
+	}
+	if v := getStringAttr(attrs, "acl.ingress"); v != "" {
+		r.ACLIngress = v
+	}
+	if v := getStringAttr(attrs, "acl.egress"); v != "" {
+		r.ACLEgress = v
+	}
+	if v := getStringAttr(attrs, "qos.ingress-policy"); v != "" {
+		r.QoSIngress = v
+	}
+	if v := getStringAttr(attrs, "qos.egress-policy"); v != "" {
+		r.QoSEgress = v
+	}
+	if v := getUint64Attr(attrs, "qos.upload-rate"); v != 0 {
+		r.UploadRate = v
+	}
+	if v := getUint64Attr(attrs, "qos.download-rate"); v != 0 {
+		r.DownloadRate = v
+	}
+}
+
+func getStringAttr(attrs map[string]interface{}, key string) string {
+	v, ok := attrs[key]
+	if !ok {
+		return ""
+	}
+	s, ok := v.(string)
+	if !ok {
+		return fmt.Sprintf("%v", v)
+	}
+	return s
+}
+
+func getUint64Attr(attrs map[string]interface{}, key string) uint64 {
+	v, ok := attrs[key]
+	if !ok {
+		return 0
+	}
+	switch val := v.(type) {
+	case uint64:
+		return val
+	case float64:
+		return uint64(val)
+	case int:
+		return uint64(val)
+	case string:
+		n, err := strconv.ParseUint(val, 10, 64)
+		if err != nil {
+			return 0
+		}
+		return n
+	default:
+		return 0
+	}
+}

--- a/pkg/svcgroup/resolver_test.go
+++ b/pkg/svcgroup/resolver_test.go
@@ -1,0 +1,159 @@
+package svcgroup
+
+import (
+	"testing"
+
+	"github.com/veesix-networks/osvbng/pkg/config/servicegroup"
+)
+
+func TestSetDelete(t *testing.T) {
+	r := New()
+
+	cfg := &servicegroup.Config{VRF: "cgnat", Unnumbered: "loop101"}
+	r.Set("residential", cfg)
+
+	got := r.Get("residential")
+	if got == nil {
+		t.Fatal("expected config, got nil")
+	}
+	if got.VRF != "cgnat" {
+		t.Errorf("expected VRF cgnat, got %s", got.VRF)
+	}
+
+	r.Delete("residential")
+	if r.Get("residential") != nil {
+		t.Error("expected nil after delete")
+	}
+}
+
+func TestGetAll(t *testing.T) {
+	r := New()
+	r.Set("a", &servicegroup.Config{VRF: "v1"})
+	r.Set("b", &servicegroup.Config{VRF: "v2"})
+
+	all := r.GetAll()
+	if len(all) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(all))
+	}
+}
+
+func TestResolveDefaultOnly(t *testing.T) {
+	r := New()
+	r.Set("default-sg", &servicegroup.Config{
+		VRF:        "cgnat",
+		Unnumbered: "loop101",
+		URPF:       "strict",
+	})
+
+	result := r.Resolve("", "default-sg", nil)
+	if result.VRF != "cgnat" {
+		t.Errorf("expected VRF cgnat, got %s", result.VRF)
+	}
+	if result.Unnumbered != "loop101" {
+		t.Errorf("expected Unnumbered loop101, got %s", result.Unnumbered)
+	}
+	if result.Name != "default-sg" {
+		t.Errorf("expected ServiceGroup default-sg, got %s", result.Name)
+	}
+}
+
+func TestResolveAAAServiceGroupOverridesDefault(t *testing.T) {
+	r := New()
+	r.Set("default-sg", &servicegroup.Config{
+		VRF:        "default-vrf",
+		Unnumbered: "loop100",
+	})
+	r.Set("premium", &servicegroup.Config{
+		VRF:        "premium-vrf",
+		Unnumbered: "loop200",
+		URPF:       "strict",
+	})
+
+	result := r.Resolve("premium", "default-sg", nil)
+	if result.VRF != "premium-vrf" {
+		t.Errorf("expected VRF premium-vrf, got %s", result.VRF)
+	}
+	if result.Unnumbered != "loop200" {
+		t.Errorf("expected Unnumbered loop200, got %s", result.Unnumbered)
+	}
+	if result.URPF != "strict" {
+		t.Errorf("expected URPF strict, got %s", result.URPF)
+	}
+	if result.Name != "premium" {
+		t.Errorf("expected ServiceGroup premium, got %s", result.Name)
+	}
+}
+
+func TestResolvePerFieldAAAOverrides(t *testing.T) {
+	r := New()
+	r.Set("residential", &servicegroup.Config{
+		VRF:        "cgnat",
+		Unnumbered: "loop101",
+		QoS: &servicegroup.QoSConfig{
+			UploadRate:   1000000000,
+			DownloadRate: 1000000000,
+		},
+	})
+
+	attrs := map[string]interface{}{
+		"vrf":               "enterprise",
+		"qos.download-rate": "10000000000",
+	}
+
+	result := r.Resolve("residential", "", attrs)
+	if result.VRF != "enterprise" {
+		t.Errorf("expected VRF enterprise, got %s", result.VRF)
+	}
+	if result.Unnumbered != "loop101" {
+		t.Errorf("expected Unnumbered loop101 (from service group), got %s", result.Unnumbered)
+	}
+	if result.UploadRate != 1000000000 {
+		t.Errorf("expected UploadRate 1000000000, got %d", result.UploadRate)
+	}
+	if result.DownloadRate != 10000000000 {
+		t.Errorf("expected DownloadRate 10000000000, got %d", result.DownloadRate)
+	}
+}
+
+func TestResolveUnknownServiceGroup(t *testing.T) {
+	r := New()
+
+	result := r.Resolve("nonexistent", "", nil)
+	if result.VRF != "" {
+		t.Errorf("expected empty VRF, got %s", result.VRF)
+	}
+	if result.Name != "" {
+		t.Errorf("expected empty ServiceGroup, got %s", result.Name)
+	}
+}
+
+func TestResolveEmptyNames(t *testing.T) {
+	r := New()
+
+	result := r.Resolve("", "", nil)
+	if result != (ServiceGroup{}) {
+		t.Errorf("expected zero-value ServiceGroup, got %+v", result)
+	}
+}
+
+func TestResolveACLOverrides(t *testing.T) {
+	r := New()
+	r.Set("sg1", &servicegroup.Config{
+		ACL: &servicegroup.ACLConfig{
+			Ingress: "default-in",
+			Egress:  "default-out",
+		},
+	})
+
+	attrs := map[string]interface{}{
+		"acl.ingress": "custom-in",
+	}
+
+	result := r.Resolve("sg1", "", attrs)
+	if result.ACLIngress != "custom-in" {
+		t.Errorf("expected ACLIngress custom-in, got %s", result.ACLIngress)
+	}
+	if result.ACLEgress != "default-out" {
+		t.Errorf("expected ACLEgress default-out, got %s", result.ACLEgress)
+	}
+}


### PR DESCRIPTION
Service groups are templates that you can attach to a subscriber group or return via user attributes to drive basic templating per subscriber config like

- VRF
- ACLs
- QoS
- Unnumbered interface attachment
- and more...