### PR TITLE
build(docker): add dpdk plugin installation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,6 +45,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     numactl \
     vpp=${DATAPLANE_VERSION} \
     vpp-plugin-core=${DATAPLANE_VERSION} \
+    vpp-plugin-dpdk=${DATAPLANE_VERSION} \
     libvppinfra=${DATAPLANE_VERSION} \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Current Dockerfile does not include the DPDK plugin, PR is to add it so as to add support for using DPDK interfaces in container images.