### PR TITLE
refactor(events): make event bus generic

### DIFF
--- a/cmd/osvbngd/main.go
+++ b/cmd/osvbngd/main.go
@@ -423,11 +423,13 @@ func main() {
 		OpDB:             opdbStore,
 		CPPM:             cppmManager,
 		Watchdog:         wd,
+		EventBus:         eventBus,
 		PluginComponents: pluginComponentsMap,
 	})
 
 	operRegistry.AutoRegisterAll(&deps.OperDeps{
 		Subscriber:       subscriberComp.(*subscriber.Component),
+		EventBus:         eventBus,
 		PluginComponents: pluginComponentsMap,
 	})
 

--- a/pkg/deps/deps.go
+++ b/pkg/deps/deps.go
@@ -8,6 +8,7 @@ import (
 	"github.com/veesix-networks/osvbng/pkg/cache"
 	"github.com/veesix-networks/osvbng/pkg/component"
 	"github.com/veesix-networks/osvbng/pkg/cppm"
+	"github.com/veesix-networks/osvbng/pkg/events"
 	"github.com/veesix-networks/osvbng/pkg/opdb"
 	"github.com/veesix-networks/osvbng/pkg/operations"
 	"github.com/veesix-networks/osvbng/pkg/southbound"
@@ -25,11 +26,13 @@ type ShowDeps struct {
 	OpDB             opdb.Store
 	CPPM             *cppm.Manager
 	Watchdog         watchdog.StateProvider
+	EventBus         events.Bus
 	PluginComponents map[string]component.Component
 }
 
 type OperDeps struct {
 	Subscriber       *subscriber.Component
+	EventBus         events.Bus
 	PluginComponents map[string]component.Component
 }
 

--- a/pkg/events/bus.go
+++ b/pkg/events/bus.go
@@ -1,14 +1,31 @@
 package events
 
-import (
-	"github.com/veesix-networks/osvbng/pkg/models"
-)
+type Handler func(Event)
 
-type EventHandler func(models.Event) error
+type Subscription interface {
+	Unsubscribe()
+}
+
+type TopicStats struct {
+	Topic       string `json:"topic"`
+	Subscribers int    `json:"subscribers"`
+}
+
+type Stats struct {
+	Topics       []TopicStats `json:"topics"`
+	PublishChLen int          `json:"publish-channel-length"`
+	PublishChCap int          `json:"publish-channel-capacity"`
+	Published    uint64       `json:"published"`
+	Dropped      uint64       `json:"dropped"`
+	DebugTopics  []string     `json:"debug-topics,omitempty"`
+}
 
 type Bus interface {
-	Publish(topic string, event models.Event) error
-	Subscribe(topic string, handler EventHandler) error
-	Unsubscribe(topic string, handler EventHandler)
+	Publish(topic string, event Event)
+	Subscribe(topic string, handler Handler) Subscription
+	SubscribeAll(handler Handler) Subscription
+	Stats() Stats
+	SetDebugTopics(topics []string)
+	DebugTopics() []string
 	Close() error
 }

--- a/pkg/events/event.go
+++ b/pkg/events/event.go
@@ -1,0 +1,11 @@
+package events
+
+import "time"
+
+type Event struct {
+	ID        string
+	Type      string
+	Timestamp time.Time
+	Source    string
+	Data      any
+}

--- a/pkg/events/local/bus.go
+++ b/pkg/events/local/bus.go
@@ -2,40 +2,70 @@ package local
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/veesix-networks/osvbng/pkg/events"
 	"github.com/veesix-networks/osvbng/pkg/logger"
-	"github.com/veesix-networks/osvbng/pkg/models"
 )
 
 type publishRequest struct {
 	topic string
-	event models.Event
+	event events.Event
+}
+
+type subscription struct {
+	id      uint64
+	handler events.Handler
+}
+
+type sub struct {
+	bus   *Bus
+	topic string
+	id    uint64
+}
+
+func (s *sub) Unsubscribe() {
+	s.bus.removeSub(s.topic, s.id)
+}
+
+type globalSub struct {
+	bus *Bus
+	id  uint64
+}
+
+func (s *globalSub) Unsubscribe() {
+	s.bus.removeGlobalSub(s.id)
 }
 
 type Bus struct {
-	ctx       context.Context
-	cancel    context.CancelFunc
-	handlers  map[string][]events.EventHandler
-	mu        sync.RWMutex
-	publishCh chan publishRequest
-	logger    *slog.Logger
+	ctx          context.Context
+	cancel       context.CancelFunc
+	subs         map[string]map[uint64]*subscription
+	globalSubs   map[uint64]*subscription
+	mu           sync.RWMutex
+	nextID       atomic.Uint64
+	publishCh    chan publishRequest
+	logger       *slog.Logger
+	published    atomic.Uint64
+	dropped      atomic.Uint64
+	debugTopics  map[string]bool
+	debugSub     events.Subscription
 }
 
 func NewBus() events.Bus {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	b := &Bus{
-		ctx:       ctx,
-		cancel:    cancel,
-		handlers:  make(map[string][]events.EventHandler),
-		publishCh: make(chan publishRequest, 10000),
-		logger:    logger.Get(logger.Events),
+		ctx:        ctx,
+		cancel:     cancel,
+		subs:       make(map[string]map[uint64]*subscription),
+		globalSubs: make(map[uint64]*subscription),
+		publishCh:  make(chan publishRequest, 10000),
+		logger:     logger.Get(logger.Events),
 	}
 
 	go b.publishLoop()
@@ -43,19 +73,23 @@ func NewBus() events.Bus {
 	return b
 }
 
-func (b *Bus) Publish(topic string, event models.Event) error {
+func (b *Bus) Publish(topic string, event events.Event) {
 	if event.ID == "" {
 		event.ID = uuid.New().String()
 	}
 	if event.Timestamp.IsZero() {
 		event.Timestamp = time.Now()
 	}
+	if event.Type == "" {
+		event.Type = topic
+	}
 
 	select {
 	case b.publishCh <- publishRequest{topic: topic, event: event}:
-		return nil
+		b.published.Add(1)
 	default:
-		return fmt.Errorf("publish channel full, dropping event")
+		b.dropped.Add(1)
+		b.logger.Warn("Publish channel full, dropping event", "topic", topic)
 	}
 }
 
@@ -66,42 +100,151 @@ func (b *Bus) publishLoop() {
 			return
 		case req := <-b.publishCh:
 			b.mu.RLock()
-			handlers := b.handlers[req.topic]
+			topicSubs := b.subs[req.topic]
+			handlers := make([]events.Handler, 0, len(topicSubs)+len(b.globalSubs))
+			for _, s := range topicSubs {
+				handlers = append(handlers, s.handler)
+			}
+			for _, s := range b.globalSubs {
+				handlers = append(handlers, s.handler)
+			}
 			b.mu.RUnlock()
 
-			for _, handler := range handlers {
-				go func(h events.EventHandler, e models.Event) {
-					if err := h(e); err != nil {
-						b.logger.Error("Handler error", "topic", req.topic, "error", err)
-					}
-				}(handler, req.event)
+			for _, h := range handlers {
+				go h(req.event)
 			}
 		}
 	}
 }
 
-func (b *Bus) Subscribe(topic string, handler events.EventHandler) error {
+func (b *Bus) Subscribe(topic string, handler events.Handler) events.Subscription {
+	id := b.nextID.Add(1)
+
 	b.mu.Lock()
-	b.handlers[topic] = append(b.handlers[topic], handler)
-	handlerCount := len(b.handlers[topic])
+	if b.subs[topic] == nil {
+		b.subs[topic] = make(map[uint64]*subscription)
+	}
+	b.subs[topic][id] = &subscription{id: id, handler: handler}
+	handlerCount := len(b.subs[topic])
 	b.mu.Unlock()
 
 	b.logger.Info("Subscribed to topic", "topic", topic, "handler_count", handlerCount)
 
-	return nil
+	return &sub{bus: b, topic: topic, id: id}
 }
 
-func (b *Bus) Unsubscribe(topic string, handler events.EventHandler) {
+func (b *Bus) SubscribeAll(handler events.Handler) events.Subscription {
+	id := b.nextID.Add(1)
+
+	b.mu.Lock()
+	b.globalSubs[id] = &subscription{id: id, handler: handler}
+	count := len(b.globalSubs)
+	b.mu.Unlock()
+
+	b.logger.Info("Subscribed to all topics", "global_subscriber_count", count)
+
+	return &globalSub{bus: b, id: id}
+}
+
+func (b *Bus) removeSub(topic string, id uint64) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	handlers := b.handlers[topic]
-	for i, h := range handlers {
-		if &h == &handler {
-			b.handlers[topic] = append(handlers[:i], handlers[i+1:]...)
-			break
+	if topicSubs, ok := b.subs[topic]; ok {
+		delete(topicSubs, id)
+		if len(topicSubs) == 0 {
+			delete(b.subs, topic)
 		}
 	}
+}
+
+func (b *Bus) removeGlobalSub(id uint64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	delete(b.globalSubs, id)
+}
+
+func (b *Bus) Stats() events.Stats {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	topics := make([]events.TopicStats, 0, len(b.subs))
+	for topic, subs := range b.subs {
+		topics = append(topics, events.TopicStats{
+			Topic:       topic,
+			Subscribers: len(subs),
+		})
+	}
+
+	var debugTopics []string
+	for t := range b.debugTopics {
+		debugTopics = append(debugTopics, t)
+	}
+
+	return events.Stats{
+		Topics:       topics,
+		PublishChLen: len(b.publishCh),
+		PublishChCap: cap(b.publishCh),
+		Published:    b.published.Load(),
+		Dropped:      b.dropped.Load(),
+		DebugTopics:  debugTopics,
+	}
+}
+
+func (b *Bus) SetDebugTopics(topics []string) {
+	b.mu.Lock()
+
+	if len(topics) == 0 {
+		b.debugTopics = nil
+		oldSub := b.debugSub
+		b.debugSub = nil
+		b.mu.Unlock()
+		if oldSub != nil {
+			oldSub.Unsubscribe()
+		}
+		b.logger.Info("Event debug logging disabled")
+		return
+	}
+
+	b.debugTopics = make(map[string]bool, len(topics))
+	for _, t := range topics {
+		b.debugTopics[t] = true
+	}
+
+	needSub := b.debugSub == nil
+	b.mu.Unlock()
+
+	if needSub {
+		sub := b.SubscribeAll(func(e events.Event) {
+			b.mu.RLock()
+			match := b.debugTopics[e.Type]
+			b.mu.RUnlock()
+			if match {
+				b.logger.Info("Event", "topic", e.Type, "source", e.Source, "data", e.Data)
+			}
+		})
+		b.mu.Lock()
+		b.debugSub = sub
+		b.mu.Unlock()
+	}
+
+	b.logger.Info("Event debug logging enabled", "topics", topics)
+}
+
+func (b *Bus) DebugTopics() []string {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	if len(b.debugTopics) == 0 {
+		return nil
+	}
+
+	topics := make([]string, 0, len(b.debugTopics))
+	for t := range b.debugTopics {
+		topics = append(topics, t)
+	}
+	return topics
 }
 
 func (b *Bus) Close() error {

--- a/pkg/events/types.go
+++ b/pkg/events/types.go
@@ -1,0 +1,29 @@
+package events
+
+import "github.com/veesix-networks/osvbng/pkg/models"
+
+type SessionLifecycleEvent struct {
+	AccessType models.AccessType
+	Protocol   models.Protocol
+	SessionID  string
+	State      models.SessionState
+	Session    any
+}
+
+type AAARequestEvent struct {
+	AccessType models.AccessType
+	Protocol   models.Protocol
+	SessionID  string
+	Request    models.AAARequest
+}
+
+type AAAResponseEvent struct {
+	AccessType models.AccessType
+	SessionID  string
+	Response   models.AAAResponse
+}
+
+type EgressEvent struct {
+	Protocol models.Protocol
+	Packet   models.EgressPacketPayload
+}

--- a/pkg/handlers/oper/paths/paths.go
+++ b/pkg/handlers/oper/paths/paths.go
@@ -8,6 +8,7 @@ type Path string
 
 const (
 	SystemLoggingLevel     Path = "system.logging.level.<*>"
+	SystemEventsDebug      Path = "system.events.debug"
 	SubscriberSessionClear Path = "subscriber.session.clear"
 )
 

--- a/pkg/handlers/oper/system/events_debug.go
+++ b/pkg/handlers/oper/system/events_debug.go
@@ -1,0 +1,64 @@
+package system
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/veesix-networks/osvbng/pkg/deps"
+	"github.com/veesix-networks/osvbng/pkg/handlers/oper"
+	"github.com/veesix-networks/osvbng/pkg/handlers/oper/paths"
+)
+
+func init() {
+	oper.RegisterFactory(NewEventsDebugHandler)
+}
+
+type EventsDebugHandler struct {
+	deps *deps.OperDeps
+}
+
+type EventsDebugRequest struct {
+	Topics []string `json:"topics"`
+}
+
+type EventsDebugResponse struct {
+	Topics []string `json:"topics"`
+}
+
+func NewEventsDebugHandler(deps *deps.OperDeps) oper.OperHandler {
+	return &EventsDebugHandler{deps: deps}
+}
+
+func (h *EventsDebugHandler) Execute(ctx context.Context, req *oper.Request) (interface{}, error) {
+	if h.deps.EventBus == nil {
+		return nil, fmt.Errorf("event bus not available")
+	}
+
+	var body EventsDebugRequest
+	if err := json.Unmarshal(req.Body, &body); err != nil {
+		return nil, fmt.Errorf("invalid request body: %w", err)
+	}
+
+	h.deps.EventBus.SetDebugTopics(body.Topics)
+
+	return &EventsDebugResponse{
+		Topics: h.deps.EventBus.DebugTopics(),
+	}, nil
+}
+
+func (h *EventsDebugHandler) PathPattern() paths.Path {
+	return paths.SystemEventsDebug
+}
+
+func (h *EventsDebugHandler) Dependencies() []paths.Path {
+	return nil
+}
+
+func (h *EventsDebugHandler) InputType() interface{} {
+	return &EventsDebugRequest{}
+}
+
+func (h *EventsDebugHandler) OutputType() interface{} {
+	return &EventsDebugResponse{}
+}

--- a/pkg/handlers/show/paths/paths.go
+++ b/pkg/handlers/show/paths/paths.go
@@ -56,6 +56,7 @@ const (
 	SystemDataplaneErrors    Path = "system.dataplane.errors"
 	SystemDataplaneBuffers   Path = "system.dataplane.buffers"
 
+	SystemEvents   Path = "system.events"
 	SystemWatchdog Path = "system.watchdog"
 )
 

--- a/pkg/handlers/show/system/events.go
+++ b/pkg/handlers/show/system/events.go
@@ -1,0 +1,41 @@
+package system
+
+import (
+	"context"
+
+	"github.com/veesix-networks/osvbng/pkg/deps"
+	"github.com/veesix-networks/osvbng/pkg/events"
+	"github.com/veesix-networks/osvbng/pkg/handlers/show"
+	"github.com/veesix-networks/osvbng/pkg/handlers/show/paths"
+)
+
+type EventsHandler struct {
+	eventBus events.Bus
+}
+
+func init() {
+	show.RegisterFactory(func(deps *deps.ShowDeps) show.ShowHandler {
+		return &EventsHandler{eventBus: deps.EventBus}
+	})
+}
+
+func (h *EventsHandler) Collect(ctx context.Context, req *show.Request) (interface{}, error) {
+	if h.eventBus == nil {
+		return events.Stats{}, nil
+	}
+	return h.eventBus.Stats(), nil
+}
+
+func (h *EventsHandler) PathPattern() paths.Path {
+	return paths.SystemEvents
+}
+
+func (h *EventsHandler) Dependencies() []paths.Path {
+	return nil
+}
+
+func (h *EventsHandler) OutputType() interface{} {
+	return &events.Stats{}
+}
+
+var _ show.ShowHandler = (*EventsHandler)(nil)

--- a/pkg/models/event.go
+++ b/pkg/models/event.go
@@ -1,37 +1,5 @@
 package models
 
-import (
-	"encoding/json"
-	"time"
-)
-
-type Event struct {
-	ID         string     `json:"event_id"`
-	Type       EventType  `json:"event_type"`
-	Timestamp  time.Time  `json:"timestamp"`
-	AccessType AccessType `json:"access_type"`
-	Protocol   Protocol   `json:"protocol"`
-	SessionID  string     `json:"session_id,omitempty"`
-
-	Payload json.RawMessage `json:"payload,omitempty"`
-}
-
-func (e *Event) GetPayload(v interface{}) error {
-	if len(e.Payload) == 0 {
-		return nil
-	}
-	return json.Unmarshal(e.Payload, v)
-}
-
-func (e *Event) SetPayload(v interface{}) error {
-	data, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-	e.Payload = data
-	return nil
-}
-
 type AAARequest struct {
 	RequestID     string            `json:"request_id"`
 	Username      string            `json:"username"`
@@ -60,16 +28,6 @@ type EgressPacketPayload struct {
 	OuterTPID uint16 `json:"outer_tpid,omitempty"`
 	SwIfIndex uint32 `json:"sw_if_index"`
 }
-
-type EventType string
-
-const (
-	EventTypePacket           EventType = "packet"
-	EventTypeSessionLifecycle EventType = "session_lifecycle"
-	EventTypeAAARequest       EventType = "aaa_request"
-	EventTypeAAAResponse      EventType = "aaa_response"
-	EventTypeEgress           EventType = "egress"
-)
 
 type AccessType string
 


### PR DESCRIPTION
The current event bus is mostly hardcoded to allow session based events, but we want to use this internal event bus between components (very used within the HA architecture to listen for interface state events to tie into the trackers and core bgp advertisements with subscriber groups)