### PR TITLE
fix(dataplane): default VPP heap to 1G and increase egress channel capacity for DPDK scale

### DIFF
--- a/pkg/config/dataplane_conf.go
+++ b/pkg/config/dataplane_conf.go
@@ -57,12 +57,12 @@ func NewDataplaneTemplateData(cfg *Config, cpu *ResolvedCPU) (*DataplaneTemplate
 	memory := cfg.Dataplane.Memory
 	if memory == nil {
 		memory = &system.MemoryConfig{
-			MainHeapSize:     "512M",
+			MainHeapSize:     "1G",
 			MainHeapPageSize: "4k",
 		}
 	}
 	if memory.MainHeapSize == "" {
-		memory.MainHeapSize = "512M"
+		memory.MainHeapSize = "1G"
 	}
 	if memory.MainHeapPageSize == "" {
 		memory.MainHeapPageSize = "4k"

--- a/pkg/config/dataplane_conf_test.go
+++ b/pkg/config/dataplane_conf_test.go
@@ -51,7 +51,7 @@ api-trace {
 }
 
 memory {
-  main-heap-size 512M
+  main-heap-size 1G
   main-heap-page-size 4k
 }
 
@@ -153,7 +153,7 @@ api-trace {
 }
 
 memory {
-  main-heap-size 512M
+  main-heap-size 1G
   main-heap-page-size 4k
 }
 
@@ -243,7 +243,7 @@ api-trace {
 }
 
 memory {
-  main-heap-size 512M
+  main-heap-size 1G
   main-heap-page-size 4k
 }
 

--- a/pkg/dataplane/shm/egress.go
+++ b/pkg/dataplane/shm/egress.go
@@ -26,7 +26,7 @@ func NewEgress(client *Client) *Egress {
 		client:    client,
 		writer:    NewEgressWriter(client),
 		logger:    logger.Get(logger.Dataplane),
-		txChan:    make(chan *dataplane.EgressPacket, 1000),
+		txChan:    make(chan *dataplane.EgressPacket, 4096),
 		closeChan: make(chan struct{}),
 	}
 
@@ -147,7 +147,7 @@ func (e *Egress) Reconnect(client *Client) error {
 
 	e.client = client
 	e.writer = NewEgressWriter(client)
-	e.txChan = make(chan *dataplane.EgressPacket, 1000)
+	e.txChan = make(chan *dataplane.EgressPacket, 4096)
 	e.closeChan = make(chan struct{})
 
 	e.wg.Add(1)

--- a/templates/dataplane.conf.tmpl
+++ b/templates/dataplane.conf.tmpl
@@ -18,9 +18,11 @@ api-trace {
 {{ end }}}
 
 memory {
-  main-heap-size {{ .Memory.MainHeapSize }}
+{{ if .Memory }}  main-heap-size {{ .Memory.MainHeapSize }}
   main-heap-page-size {{ .Memory.MainHeapPageSize }}
-}
+{{ else }}  main-heap-size 1G
+  main-heap-page-size 4k
+{{ end }}}
 
 api-segment {
   gid osvbng


### PR DESCRIPTION
We set a better default here for most DPDK implementations, this is mostly overkill and targeted towards a 48k subscriber deployment, but I'd rather have good defaults for large scale deployment than under utilize the hardware