### PR TITLE
fix(arp): use per-interface IP dump and ifmgr cache

### DIFF
--- a/cmd/osvbngd/main.go
+++ b/cmd/osvbngd/main.go
@@ -178,6 +178,10 @@ func main() {
 		mainLog.Warn("Failed to load interfaces from dataplane", "error", err)
 	}
 
+	if err := vpp.LoadIPState(); err != nil {
+		mainLog.Warn("Failed to load IP state from dataplane", "error", err)
+	}
+
 	mainLog.Info("Loading dataplane state")
 	if err := configd.LoadFromDataplane(vpp); err != nil {
 		log.Fatalf("Failed to load dataplane state: %v", err)

--- a/pkg/ifmgr/manager.go
+++ b/pkg/ifmgr/manager.go
@@ -190,6 +190,25 @@ func (m *Manager) SetFIBTableID(swIfIndex uint32, tableID uint32) {
 	}
 }
 
+func (m *Manager) HasIPv4(ip net.IP) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	v4 := ip.To4()
+	if v4 == nil {
+		return false
+	}
+
+	for _, iface := range m.bySwIfIndex {
+		for _, addr := range iface.IPv4Addresses {
+			if addr.Equal(v4) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (m *Manager) HasIPv4InFIB(ip net.IP, tableID uint32) bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()


### PR DESCRIPTION
- Per subscriber VRF ARP resolution is now only responding when the subscriber is within the VRF and an IP exists inside the VRF fib. We should probably perform a kind of "control-plane urpf" lookup to ensure the src IP comes from a relevant IP we're expecting it from 