### PR TITLE
feat(dev): one-shot QEMU/KVM development environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Licensed under the GNU General Public License v3.0 or later.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-.PHONY: all build generate generate-proto clean run test cli build-cli docker-local docker-kea-local lint fmt robot-test clean-branches
+.PHONY: all build generate generate-proto clean run test cli build-cli docker-local docker-kea-local lint fmt robot-test clean-branches dev-vm dev-vm-sync
 
 all: generate build
 
@@ -78,5 +78,14 @@ clean-branches:
 	git branch --format='%(refname:short)' | grep -v '^main$$' | while read branch; do \
 		git show-ref --verify --quiet "refs/remotes/origin/$$branch" || git branch -D "$$branch"; \
 	done
+
+dev-vm:
+	@scripts/dev/dev-vm.sh
+
+dev-vm-sync:
+	@scripts/dev/sync-vm.sh
+
+dev-vm-provision:
+	@scripts/dev/reprovision-vm.sh
 
 .DEFAULT_GOAL := all

--- a/docs/contributing/please_read_first.md
+++ b/docs/contributing/please_read_first.md
@@ -12,6 +12,9 @@
 - [golangci-lint](https://golangci-lint.run/docs/welcome/install/local/)
 - Docker & Docker Compose (for local testing)
 
+!!! tip "Prefer a sandboxed VM?"
+    If you'd rather not install Go, VPP, FRR, or Docker on your host directly, see [Development VM (QEMU/KVM)](#development-vm-qemukvm) — `make dev-vm` provisions a Debian 12 VM with the full toolchain pre-installed.
+
 ## Clone and Build
 
 ```bash
@@ -31,6 +34,98 @@ cd docker/dev
 ```
 
 This builds the Docker image, creates the network topology, and starts osvbng.
+
+## Development VM (QEMU/KVM)
+
+For QEMU image work, dataplane changes, or to keep your host clean of VPP/FRR/kernel-module tweaks, `make dev-vm` provisions a Debian 12 VM via libvirt with the full toolchain (Go, VPP, FRR, Docker, containerlab, packer) pre-installed and your SSH key authorised. The Docker smoke test in `docker/dev/` runs unchanged inside the VM.
+
+### Host prerequisites (Debian / Ubuntu / Pop!_OS)
+
+```bash
+sudo apt install -y \
+    virtinst \
+    libvirt-daemon-system \
+    cloud-image-utils \
+    qemu-utils \
+    whiptail \
+    rsync
+
+sudo usermod -aG libvirt $USER
+newgrp libvirt           # or log out and back in
+```
+
+You also need an SSH public key in `~/.ssh/`. If you don't have one: `ssh-keygen`.
+
+!!! warning "Don't run `make dev-vm` with sudo"
+    The script issues its own `sudo` calls where needed and resolves your SSH key via `$HOME`. Running the whole thing with `sudo` makes it search `/root/.ssh/` and fail with `No SSH public keys found`.
+
+### Create the VM
+
+```bash
+make dev-vm
+```
+
+Downloads the Debian 12 cloud image (~400 MB, cached), creates a 30 GB qcow2 disk, defines a 6 GB / 4 vCPU domain named `osvbng-dev`, then SSHes in and runs the provisioner. First run takes ~10 minutes; subsequent recreates are faster. Override defaults via env: `VM_MEMORY=8192 make dev-vm`.
+
+### Sync your code
+
+```bash
+make dev-vm-sync
+```
+
+Rsyncs the working tree into `/home/dev/osvbng/` in the VM (excludes `.git/`, `bin/`, `output/`, `*.qcow2`).
+
+### Reprovision after `versions.env` changes
+
+```bash
+make dev-vm-provision
+```
+
+Re-runs the provisioner with the current `versions.env` so VPP / FRR / Go versions match the project pin.
+
+### Connecting to the VM
+
+The VM gets a libvirt-DHCP lease on the `default` network (typically `192.168.122.0/24`); the IP can change on recreate. Look it up:
+
+```bash
+virsh -c qemu:///system domifaddr osvbng-dev | awk '/ipv4/ {split($4,a,"/"); print a[1]}'
+```
+
+Add a host alias once and update the IP after each recreate:
+
+```sshconfig
+# ~/.ssh/config
+Host osvbng-dev
+    HostName 192.168.122.X
+    User dev
+    StrictHostKeyChecking accept-new
+    UserKnownHostsFile /dev/null
+    LogLevel ERROR
+```
+
+Then: `ssh osvbng-dev`.
+
+### Reaching osvbng services from your host browser
+
+When you run the in-VM Docker smoke test (`docker/dev/dev.sh start`), osvbng listens on a Docker bridge *inside* the VM (`172.30.0.2:8080/9090/50050`), so it isn't directly reachable from the host. Forward the ports over SSH:
+
+```bash
+ssh -L 8080:172.30.0.2:8080 \
+    -L 9090:172.30.0.2:9090 \
+    -L 50050:172.30.0.2:50050 \
+    osvbng-dev
+```
+
+Leave that session open and open `http://localhost:8080/api/docs` on the host. Grafana is already published to the VM's `eth0:3000`, so it's reachable directly at `http://<vm-ip>:3000` (admin/admin).
+
+### VM lifecycle
+
+```bash
+virsh start osvbng-dev
+virsh shutdown osvbng-dev
+virsh destroy osvbng-dev                              # force stop
+virsh undefine osvbng-dev --remove-all-storage        # delete entirely
+```
 
 ## Development
 

--- a/scripts/dev/dev-vm.sh
+++ b/scripts/dev/dev-vm.sh
@@ -160,9 +160,7 @@ done
 echo "Provisioning..."
 . "$PROJECT_ROOT/versions.env"
 scp $SSH_OPTS "$SCRIPT_DIR/provision.sh" "dev@${IP}:/tmp/provision.sh"
-scp $SSH_OPTS "$PROJECT_ROOT/scripts/qemu/test-runner/packer/scripts/configure-kernel.sh" "dev@${IP}:/tmp/configure-kernel.sh"
 ssh $SSH_OPTS "dev@${IP}" "sudo env GOLANG_VERSION=${GOLANG_VERSION} DATAPLANE_VERSION=${DATAPLANE_VERSION} CONTAINERLAB_VERSION=${CONTAINERLAB_VERSION} bash /tmp/provision.sh"
-ssh $SSH_OPTS "dev@${IP}" "sudo bash /tmp/configure-kernel.sh"
 
 
 echo ""

--- a/scripts/dev/dev-vm.sh
+++ b/scripts/dev/dev-vm.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+# Copyright 2025 Veesix Networks Ltd
+# Licensed under the GNU General Public License v3.0 or later.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Bootstrap a dev VM with virsh/KVM.
+# Downloads a Debian 12 cloud image, creates a VM, and provisions it.
+#
+# Usage: ./dev-vm.sh [path/to/key.pub]
+#
+# After creation, use virsh directly to manage the VM:
+#   virsh start osvbng-dev
+#   virsh shutdown osvbng-dev
+#   virsh destroy osvbng-dev    # force stop
+#   virsh undefine osvbng-dev --remove-all-storage
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+VM_NAME="osvbng-dev"
+VM_MEMORY=4096
+VM_VCPUS=4
+VM_DISK_SIZE="30G"
+LIBVIRT_URI="qemu:///system"
+
+DATA_DIR="/var/lib/libvirt/images/osvbng-dev"
+DISK_PATH="$DATA_DIR/${VM_NAME}.qcow2"
+CLOUD_INIT_ISO="$DATA_DIR/cloud-init.iso"
+DEBIAN_IMAGE_URL="https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-generic-amd64.qcow2"
+DEBIAN_IMAGE_CACHE="$DATA_DIR/debian-12-generic-amd64.qcow2"
+
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+
+# --- Preflight checks ---
+
+for cmd in virsh virt-install qemu-img cloud-localds; do
+    command -v "$cmd" &>/dev/null || {
+        echo "Missing: $cmd. Install with: sudo apt install virtinst libvirt-daemon-system cloud-image-utils qemu-utils"
+        exit 1
+    }
+done
+
+if command -v whiptail &>/dev/null; then
+    TUI_TOOL="whiptail"
+elif command -v dialog &>/dev/null; then
+    TUI_TOOL="dialog"
+else
+    echo "Error: Neither whiptail nor dialog found."
+    echo "  Debian/Ubuntu: sudo apt install whiptail"
+    echo "  Or:            sudo apt install dialog"
+    exit 1
+fi
+
+VIRT_TYPE="kvm"
+if [ ! -w /dev/kvm ]; then
+    echo "WARNING: KVM not available. VM will run under emulation and be very slow."
+    VIRT_TYPE="qemu"
+fi
+
+if virsh --connect "$LIBVIRT_URI" list --all --name 2>/dev/null | grep -qx "$VM_NAME"; then
+    echo "VM '$VM_NAME' already exists. To recreate:"
+    echo "  virsh destroy $VM_NAME; virsh undefine $VM_NAME --remove-all-storage"
+    exit 1
+fi
+
+# SSH Keys selection and copy
+
+PUB_KEYS=()
+for keyfile in "$HOME"/.ssh/*.pub; do
+    [ -f "$keyfile" ] && PUB_KEYS+=("$keyfile")
+done
+[ ${#PUB_KEYS[@]} -gt 0 ] || { echo "No SSH public keys found in ~/.ssh/. Run: ssh-keygen"; exit 1; }
+
+if [ ${#PUB_KEYS[@]} -eq 1 ]; then
+    SELECTED_KEYS=("${PUB_KEYS[0]}")
+else
+    CHECKLIST_ARGS=()
+    for keyfile in "${PUB_KEYS[@]}"; do
+        CHECKLIST_ARGS+=("$keyfile" "$(basename "$keyfile")" "ON")
+    done
+
+    SELECTED=$($TUI_TOOL --title "SSH Key Selection" --checklist \
+        "Select SSH public key(s) to copy into the dev VM:" 15 70 ${#PUB_KEYS[@]} \
+        "${CHECKLIST_ARGS[@]}" 3>&1 1>&2 2>&3) || { echo "Cancelled."; exit 1; }
+
+    SELECTED_KEYS=()
+    for item in $SELECTED; do
+        SELECTED_KEYS+=("${item//\"/}")
+    done
+    [ ${#SELECTED_KEYS[@]} -gt 0 ] || { echo "No keys selected."; exit 1; }
+fi
+
+SSH_KEYS=""
+for keyfile in "${SELECTED_KEYS[@]}"; do
+    SSH_KEYS="${SSH_KEYS}      - $(cat "$keyfile")"$'\n'
+done
+
+sudo mkdir -p "$DATA_DIR"
+
+if [ ! -f "$DEBIAN_IMAGE_CACHE" ]; then
+    echo "Downloading Debian 12 cloud image..."
+    sudo curl -fL -o "$DEBIAN_IMAGE_CACHE" "$DEBIAN_IMAGE_URL"
+fi
+
+sudo cp "$DEBIAN_IMAGE_CACHE" "$DISK_PATH"
+sudo qemu-img resize "$DISK_PATH" "$VM_DISK_SIZE"
+
+USERDATA=$(mktemp)
+cat > "$USERDATA" <<EOF
+#cloud-config
+hostname: ${VM_NAME}
+users:
+  - name: dev
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    groups: sudo
+    ssh_authorized_keys:
+${SSH_KEYS}
+package_update: false
+runcmd:
+  - systemctl enable --now qemu-guest-agent || true
+EOF
+sudo cloud-localds "$CLOUD_INIT_ISO" "$USERDATA"
+rm -f "$USERDATA"
+
+echo "Creating VM..."
+virt-install \
+    --connect "$LIBVIRT_URI" \
+    --name "$VM_NAME" \
+    --memory "$VM_MEMORY" \
+    --vcpus "$VM_VCPUS" \
+    --virt-type "$VIRT_TYPE" \
+    --cpu host-passthrough \
+    --os-variant debian12 \
+    --import \
+    --disk "path=${DISK_PATH},format=qcow2,bus=virtio" \
+    --disk "path=${CLOUD_INIT_ISO},device=cdrom" \
+    --network network=default,model=virtio \
+    --graphics none \
+    --noautoconsole \
+    --quiet
+
+echo "Waiting for VM..."
+IP=""
+for i in $(seq 1 40); do
+    IP=$(virsh --connect "$LIBVIRT_URI" domifaddr "$VM_NAME" 2>/dev/null \
+        | awk '/ipv4/ {split($4, a, "/"); print a[1]; exit}')
+    [ -n "$IP" ] && break
+    sleep 3
+done
+[ -n "$IP" ] || { echo "Timed out waiting for VM IP"; exit 1; }
+
+for i in $(seq 1 40); do
+    ssh $SSH_OPTS -o ConnectTimeout=3 "dev@${IP}" true 2>/dev/null && break
+    sleep 3
+done
+
+echo "Provisioning..."
+. "$PROJECT_ROOT/versions.env"
+scp $SSH_OPTS "$SCRIPT_DIR/provision.sh" "dev@${IP}:/tmp/provision.sh"
+scp $SSH_OPTS "$PROJECT_ROOT/scripts/qemu/test-runner/packer/scripts/configure-kernel.sh" "dev@${IP}:/tmp/configure-kernel.sh"
+ssh $SSH_OPTS "dev@${IP}" "sudo env GOLANG_VERSION=${GOLANG_VERSION} DATAPLANE_VERSION=${DATAPLANE_VERSION} CONTAINERLAB_VERSION=${CONTAINERLAB_VERSION} bash /tmp/provision.sh"
+ssh $SSH_OPTS "dev@${IP}" "sudo bash /tmp/configure-kernel.sh"
+
+
+echo ""
+echo "Dev VM ready! IP: ${IP}"
+echo ""
+echo "  ssh dev@${IP}"
+echo ""
+echo "Add to ~/.ssh/config for VSCode Remote SSH:"
+echo ""
+echo "  Host ${VM_NAME}"
+echo "    HostName ${IP}"
+echo "    User dev"
+echo ""

--- a/scripts/dev/dev-vm.sh
+++ b/scripts/dev/dev-vm.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2025 Veesix Networks Ltd
+# Copyright 2026 The osvbng Authors
 # Licensed under the GNU General Public License v3.0 or later.
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/scripts/dev/dev-vm.sh
+++ b/scripts/dev/dev-vm.sh
@@ -33,82 +33,85 @@ DEBIAN_IMAGE_CACHE="$DATA_DIR/debian-12-generic-amd64.qcow2"
 
 SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
 
-# --- Preflight checks ---
+preflight_checks() {
+    for cmd in virsh virt-install qemu-img cloud-localds; do
+        command -v "$cmd" &>/dev/null || {
+            echo "Missing: $cmd. Install with: sudo apt install virtinst libvirt-daemon-system cloud-image-utils qemu-utils"
+            exit 1
+        }
+    done
 
-for cmd in virsh virt-install qemu-img cloud-localds; do
-    command -v "$cmd" &>/dev/null || {
-        echo "Missing: $cmd. Install with: sudo apt install virtinst libvirt-daemon-system cloud-image-utils qemu-utils"
+    if command -v whiptail &>/dev/null; then
+        TUI_TOOL="whiptail"
+    elif command -v dialog &>/dev/null; then
+        TUI_TOOL="dialog"
+    else
+        echo "Error: Neither whiptail nor dialog found."
+        echo "  Debian/Ubuntu: sudo apt install whiptail"
+        echo "  Or:            sudo apt install dialog"
         exit 1
-    }
-done
+    fi
 
-if command -v whiptail &>/dev/null; then
-    TUI_TOOL="whiptail"
-elif command -v dialog &>/dev/null; then
-    TUI_TOOL="dialog"
-else
-    echo "Error: Neither whiptail nor dialog found."
-    echo "  Debian/Ubuntu: sudo apt install whiptail"
-    echo "  Or:            sudo apt install dialog"
-    exit 1
-fi
+    VIRT_TYPE="kvm"
+    if [ ! -w /dev/kvm ]; then
+        echo "WARNING: KVM not available. VM will run under emulation and be very slow."
+        VIRT_TYPE="qemu"
+    fi
 
-VIRT_TYPE="kvm"
-if [ ! -w /dev/kvm ]; then
-    echo "WARNING: KVM not available. VM will run under emulation and be very slow."
-    VIRT_TYPE="qemu"
-fi
+    if virsh --connect "$LIBVIRT_URI" list --all --name 2>/dev/null | grep -qx "$VM_NAME"; then
+        echo "VM '$VM_NAME' already exists. To recreate:"
+        echo "  virsh destroy $VM_NAME; virsh undefine $VM_NAME --remove-all-storage"
+        exit 1
+    fi
+}
 
-if virsh --connect "$LIBVIRT_URI" list --all --name 2>/dev/null | grep -qx "$VM_NAME"; then
-    echo "VM '$VM_NAME' already exists. To recreate:"
-    echo "  virsh destroy $VM_NAME; virsh undefine $VM_NAME --remove-all-storage"
-    exit 1
-fi
-
-# SSH Keys selection and copy
-
-PUB_KEYS=()
-for keyfile in "$HOME"/.ssh/*.pub; do
-    [ -f "$keyfile" ] && PUB_KEYS+=("$keyfile")
-done
-[ ${#PUB_KEYS[@]} -gt 0 ] || { echo "No SSH public keys found in ~/.ssh/. Run: ssh-keygen"; exit 1; }
-
-if [ ${#PUB_KEYS[@]} -eq 1 ]; then
-    SELECTED_KEYS=("${PUB_KEYS[0]}")
-else
-    CHECKLIST_ARGS=()
-    for keyfile in "${PUB_KEYS[@]}"; do
-        CHECKLIST_ARGS+=("$keyfile" "$(basename "$keyfile")" "ON")
+select_ssh_keys() {
+    PUB_KEYS=()
+    for keyfile in "$HOME"/.ssh/*.pub; do
+        [ -f "$keyfile" ] && PUB_KEYS+=("$keyfile")
     done
+    [ ${#PUB_KEYS[@]} -gt 0 ] || { echo "No SSH public keys found in ~/.ssh/. Run: ssh-keygen"; exit 1; }
 
-    SELECTED=$($TUI_TOOL --title "SSH Key Selection" --checklist \
-        "Select SSH public key(s) to copy into the dev VM:" 15 70 ${#PUB_KEYS[@]} \
-        "${CHECKLIST_ARGS[@]}" 3>&1 1>&2 2>&3) || { echo "Cancelled."; exit 1; }
+    if [ ${#PUB_KEYS[@]} -eq 1 ]; then
+        SELECTED_KEYS=("${PUB_KEYS[0]}")
+    else
+        CHECKLIST_ARGS=()
+        for keyfile in "${PUB_KEYS[@]}"; do
+            CHECKLIST_ARGS+=("$keyfile" "$(basename "$keyfile")" "ON")
+        done
 
-    SELECTED_KEYS=()
-    for item in $SELECTED; do
-        SELECTED_KEYS+=("${item//\"/}")
+        SELECTED=$($TUI_TOOL --title "SSH Key Selection" --checklist \
+            "Select SSH public key(s) to copy into the dev VM:" 15 70 ${#PUB_KEYS[@]} \
+            "${CHECKLIST_ARGS[@]}" 3>&1 1>&2 2>&3) || { echo "Cancelled."; exit 1; }
+
+        SELECTED_KEYS=()
+        for item in $SELECTED; do
+            SELECTED_KEYS+=("${item//\"/}")
+        done
+        [ ${#SELECTED_KEYS[@]} -gt 0 ] || { echo "No keys selected."; exit 1; }
+    fi
+
+    SSH_KEYS=""
+    for keyfile in "${SELECTED_KEYS[@]}"; do
+        SSH_KEYS="${SSH_KEYS}      - $(cat "$keyfile")"$'\n'
     done
-    [ ${#SELECTED_KEYS[@]} -gt 0 ] || { echo "No keys selected."; exit 1; }
-fi
+}
 
-SSH_KEYS=""
-for keyfile in "${SELECTED_KEYS[@]}"; do
-    SSH_KEYS="${SSH_KEYS}      - $(cat "$keyfile")"$'\n'
-done
+prepare_disk() {
+    sudo mkdir -p "$DATA_DIR"
 
-sudo mkdir -p "$DATA_DIR"
+    if [ ! -f "$DEBIAN_IMAGE_CACHE" ]; then
+        echo "Downloading Debian 12 cloud image..."
+        sudo curl -fL -o "$DEBIAN_IMAGE_CACHE" "$DEBIAN_IMAGE_URL"
+    fi
 
-if [ ! -f "$DEBIAN_IMAGE_CACHE" ]; then
-    echo "Downloading Debian 12 cloud image..."
-    sudo curl -fL -o "$DEBIAN_IMAGE_CACHE" "$DEBIAN_IMAGE_URL"
-fi
+    sudo cp "$DEBIAN_IMAGE_CACHE" "$DISK_PATH"
+    sudo qemu-img resize "$DISK_PATH" "$VM_DISK_SIZE"
+}
 
-sudo cp "$DEBIAN_IMAGE_CACHE" "$DISK_PATH"
-sudo qemu-img resize "$DISK_PATH" "$VM_DISK_SIZE"
-
-USERDATA=$(mktemp)
-cat > "$USERDATA" <<EOF
+create_cloud_init() {
+    USERDATA=$(mktemp)
+    cat > "$USERDATA" <<EOF
 #cloud-config
 hostname: ${VM_NAME}
 users:
@@ -122,46 +125,62 @@ package_update: false
 runcmd:
   - systemctl enable --now qemu-guest-agent || true
 EOF
-sudo cloud-localds "$CLOUD_INIT_ISO" "$USERDATA"
-rm -f "$USERDATA"
+    sudo cloud-localds "$CLOUD_INIT_ISO" "$USERDATA"
+    rm -f "$USERDATA"
+}
 
-echo "Creating VM..."
-virt-install \
-    --connect "$LIBVIRT_URI" \
-    --name "$VM_NAME" \
-    --memory "$VM_MEMORY" \
-    --vcpus "$VM_VCPUS" \
-    --virt-type "$VIRT_TYPE" \
-    --cpu host-passthrough \
-    --os-variant debian12 \
-    --import \
-    --disk "path=${DISK_PATH},format=qcow2,bus=virtio" \
-    --disk "path=${CLOUD_INIT_ISO},device=cdrom" \
-    --network network=default,model=virtio \
-    --graphics none \
-    --noautoconsole \
-    --quiet
+create_vm() {
+    echo "Creating VM..."
+    virt-install \
+        --connect "$LIBVIRT_URI" \
+        --name "$VM_NAME" \
+        --memory "$VM_MEMORY" \
+        --vcpus "$VM_VCPUS" \
+        --virt-type "$VIRT_TYPE" \
+        --cpu host-passthrough \
+        --os-variant debian12 \
+        --import \
+        --disk "path=${DISK_PATH},format=qcow2,bus=virtio" \
+        --disk "path=${CLOUD_INIT_ISO},device=cdrom" \
+        --network network=default,model=virtio \
+        --graphics none \
+        --noautoconsole \
+        --quiet
+}
 
-echo "Waiting for VM..."
-IP=""
-for i in $(seq 1 40); do
-    IP=$(virsh --connect "$LIBVIRT_URI" domifaddr "$VM_NAME" 2>/dev/null \
-        | awk '/ipv4/ {split($4, a, "/"); print a[1]; exit}')
-    [ -n "$IP" ] && break
-    sleep 3
-done
-[ -n "$IP" ] || { echo "Timed out waiting for VM IP"; exit 1; }
+wait_for_vm() {
+    echo "Waiting for VM..."
+    IP=""
+    for i in $(seq 1 40); do
+        IP=$(virsh --connect "$LIBVIRT_URI" domifaddr "$VM_NAME" 2>/dev/null \
+            | awk '/ipv4/ {split($4, a, "/"); print a[1]; exit}')
+        [ -n "$IP" ] && break
+        sleep 3
+    done
+    [ -n "$IP" ] || { echo "Timed out waiting for VM IP"; exit 1; }
 
-for i in $(seq 1 40); do
-    ssh $SSH_OPTS -o ConnectTimeout=3 "dev@${IP}" true 2>/dev/null && break
-    sleep 3
-done
+    for i in $(seq 1 40); do
+        ssh $SSH_OPTS -o ConnectTimeout=3 "dev@${IP}" true 2>/dev/null && break
+        sleep 3
+    done
+}
 
-echo "Provisioning..."
-. "$PROJECT_ROOT/versions.env"
-scp $SSH_OPTS "$SCRIPT_DIR/provision.sh" "dev@${IP}:/tmp/provision.sh"
-ssh $SSH_OPTS "dev@${IP}" "sudo env GOLANG_VERSION=${GOLANG_VERSION} DATAPLANE_VERSION=${DATAPLANE_VERSION} CONTAINERLAB_VERSION=${CONTAINERLAB_VERSION} bash /tmp/provision.sh"
+provision_vm() {
+    echo "Provisioning..."
+    . "$PROJECT_ROOT/versions.env"
+    scp $SSH_OPTS "$SCRIPT_DIR/provision.sh" "dev@${IP}:/tmp/provision.sh"
+    ssh $SSH_OPTS "dev@${IP}" "sudo env GOLANG_VERSION=${GOLANG_VERSION} DATAPLANE_VERSION=${DATAPLANE_VERSION} CONTAINERLAB_VERSION=${CONTAINERLAB_VERSION} bash /tmp/provision.sh"
+}
 
+# --- Main ---
+
+preflight_checks
+select_ssh_keys
+prepare_disk
+create_cloud_init
+create_vm
+wait_for_vm
+provision_vm
 
 echo ""
 echo "Dev VM ready! IP: ${IP}"

--- a/scripts/dev/dev-vm.sh
+++ b/scripts/dev/dev-vm.sh
@@ -20,7 +20,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 VM_NAME="osvbng-dev"
-# VM_MEMORY is selected interactively below
+VM_MEMORY="${VM_MEMORY:-6144}"
 VM_VCPUS=4
 VM_DISK_SIZE="30G"
 LIBVIRT_URI="qemu:///system"
@@ -64,15 +64,6 @@ if virsh --connect "$LIBVIRT_URI" list --all --name 2>/dev/null | grep -qx "$VM_
     echo "  virsh destroy $VM_NAME; virsh undefine $VM_NAME --remove-all-storage"
     exit 1
 fi
-
-# Memory selection
-
-VM_MEMORY=$($TUI_TOOL --title "VM Memory" --radiolist \
-    "Select memory for the dev VM.\nVPP needs ~1GB hugepages, plus OS and Docker overhead." 14 60 3 \
-    "4096"  "4 GB  (minimal, hugepages may fall short)" OFF \
-    "6144"  "6 GB  (recommended)" ON \
-    "8192"  "8 GB  (comfortable)" OFF \
-    3>&1 1>&2 2>&3) || { echo "Cancelled."; exit 1; }
 
 # SSH Keys selection and copy
 

--- a/scripts/dev/dev-vm.sh
+++ b/scripts/dev/dev-vm.sh
@@ -20,7 +20,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 VM_NAME="osvbng-dev"
-VM_MEMORY=4096
+# VM_MEMORY is selected interactively below
 VM_VCPUS=4
 VM_DISK_SIZE="30G"
 LIBVIRT_URI="qemu:///system"
@@ -64,6 +64,15 @@ if virsh --connect "$LIBVIRT_URI" list --all --name 2>/dev/null | grep -qx "$VM_
     echo "  virsh destroy $VM_NAME; virsh undefine $VM_NAME --remove-all-storage"
     exit 1
 fi
+
+# Memory selection
+
+VM_MEMORY=$($TUI_TOOL --title "VM Memory" --radiolist \
+    "Select memory for the dev VM.\nVPP needs ~1GB hugepages, plus OS and Docker overhead." 14 60 3 \
+    "4096"  "4 GB  (minimal, hugepages may fall short)" OFF \
+    "6144"  "6 GB  (recommended)" ON \
+    "8192"  "8 GB  (comfortable)" OFF \
+    3>&1 1>&2 2>&3) || { echo "Cancelled."; exit 1; }
 
 # SSH Keys selection and copy
 

--- a/scripts/dev/provision.sh
+++ b/scripts/dev/provision.sh
@@ -142,6 +142,24 @@ else
     echo "  Enable nested virt on host: modprobe kvm_intel nested=1"
 fi
 
+# --- Kernel modules (VRF, MPLS) ---
+
+cat > /etc/modules-load.d/osvbng.conf <<EOF
+vrf
+mpls_router
+mpls_iptunnel
+dummy
+EOF
+
+cat > /etc/sysctl.d/99-mpls.conf <<EOF
+net.mpls.platform_labels=1048575
+EOF
+
+for mod in vrf mpls_router mpls_iptunnel dummy; do
+    modprobe "$mod" 2>/dev/null || true
+done
+sysctl -p /etc/sysctl.d/99-mpls.conf 2>/dev/null || true
+
 # --- Dev user setup ---
 
 if id dev &>/dev/null; then

--- a/scripts/dev/provision.sh
+++ b/scripts/dev/provision.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# Copyright 2025 Veesix Networks Ltd
+# Licensed under the GNU General Public License v3.0 or later.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Dev VM provisioning script — runs inside the VM.
+# Installs all dependencies needed to build and test osvbng from source.
+# Idempotent — safe to re-run when versions.env changes.
+
+set -euo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+GOLANG_VERSION="${GOLANG_VERSION:-1.24}"
+DATAPLANE_VERSION="${DATAPLANE_VERSION:-25.10-release}"
+
+# --- Base packages ---
+
+apt-get update
+apt-get install -y \
+    build-essential \
+    pkg-config \
+    libnl-3-dev \
+    libnl-route-3-dev \
+    libmnl-dev \
+    curl \
+    wget \
+    git \
+    sudo \
+    vim \
+    htop \
+    tcpdump \
+    lsb-release \
+    gnupg \
+    ca-certificates \
+    sqlite3 \
+    libsqlite3-dev \
+    protobuf-compiler \
+    rsync
+
+# --- Go ---
+
+if [ ! -d "/usr/local/go" ] || ! /usr/local/go/bin/go version 2>/dev/null | grep -q "go${GOLANG_VERSION}"; then
+    rm -rf /usr/local/go
+    curl -fsSL "https://go.dev/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz" | tar -C /usr/local -xz
+fi
+
+cat > /etc/profile.d/go.sh <<'EOF'
+export PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"
+EOF
+
+export PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"
+
+go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+
+# --- VPP ---
+
+export VPP_INSTALL_SKIP_SYSCTL=true
+
+if ! dpkg -s vpp &>/dev/null; then
+    curl -s https://packagecloud.io/install/repositories/fdio/release/script.deb.sh | bash
+
+    apt-get update
+    apt-get install -y --no-install-recommends \
+        numactl \
+        "vpp=${DATAPLANE_VERSION}" \
+        "vpp-plugin-core=${DATAPLANE_VERSION}" \
+        "vpp-plugin-dpdk=${DATAPLANE_VERSION}" \
+        "libvppinfra=${DATAPLANE_VERSION}"
+
+    systemctl disable vpp
+    systemctl stop vpp || true
+fi
+
+# --- FRR ---
+
+if ! dpkg -s frr &>/dev/null; then
+    curl -s https://deb.frrouting.org/frr/keys.gpg | tee /usr/share/keyrings/frrouting.gpg > /dev/null
+    echo "deb [signed-by=/usr/share/keyrings/frrouting.gpg] https://deb.frrouting.org/frr $(lsb_release -s -c) frr-stable" \
+        | tee /etc/apt/sources.list.d/frr.list
+
+    apt-get update
+    apt-get install -y --no-install-recommends \
+        frr \
+        frr-pythontools
+
+    systemctl disable frr
+    systemctl stop frr || true
+fi
+
+# --- Docker ---
+
+if ! command -v docker &>/dev/null; then
+    install -m 0755 -d /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+    chmod a+r /etc/apt/keyrings/docker.gpg
+
+    echo \
+        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+        $(lsb_release -s -c) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+    apt-get update
+    apt-get install -y \
+        docker-ce \
+        docker-ce-cli \
+        containerd.io \
+        docker-buildx-plugin \
+        docker-compose-plugin
+
+    systemctl enable docker
+fi
+
+# --- Containerlab ---
+
+CONTAINERLAB_VERSION="${CONTAINERLAB_VERSION:-0.73.0}"
+
+if ! command -v containerlab &>/dev/null; then
+    bash -c "$(curl -sL https://get.containerlab.dev)" -- -v "${CONTAINERLAB_VERSION}"
+fi
+
+# --- QEMU/KVM + Packer (for building osvbng QEMU images) ---
+
+apt-get update
+apt-get install -y \
+    qemu-system-x86 \
+    qemu-utils \
+    cloud-image-utils
+
+if ! command -v packer &>/dev/null; then
+    curl -fsSL https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp.gpg
+    echo "deb [signed-by=/usr/share/keyrings/hashicorp.gpg] https://apt.releases.hashicorp.com $(lsb_release -s -c) main" \
+        | tee /etc/apt/sources.list.d/hashicorp.list
+    apt-get update
+    apt-get install -y packer
+fi
+
+if [ -w /dev/kvm ]; then
+    echo "  KVM:    available (nested virtualization working)"
+else
+    echo "  WARNING: /dev/kvm not available. Packer builds will use TCG (slow)."
+    echo "  Enable nested virt on host: modprobe kvm_intel nested=1"
+fi
+
+# --- Dev user setup ---
+
+if id dev &>/dev/null; then
+    usermod -aG docker dev 2>/dev/null || true
+fi
+
+# --- Cleanup ---
+
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+
+echo "Provisioning complete."
+echo "  Go:     $(/usr/local/go/bin/go version)"
+echo "  VPP:    $(dpkg -s vpp 2>/dev/null | grep Version | awk '{print $2}')"
+echo "  FRR:    $(dpkg -s frr 2>/dev/null | grep Version | awk '{print $2}')"
+echo "  Docker: $(docker --version 2>/dev/null)"

--- a/scripts/dev/provision.sh
+++ b/scripts/dev/provision.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2025 Veesix Networks Ltd
+# Copyright 2026 The osvbng Authors
 # Licensed under the GNU General Public License v3.0 or later.
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/scripts/dev/provision.sh
+++ b/scripts/dev/provision.sh
@@ -51,8 +51,8 @@ EOF
 
 export PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"
 
-go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+GOBIN=/usr/local/bin go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+GOBIN=/usr/local/bin go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 
 # --- VPP ---
 
@@ -159,6 +159,14 @@ for mod in vrf mpls_router mpls_iptunnel dummy; do
     modprobe "$mod" 2>/dev/null || true
 done
 sysctl -p /etc/sysctl.d/99-mpls.conf 2>/dev/null || true
+
+# --- Hugepages mount ---
+
+mkdir -p /dev/hugepages
+if ! mountpoint -q /dev/hugepages; then
+    mount -t hugetlbfs -o pagesize=2M none /dev/hugepages
+fi
+grep -q hugetlbfs /etc/fstab || echo "none /dev/hugepages hugetlbfs pagesize=2M 0 0" >> /etc/fstab
 
 # --- Dev user setup ---
 

--- a/scripts/dev/reprovision-vm.sh
+++ b/scripts/dev/reprovision-vm.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright 2025 Veesix Networks Ltd
+# Licensed under the GNU General Public License v3.0 or later.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Re-run provisioning on the dev VM.
+# Useful after updating versions.env or provision.sh.
+# Usage: ./reprovision-vm.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+VM_NAME="osvbng-dev"
+LIBVIRT_URI="qemu:///system"
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+
+IP=$(virsh --connect "$LIBVIRT_URI" domifaddr "$VM_NAME" 2>/dev/null \
+    | awk '/ipv4/ {split($4, a, "/"); print a[1]; exit}')
+[ -n "$IP" ] || { echo "Could not determine VM IP. Is the VM running?"; exit 1; }
+
+# Sync the latest provision script and versions
+scp $SSH_OPTS "$SCRIPT_DIR/provision.sh" "dev@${IP}:/tmp/provision.sh"
+
+. "$PROJECT_ROOT/versions.env"
+ssh $SSH_OPTS "dev@${IP}" "sudo env GOLANG_VERSION=${GOLANG_VERSION} DATAPLANE_VERSION=${DATAPLANE_VERSION} CONTAINERLAB_VERSION=${CONTAINERLAB_VERSION} bash /tmp/provision.sh"

--- a/scripts/dev/reprovision-vm.sh
+++ b/scripts/dev/reprovision-vm.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2025 Veesix Networks Ltd
+# Copyright 2026 The osvbng Authors
 # Licensed under the GNU General Public License v3.0 or later.
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/scripts/dev/sync-vm.sh
+++ b/scripts/dev/sync-vm.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2025 Veesix Networks Ltd
+# Copyright 2026 The osvbng Authors
 # Licensed under the GNU General Public License v3.0 or later.
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/scripts/dev/sync-vm.sh
+++ b/scripts/dev/sync-vm.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright 2025 Veesix Networks Ltd
+# Licensed under the GNU General Public License v3.0 or later.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Rsync project into the dev VM.
+# Usage: ./sync-vm.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+VM_NAME="osvbng-dev"
+LIBVIRT_URI="qemu:///system"
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+
+IP=$(virsh --connect "$LIBVIRT_URI" domifaddr "$VM_NAME" 2>/dev/null \
+    | awk '/ipv4/ {split($4, a, "/"); print a[1]; exit}')
+[ -n "$IP" ] || { echo "Could not determine VM IP. Is the VM running?"; exit 1; }
+
+rsync -avz --delete \
+    --exclude .git \
+    --exclude bin/ \
+    --exclude output/ \
+    --exclude '*.qcow2*' \
+    -e "ssh $SSH_OPTS" \
+    "$PROJECT_ROOT/" "dev@${IP}:~/osvbng/"

--- a/versions.env
+++ b/versions.env
@@ -1,5 +1,6 @@
 # Component versions for osvbng builds
 export DATAPLANE_VERSION=25.10-release
-export GOLANG_VERSION=1.24
+export GOLANG_VERSION=1.24.0
 export DEBIAN_VERSION=12
+export CONTAINERLAB_VERSION=0.73.0
 export TEST_RUNNER_VERSION=test-runner-v1


### PR DESCRIPTION
This PR introduces a one-shot development script to deploy a Docker based VM (Debian 12). The `scripts/dev/**.sh` contain scripts for VM creation, provisioning, reprovisioning, and code sync through `rsync`.

## VM setup
```
make dev-vm
``` 
The dev-vm creates the VM with `libvirt` & `virsh`(downloads cloud image, create cloud-init ISO, launches the VM, SSHs into it and runs provisioning)
```
make dev-vm-sync
```
Syncs the codebase to the VM's `/home/dev/osvbng` with rsync.

## Reprovisioning dependencies version updates
The `provision.sh` uses existing `versions.env` to update dependencies. To reprovision, run:
```
make dev-vm-provision
```

## !! NOTE
Although the creation of development environment for QEMU/KVM environments was discussed, I think it'd be better to derive the environment from the existing test-runner setup instead of embedding it in `dev-*` scripts. That way, we won't to worry about the development environment for testing and development diverging due to having two separate setup scripts. Require feedbacks on this

### Issues
closes #187.

### Tested on
- Ubuntu 24.04.3 LTS x86_6 host
- osvbng 0.7.0