### PR TITLE
feat(plugin): add community cgnat-http-exporter plugin

### DIFF
--- a/docs/architecture/EVENTS.md
+++ b/docs/architecture/EVENTS.md
@@ -216,6 +216,7 @@ Common plugin use cases:
 - **CDR / billing** - subscribe to `TopicSessionLifecycle` for session start/stop
 - **External IPAM** - subscribe to `TopicSessionLifecycle` to sync IP allocations
 - **Lawful intercept** - subscribe to `TopicSessionLifecycle` to activate/deactivate taps
+- **CGNAT port-block logging** - subscribe to `TopicCGNATMapping` to persist allocate/release events for metadata retention
 - **CoA / policy push** - publish to `TopicSubscriberMutation` with attribute changes
 - **Admin disconnect** - publish to `TopicSubscriberTerminate` with session target
 - **Standby awareness** - subscribe to `TopicHAStateChange` to disable features on standby

--- a/docs/configuration/plugins.md
+++ b/docs/configuration/plugins.md
@@ -11,6 +11,7 @@ Plugin-specific configuration. Each key under `plugins` is a plugin namespace wi
 ## Exporters
 
 - [exporter.prometheus](plugins/exporter-prometheus.md) - Prometheus metrics exporter
+- [exporter.cgnat.http](plugins/exporter-cgnat-http.md) - HTTP exporter for CGNAT port-block allocate/release events (metadata retention / LI correlation)
 
 ## Northbound
 

--- a/docs/configuration/plugins/exporter-cgnat-http.md
+++ b/docs/configuration/plugins/exporter-cgnat-http.md
@@ -1,0 +1,118 @@
+# exporter.cgnat.http
+
+Community HTTP exporter for CGNAT port-block allocation and release
+events. Subscribes to `TopicCGNATMapping` on the internal event bus
+and POSTs one JSON payload per allocate/release to a configured
+endpoint. Intended primarily for **metadata retention and lawful-intercept
+correlation** — the destination service persists the events and answers
+"which subscriber had outside-IP:port at time T" queries.
+
+The publisher is the CGNAT component; a single BNG can emit thousands
+of port-block events per second at peak. The exporter consumes events
+on a bounded in-memory queue with a dedicated worker pool so the
+mapping hot path never blocks on HTTP I/O.
+
+| Field | Type | Description | Example |
+|-------|------|-------------|---------|
+| `enabled` | bool | Enable the plugin | `true` |
+| `endpoint` | string | Destination URL for each event | `https://portal.example.com/api/v1/bng/cgnat-mapping` |
+| `method` | string | HTTP method (default `POST`) | `POST` |
+| `timeout` | duration | Per-request timeout (default `5s`) | `5s` |
+| `tls` | object | TLS configuration | |
+| `auth` | object | HTTP authentication | |
+| `headers` | map | Additional request headers | |
+| `queue_size` | int | In-memory queue capacity (default `10000`) | `10000` |
+| `workers` | int | Concurrent HTTP workers (default `1`) | `2` |
+| `max_retries` | int | Retry attempts after the first POST fails (default `3`) | `5` |
+| `retry_initial` | duration | Initial backoff between retries (default `500ms`) | `500ms` |
+| `retry_max` | duration | Maximum backoff (default `30s`) | `30s` |
+| `include_inside_ip` | bool | Include the subscriber's inside IP in the payload (default `true`) | `true` |
+
+## TLS
+
+Same shape as the `subscriber.auth.http` plugin:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `insecure_skip_verify` | bool | Skip TLS certificate verification |
+| `ca_cert_file` | string | Path to a CA certificate PEM file |
+| `cert_file` | string | Path to a client certificate PEM file |
+| `key_file` | string | Path to a client private key PEM file |
+
+## Auth
+
+| Field | Type | Description | Example |
+|-------|------|-------------|---------|
+| `type` | string | `basic` or `bearer` | `bearer` |
+| `username` | string | Basic-auth username | `admin` |
+| `password` | string | Basic-auth password | |
+| `token` | string | Bearer token | |
+
+## Payload
+
+Each event is POSTed as a single JSON object:
+
+```json
+{
+  "event": "allocate",
+  "at": "2026-04-20T08:01:12.345Z",
+  "srg_name": "default",
+  "session_id": "f6be89db-7454-41fb-9849-fc4aa683a9a6",
+  "pool_name": "cgnat-syd-01",
+  "pool_id": 7,
+  "outside_ip": "100.64.12.7",
+  "port_block_start": 49152,
+  "port_block_end": 49351,
+  "inside_ip": "10.50.14.9",
+  "inside_vrf_id": 42
+}
+```
+
+`event` is `allocate` for new port-block assignments and `release`
+when a block is returned to the pool. `session_id` correlates to the
+BNG session (same value emitted on the auth/accounting endpoints of
+`subscriber.auth.http`), so the downstream service can join
+port-block events to subscriber identity via its own records.
+
+## Reliability
+
+- **Queue overflow** — events arriving when the internal queue is full are
+  **dropped** (counted), never blocked. The publisher is the CGNAT
+  component's mapping hot path; blocking there would slow the entire
+  dataplane. Operators should alert on a non-zero drop counter.
+- **HTTP retries** — network errors and 5xx responses are retried with
+  exponential backoff up to `max_retries`. 4xx responses (client errors
+  — bad payload, bad auth) are **not** retried; the event is recorded
+  as failed so the operator is prompted to fix the configuration.
+- **Shutdown** — on component stop, the subscriber is removed from the
+  bus and the queue is drained for up to 5 seconds. Events still
+  queued after the grace period are lost.
+
+!!! warning "At-most-once, not at-least-once"
+    This exporter makes a best-effort to deliver every event but the
+    in-memory queue + no disk spooling means a BNG process crash or a
+    sustained portal outage will lose events. For strict compliance
+    regimes that require at-least-once delivery, pair this plugin with
+    a durable collector (local syslog, Kafka, etc.) on the BNG.
+
+## Example
+
+```yaml
+plugins:
+  exporter.cgnat.http:
+    enabled: true
+    endpoint: https://portal.example.com/api/v1/bng/cgnat-mapping
+    method: POST
+    timeout: 5s
+    queue_size: 10000
+    workers: 2
+    max_retries: 5
+    retry_initial: 500ms
+    retry_max: 30s
+    include_inside_ip: true
+    auth:
+      type: bearer
+      token: REPLACE_WITH_PORTAL_TOKEN
+    headers:
+      X-BNG-Node-Id: "osvbng-nsw-1"
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
       - subscriber.auth.http: configuration/plugins/auth-http.md
       - subscriber.auth.radius: configuration/plugins/auth-radius.md
       - exporter.prometheus: configuration/plugins/exporter-prometheus.md
+      - exporter.cgnat.http: configuration/plugins/exporter-cgnat-http.md
       - northbound.api: configuration/plugins/northbound-api.md
       - example.hello: configuration/plugins/example-hello.md
   - Examples:

--- a/plugins/community/all/cgnat_http_exporter.go
+++ b/plugins/community/all/cgnat_http_exporter.go
@@ -1,0 +1,7 @@
+// Copyright 2026 Veesix Networks Ltd
+// Licensed under the GNU General Public License v3.0 or later.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package all
+
+import _ "github.com/veesix-networks/osvbng/plugins/community/cgnat-http-exporter"

--- a/plugins/community/cgnat-http-exporter/client.go
+++ b/plugins/community/cgnat-http-exporter/client.go
@@ -1,0 +1,150 @@
+// Copyright 2026 Veesix Networks Ltd
+// Licensed under the GNU General Public License v3.0 or later.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cgnathttp
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// client owns the *http.Client plus the request-shaping logic. Kept
+// small on purpose — no retry/backoff state lives here (see sendWithRetry
+// for that); this struct is just "build + execute a single request".
+type client struct {
+	cfg  *Config
+	http *http.Client
+}
+
+func newClient(cfg *Config) (*client, error) {
+	transport := &http.Transport{}
+	if cfg.TLS != nil {
+		tlsCfg, err := buildTLSConfig(cfg.TLS)
+		if err != nil {
+			return nil, err
+		}
+		transport.TLSClientConfig = tlsCfg
+	}
+	return &client{
+		cfg: cfg,
+		http: &http.Client{
+			Transport: transport,
+			Timeout:   cfg.Timeout,
+		},
+	}, nil
+}
+
+// post issues one HTTP request. Retry logic is layered on top by the
+// caller (sendWithRetry).
+//
+// Returned booleans:
+//   - ok:      true when the server responded 2xx.
+//   - retryable: true when the caller should back off and retry; false
+//     for 4xx responses (configuration-level errors — retrying won't fix
+//     them, and hammering the portal for a bad payload would be rude).
+//     Network errors and 5xx are retryable.
+func (c *client) post(ctx context.Context, body []byte) (ok, retryable bool, status int, err error) {
+	req, err := http.NewRequestWithContext(ctx, c.cfg.Method, c.cfg.Endpoint, bytes.NewReader(body))
+	if err != nil {
+		return false, false, 0, fmt.Errorf("build request: %w", err)
+	}
+	c.setHeaders(req)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		// Network / DNS / timeout — transient, retryable.
+		return false, true, 0, err
+	}
+	defer resp.Body.Close()
+
+	switch {
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		return true, false, resp.StatusCode, nil
+	case resp.StatusCode >= 400 && resp.StatusCode < 500:
+		// Client error — our payload or auth is wrong. Don't retry;
+		// surface to the operator via logs + metrics instead.
+		return false, false, resp.StatusCode, fmt.Errorf("http %d", resp.StatusCode)
+	default:
+		// 5xx, 3xx-non-redirect, anything else — retryable.
+		return false, true, resp.StatusCode, fmt.Errorf("http %d", resp.StatusCode)
+	}
+}
+
+func (c *client) setHeaders(req *http.Request) {
+	req.Header.Set("Content-Type", "application/json")
+
+	if c.cfg.Auth != nil {
+		switch strings.ToLower(c.cfg.Auth.Type) {
+		case "basic":
+			req.SetBasicAuth(c.cfg.Auth.Username, c.cfg.Auth.Password)
+		case "bearer":
+			req.Header.Set("Authorization", "Bearer "+c.cfg.Auth.Token)
+		}
+	}
+	for k, v := range c.cfg.Headers {
+		req.Header.Set(k, v)
+	}
+}
+
+func buildTLSConfig(cfg *TLSConfig) (*tls.Config, error) {
+	out := &tls.Config{
+		InsecureSkipVerify: cfg.InsecureSkipVerify,
+		MinVersion:         tls.VersionTLS12,
+	}
+	if cfg.CACertFile != "" {
+		pem, err := os.ReadFile(cfg.CACertFile)
+		if err != nil {
+			return nil, fmt.Errorf("read ca cert %q: %w", cfg.CACertFile, err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("parse ca cert %q", cfg.CACertFile)
+		}
+		out.RootCAs = pool
+	}
+	if cfg.CertFile != "" && cfg.KeyFile != "" {
+		cert, err := tls.LoadX509KeyPair(cfg.CertFile, cfg.KeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("load client keypair: %w", err)
+		}
+		out.Certificates = []tls.Certificate{cert}
+	}
+	return out, nil
+}
+
+// nextBackoff returns the next delay in an exponential sequence clamped
+// at max. Pure function to keep worker logic testable without fakes.
+func nextBackoff(prev, initial, max time.Duration) time.Duration {
+	if prev == 0 {
+		return initial
+	}
+	next := prev * 2
+	if next > max {
+		return max
+	}
+	return next
+}
+
+// sleepCtx sleeps for d unless ctx is cancelled first; returns false if
+// ctx cancelled (caller should abandon the work).
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return ctx.Err() == nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}

--- a/plugins/community/cgnat-http-exporter/client_test.go
+++ b/plugins/community/cgnat-http-exporter/client_test.go
@@ -1,0 +1,171 @@
+// Copyright 2026 Veesix Networks Ltd
+// Licensed under the GNU General Public License v3.0 or later.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cgnathttp
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func testConfig(endpoint string) *Config {
+	cfg := &Config{
+		Enabled:  true,
+		Endpoint: endpoint,
+	}
+	cfg.applyDefaults()
+	return cfg
+}
+
+func TestClient_Post_Success(t *testing.T) {
+	var got []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got, _ = io.ReadAll(r.Body)
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("content-type = %q, want application/json", got)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c, err := newClient(testConfig(srv.URL))
+	if err != nil {
+		t.Fatalf("newClient: %v", err)
+	}
+	ok, retryable, status, err := c.post(context.Background(), []byte(`{"hi":"there"}`))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	if !ok || retryable || status != 200 {
+		t.Errorf("ok=%v retryable=%v status=%d, want true/false/200", ok, retryable, status)
+	}
+	if string(got) != `{"hi":"there"}` {
+		t.Errorf("server received %q", got)
+	}
+}
+
+func TestClient_Post_4xx_NotRetryable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	c, _ := newClient(testConfig(srv.URL))
+	ok, retryable, status, _ := c.post(context.Background(), []byte(`{}`))
+	if ok || retryable {
+		t.Errorf("ok=%v retryable=%v, want false/false for 4xx", ok, retryable)
+	}
+	if status != 400 {
+		t.Errorf("status=%d, want 400", status)
+	}
+}
+
+func TestClient_Post_5xx_Retryable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c, _ := newClient(testConfig(srv.URL))
+	ok, retryable, status, _ := c.post(context.Background(), []byte(`{}`))
+	if ok || !retryable {
+		t.Errorf("ok=%v retryable=%v, want false/true for 5xx", ok, retryable)
+	}
+	if status != 500 {
+		t.Errorf("status=%d, want 500", status)
+	}
+}
+
+func TestClient_SetHeaders_BearerAndCustom(t *testing.T) {
+	var got *http.Request
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		got = r
+	}))
+	defer srv.Close()
+
+	cfg := testConfig(srv.URL)
+	cfg.Auth = &AuthConfig{Type: "bearer", Token: "abc123"}
+	cfg.Headers = map[string]string{"X-BNG-Node-Id": "osvbng-nsw-1"}
+
+	c, _ := newClient(cfg)
+	_, _, _, _ = c.post(context.Background(), []byte(`{}`))
+
+	if got == nil {
+		t.Fatal("handler never fired")
+	}
+	if a := got.Header.Get("Authorization"); a != "Bearer abc123" {
+		t.Errorf("authz = %q, want Bearer abc123", a)
+	}
+	if n := got.Header.Get("X-BNG-Node-Id"); n != "osvbng-nsw-1" {
+		t.Errorf("X-BNG-Node-Id = %q", n)
+	}
+}
+
+func TestClient_SetHeaders_Basic(t *testing.T) {
+	var got *http.Request
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		got = r
+	}))
+	defer srv.Close()
+
+	cfg := testConfig(srv.URL)
+	cfg.Auth = &AuthConfig{Type: "basic", Username: "u", Password: "p"}
+
+	c, _ := newClient(cfg)
+	_, _, _, _ = c.post(context.Background(), []byte(`{}`))
+
+	u, p, ok := got.BasicAuth()
+	if !ok || u != "u" || p != "p" {
+		t.Errorf("basic auth u=%q p=%q ok=%v", u, p, ok)
+	}
+}
+
+func TestNextBackoff(t *testing.T) {
+	cases := []struct {
+		prev, init, max, want time.Duration
+	}{
+		{0, 100 * time.Millisecond, time.Second, 100 * time.Millisecond},
+		{100 * time.Millisecond, 100 * time.Millisecond, time.Second, 200 * time.Millisecond},
+		{500 * time.Millisecond, 100 * time.Millisecond, time.Second, time.Second}, // capped
+		{2 * time.Second, 100 * time.Millisecond, time.Second, time.Second},        // already at cap
+	}
+	for _, tc := range cases {
+		if got := nextBackoff(tc.prev, tc.init, tc.max); got != tc.want {
+			t.Errorf("nextBackoff(prev=%v init=%v max=%v) = %v, want %v",
+				tc.prev, tc.init, tc.max, got, tc.want)
+		}
+	}
+}
+
+func TestSleepCtx_Cancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if sleepCtx(ctx, 5*time.Second) {
+		t.Errorf("sleepCtx with cancelled ctx should return false")
+	}
+}
+
+func TestSleepCtx_Completes(t *testing.T) {
+	start := time.Now()
+	if !sleepCtx(context.Background(), 10*time.Millisecond) {
+		t.Errorf("sleepCtx should return true on normal completion")
+	}
+	if elapsed := time.Since(start); elapsed < 10*time.Millisecond {
+		t.Errorf("slept for %v, expected >= 10ms", elapsed)
+	}
+}
+
+// Reference an atomic.Uint64 so the test file fails early if someone
+// strips the sync/atomic import from the code under test — the package
+// relies on it for its counters.
+var _ = atomic.Uint64{}
+
+// Sanity check: server that always fails, driven through sendWithRetry
+// lives in exporter_test.go — kept out of this file to keep the
+// client-level tests isolated from the Component.

--- a/plugins/community/cgnat-http-exporter/config.go
+++ b/plugins/community/cgnat-http-exporter/config.go
@@ -1,0 +1,175 @@
+// Copyright 2026 Veesix Networks Ltd
+// Licensed under the GNU General Public License v3.0 or later.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package cgnathttp is a community exporter plugin that subscribes to
+// TopicCGNATMapping and POSTs each port-block allocate/release event
+// to a configured HTTP endpoint.
+//
+// The event stream is the authoritative source for lawful-intercept and
+// metadata-retention correlation: "at time T, this outside IP:port range
+// was assigned to this subscriber session". A downstream portal can
+// persist the POSTs into an append-only log and serve reverse lookups.
+//
+// Events are consumed off the bus asynchronously (bounded in-memory
+// queue + worker goroutines). The subscribe handler never blocks the
+// CGNAT component's mapping hot path — if the queue is full the event
+// is dropped and a counter is incremented so operators can alert on it.
+package cgnathttp
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/veesix-networks/osvbng/pkg/component"
+	"github.com/veesix-networks/osvbng/pkg/configmgr"
+)
+
+// Namespace is the plugin config key. Matches YAML under `plugins:`.
+const Namespace = "exporter.cgnat.http"
+
+// Config controls the exporter. Zero-values resolve to the defaults in
+// applyDefaults. Timeout / retry / queue sizing are chosen so that an
+// operator who only sets `enabled: true` + `endpoint:` gets a useful
+// exporter without further tuning.
+type Config struct {
+	Enabled bool `json:"enabled" yaml:"enabled"`
+
+	// Endpoint is the absolute URL that each event is POSTed to.
+	Endpoint string `json:"endpoint" yaml:"endpoint"`
+
+	// Method overrides the HTTP verb. Defaults to POST; any standard
+	// verb is accepted but POST is the only one that makes semantic
+	// sense for an event stream.
+	Method string `json:"method,omitempty" yaml:"method,omitempty"`
+
+	// Timeout bounds each individual HTTP request. Retries get their
+	// own timeout budget.
+	Timeout time.Duration `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+
+	// TLS + Auth + Headers mirror the subscriber.auth.http plugin for
+	// operator familiarity.
+	TLS     *TLSConfig        `json:"tls,omitempty" yaml:"tls,omitempty"`
+	Auth    *AuthConfig       `json:"auth,omitempty" yaml:"auth,omitempty"`
+	Headers map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
+
+	// QueueSize is the capacity of the internal buffer between the
+	// event subscriber and the HTTP worker(s). Events arriving when
+	// the queue is full are dropped (see Metric_EventsDropped).
+	QueueSize int `json:"queue_size,omitempty" yaml:"queue_size,omitempty"`
+
+	// Workers is the number of concurrent goroutines draining the
+	// queue. One is enough for most deployments; increase if the
+	// downstream portal is slow and the queue backs up.
+	Workers int `json:"workers,omitempty" yaml:"workers,omitempty"`
+
+	// MaxRetries is the number of attempts after the initial POST
+	// before an event is given up on. Zero means no retry (single
+	// POST attempt).
+	MaxRetries int `json:"max_retries,omitempty" yaml:"max_retries,omitempty"`
+
+	// RetryInitial / RetryMax bound exponential backoff. Delay
+	// doubles after each failure and is capped at RetryMax.
+	RetryInitial time.Duration `json:"retry_initial,omitempty" yaml:"retry_initial,omitempty"`
+	RetryMax     time.Duration `json:"retry_max,omitempty"     yaml:"retry_max,omitempty"`
+
+	// IncludeInsideIP controls whether the subscriber's inside
+	// (private) IP is included in the POST body. Default true.
+	// Disable if your downstream system shouldn't see inside IPs for
+	// privacy/compliance reasons — outside IP + port range are still
+	// sufficient to correlate via session_id.
+	IncludeInsideIP *bool `json:"include_inside_ip,omitempty" yaml:"include_inside_ip,omitempty"`
+}
+
+type TLSConfig struct {
+	InsecureSkipVerify bool   `json:"insecure_skip_verify,omitempty" yaml:"insecure_skip_verify,omitempty"`
+	CACertFile         string `json:"ca_cert_file,omitempty"         yaml:"ca_cert_file,omitempty"`
+	CertFile           string `json:"cert_file,omitempty"            yaml:"cert_file,omitempty"`
+	KeyFile            string `json:"key_file,omitempty"             yaml:"key_file,omitempty"`
+}
+
+type AuthConfig struct {
+	Type     string `json:"type,omitempty"     yaml:"type,omitempty"` // "basic" | "bearer"
+	Username string `json:"username,omitempty" yaml:"username,omitempty"`
+	Password string `json:"password,omitempty" yaml:"password,omitempty"`
+	Token    string `json:"token,omitempty"    yaml:"token,omitempty"`
+}
+
+// Defaults — tuned for a typical BNG that processes a few thousand PBA
+// events per second at peak. QueueSize of 10k absorbs ~30s of backlog
+// at 300 events/s; operators with hotter dataplanes should raise it.
+const (
+	defaultMethod       = "POST"
+	defaultTimeout      = 5 * time.Second
+	defaultQueueSize    = 10000
+	defaultWorkers      = 1
+	defaultMaxRetries   = 3
+	defaultRetryInitial = 500 * time.Millisecond
+	defaultRetryMax     = 30 * time.Second
+)
+
+// applyDefaults fills in zero-value fields. Mutates c.
+func (c *Config) applyDefaults() {
+	if c.Method == "" {
+		c.Method = defaultMethod
+	}
+	if c.Timeout == 0 {
+		c.Timeout = defaultTimeout
+	}
+	if c.QueueSize == 0 {
+		c.QueueSize = defaultQueueSize
+	}
+	if c.Workers == 0 {
+		c.Workers = defaultWorkers
+	}
+	if c.MaxRetries == 0 {
+		c.MaxRetries = defaultMaxRetries
+	}
+	if c.RetryInitial == 0 {
+		c.RetryInitial = defaultRetryInitial
+	}
+	if c.RetryMax == 0 {
+		c.RetryMax = defaultRetryMax
+	}
+	if c.IncludeInsideIP == nil {
+		b := true
+		c.IncludeInsideIP = &b
+	}
+}
+
+// validate returns a descriptive error if the config is unusable. Called
+// from NewComponent before the worker is started so misconfiguration is
+// caught at load time instead of at the first event.
+func (c *Config) validate() error {
+	if c.Endpoint == "" {
+		return fmt.Errorf("endpoint is required")
+	}
+	if c.Workers < 1 {
+		return fmt.Errorf("workers must be >= 1")
+	}
+	if c.QueueSize < 1 {
+		return fmt.Errorf("queue_size must be >= 1")
+	}
+	if c.MaxRetries < 0 {
+		return fmt.Errorf("max_retries must be >= 0")
+	}
+	if c.RetryInitial < 0 || c.RetryMax < c.RetryInitial {
+		return fmt.Errorf("retry_initial must be <= retry_max and both non-negative")
+	}
+	if c.Auth != nil {
+		switch c.Auth.Type {
+		case "", "basic", "bearer":
+		default:
+			return fmt.Errorf("auth.type must be empty, basic, or bearer")
+		}
+	}
+	return nil
+}
+
+func init() {
+	configmgr.RegisterPluginConfig(Namespace, Config{})
+	component.Register(Namespace, NewComponent,
+		component.WithAuthor("veesix ::networks contributors"),
+		component.WithVersion("1.0.0"),
+	)
+}

--- a/plugins/community/cgnat-http-exporter/exporter.go
+++ b/plugins/community/cgnat-http-exporter/exporter.go
@@ -1,0 +1,300 @@
+// Copyright 2026 Veesix Networks Ltd
+// Licensed under the GNU General Public License v3.0 or later.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cgnathttp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/veesix-networks/osvbng/pkg/component"
+	"github.com/veesix-networks/osvbng/pkg/configmgr"
+	"github.com/veesix-networks/osvbng/pkg/events"
+	"github.com/veesix-networks/osvbng/pkg/logger"
+	"github.com/veesix-networks/osvbng/pkg/models"
+)
+
+// Component is the cgnat-http-exporter. One per osvbng instance when
+// the plugin is enabled. It subscribes to TopicCGNATMapping and fans
+// events out to a worker pool that POSTs each one to the configured
+// endpoint.
+type Component struct {
+	*component.Base
+
+	logger *logger.Logger
+	cfg    *Config
+	bus    events.Bus
+	client *client
+
+	// queue carries marshalled event payloads from the subscribe
+	// handler to the worker pool. Keeping the marshalled bytes on
+	// the queue (not the raw *CGNATMappingEvent) means we do the
+	// allocation once, and workers do not hold a reference to the
+	// mapping object the CGNAT component owns.
+	queue chan []byte
+
+	// Counters. Exposed via GetStats() for `show cgnat-http-exporter`
+	// style handlers or Prometheus in a future pass.
+	received atomic.Uint64
+	sent     atomic.Uint64
+	failed   atomic.Uint64
+	dropped  atomic.Uint64 // queue was full on ingest
+
+	sub    events.Subscription
+	wg     sync.WaitGroup
+	cancel context.CancelFunc
+}
+
+// NewComponent is the plugin entry point wired via component.Register
+// in config.go. Returns (nil, nil) when the plugin config is absent or
+// disabled — same convention as the hello reference plugin.
+func NewComponent(deps component.Dependencies) (component.Component, error) {
+	raw, ok := configmgr.GetPluginConfig(Namespace)
+	if !ok {
+		return nil, nil
+	}
+	cfg, ok := raw.(*Config)
+	if !ok {
+		return nil, fmt.Errorf("invalid config type for %s", Namespace)
+	}
+	if !cfg.Enabled {
+		return nil, nil
+	}
+	cfg.applyDefaults()
+	if err := cfg.validate(); err != nil {
+		return nil, fmt.Errorf("%s: %w", Namespace, err)
+	}
+	if deps.EventBus == nil {
+		return nil, fmt.Errorf("%s: event bus dependency missing", Namespace)
+	}
+
+	cl, err := newClient(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("%s: http client: %w", Namespace, err)
+	}
+
+	return &Component{
+		Base:   component.NewBase(Namespace),
+		logger: logger.Get(Namespace),
+		cfg:    cfg,
+		bus:    deps.EventBus,
+		client: cl,
+		queue:  make(chan []byte, cfg.QueueSize),
+	}, nil
+}
+
+// Start subscribes to the CGNAT mapping topic and spins up the worker
+// pool. Non-blocking — returns as soon as workers are running.
+func (c *Component) Start(ctx context.Context) error {
+	c.StartContext(ctx)
+
+	workerCtx, cancel := context.WithCancel(ctx)
+	c.cancel = cancel
+
+	for i := 0; i < c.cfg.Workers; i++ {
+		c.wg.Add(1)
+		go c.worker(workerCtx)
+	}
+
+	c.sub = c.bus.Subscribe(events.TopicCGNATMapping, c.handleEvent)
+
+	c.logger.Info("cgnat-http-exporter started",
+		"endpoint", c.cfg.Endpoint,
+		"workers", c.cfg.Workers,
+		"queue_size", c.cfg.QueueSize,
+		"max_retries", c.cfg.MaxRetries,
+	)
+	return nil
+}
+
+// Stop unsubscribes, drains the queue for a short grace period, then
+// cancels the workers. Events still in the queue at shutdown are
+// logged but not retried — they'd be racing against a dead process.
+func (c *Component) Stop(ctx context.Context) error {
+	if c.sub != nil {
+		c.sub.Unsubscribe()
+	}
+	// Close the queue so workers see EOF and exit after draining.
+	close(c.queue)
+
+	// Give workers a few seconds to drain before we force-cancel.
+	done := make(chan struct{})
+	go func() {
+		c.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		c.logger.Warn("cgnat-http-exporter: workers did not drain in 5s, forcing shutdown",
+			"queued", len(c.queue))
+		if c.cancel != nil {
+			c.cancel()
+		}
+		c.wg.Wait()
+	}
+
+	c.StopContext()
+	c.logger.Info("cgnat-http-exporter stopped",
+		"received", c.received.Load(),
+		"sent", c.sent.Load(),
+		"failed", c.failed.Load(),
+		"dropped", c.dropped.Load(),
+	)
+	return nil
+}
+
+// handleEvent is called synchronously from the event bus. It MUST NOT
+// block — the CGNAT component is the publisher and any hold here slows
+// the mapping-allocation path. Non-blocking enqueue; drop on overflow.
+func (c *Component) handleEvent(ev events.Event) {
+	data, ok := ev.Data.(*events.CGNATMappingEvent)
+	if !ok || data == nil || data.Mapping == nil {
+		return
+	}
+	c.received.Add(1)
+
+	body, err := c.marshal(data)
+	if err != nil {
+		c.failed.Add(1)
+		c.logger.Warn("cgnat-http-exporter: marshal failed", "err", err)
+		return
+	}
+
+	// Non-blocking send: drop if the queue is saturated. Dropping is
+	// preferable to blocking the publisher (CGNAT mapping hot path).
+	// Operators should alert on a non-zero drop counter.
+	select {
+	case c.queue <- body:
+	default:
+		c.dropped.Add(1)
+		c.logger.Warn("cgnat-http-exporter: queue full, dropping event",
+			"session_id", data.SessionID,
+			"queue_size", c.cfg.QueueSize,
+		)
+	}
+}
+
+// worker drains the queue and POSTs each event. Retries with
+// exponential backoff. Exits when the queue is closed and drained, or
+// when ctx is cancelled (forced shutdown).
+func (c *Component) worker(ctx context.Context) {
+	defer c.wg.Done()
+	for body := range c.queue {
+		c.sendWithRetry(ctx, body)
+		if ctx.Err() != nil {
+			return
+		}
+	}
+}
+
+// sendWithRetry layers exponential backoff on top of client.post.
+// Aborts early when the event is a 4xx (non-retryable) or when ctx is
+// cancelled. Updates sent/failed counters.
+func (c *Component) sendWithRetry(ctx context.Context, body []byte) {
+	var delay time.Duration
+	for attempt := 0; attempt <= c.cfg.MaxRetries; attempt++ {
+		ok, retryable, status, err := c.client.post(ctx, body)
+		if ok {
+			c.sent.Add(1)
+			return
+		}
+		if !retryable || attempt == c.cfg.MaxRetries {
+			c.failed.Add(1)
+			c.logger.Warn("cgnat-http-exporter: send failed",
+				"attempt", attempt+1,
+				"status", status,
+				"err", err,
+				"retryable", retryable,
+			)
+			return
+		}
+		delay = nextBackoff(delay, c.cfg.RetryInitial, c.cfg.RetryMax)
+		if !sleepCtx(ctx, delay) {
+			return
+		}
+	}
+}
+
+// payload is the JSON structure we POST per event. Field names chosen
+// for consumer ergonomics over matching internal Go naming exactly.
+type payload struct {
+	Event          string    `json:"event"` // "allocate" | "release"
+	At             time.Time `json:"at"`
+	SRGName        string    `json:"srg_name,omitempty"`
+	SessionID      string    `json:"session_id,omitempty"`
+	PoolName       string    `json:"pool_name"`
+	PoolID         uint32    `json:"pool_id"`
+	OutsideIP      string    `json:"outside_ip"`
+	PortBlockStart uint16    `json:"port_block_start"`
+	PortBlockEnd   uint16    `json:"port_block_end"`
+	InsideIP       string    `json:"inside_ip,omitempty"`
+	InsideVRFID    uint32    `json:"inside_vrf_id,omitempty"`
+}
+
+func (c *Component) marshal(ev *events.CGNATMappingEvent) ([]byte, error) {
+	m := ev.Mapping
+	p := payload{
+		Event:          eventKind(ev.IsAdd),
+		At:             time.Now().UTC(),
+		SRGName:        ev.SRGName,
+		SessionID:      ev.SessionID,
+		PoolName:       m.PoolName,
+		PoolID:         m.PoolID,
+		OutsideIP:      ipString(m.OutsideIP),
+		PortBlockStart: m.PortBlockStart,
+		PortBlockEnd:   m.PortBlockEnd,
+	}
+	if c.cfg.IncludeInsideIP != nil && *c.cfg.IncludeInsideIP {
+		p.InsideIP = ipString(m.InsideIP)
+		p.InsideVRFID = m.InsideVRFID
+	}
+	return json.Marshal(&p)
+}
+
+func eventKind(isAdd bool) string {
+	if isAdd {
+		return "allocate"
+	}
+	return "release"
+}
+
+// ipString handles a nil net.IP gracefully — test events sometimes omit
+// it, and we'd rather emit "" than panic on .String().
+func ipString(ip interface{ String() string }) string {
+	if ip == nil {
+		return ""
+	}
+	return ip.String()
+}
+
+// Stats snapshots the atomic counters. Exposed so a future show handler
+// can render them without reaching into atomics directly.
+type Stats struct {
+	Received uint64 `json:"received"`
+	Sent     uint64 `json:"sent"`
+	Failed   uint64 `json:"failed"`
+	Dropped  uint64 `json:"dropped"`
+	Queued   int    `json:"queued"`
+}
+
+func (c *Component) GetStats() Stats {
+	return Stats{
+		Received: c.received.Load(),
+		Sent:     c.sent.Load(),
+		Failed:   c.failed.Load(),
+		Dropped:  c.dropped.Load(),
+		Queued:   len(c.queue),
+	}
+}
+
+// compile-time check that we satisfy the component interface.
+var _ component.Component = (*Component)(nil)
+
+// compile-time sanity check on event payload — catches upstream renames.
+var _ = (*events.CGNATMappingEvent)(&events.CGNATMappingEvent{Mapping: &models.CGNATMapping{}})

--- a/plugins/community/cgnat-http-exporter/exporter_test.go
+++ b/plugins/community/cgnat-http-exporter/exporter_test.go
@@ -1,0 +1,312 @@
+// Copyright 2026 Veesix Networks Ltd
+// Licensed under the GNU General Public License v3.0 or later.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cgnathttp
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/veesix-networks/osvbng/pkg/events"
+	"github.com/veesix-networks/osvbng/pkg/logger"
+	"github.com/veesix-networks/osvbng/pkg/models"
+)
+
+func loggerForTest() *logger.Logger { return logger.Get("cgnat-http-exporter-test") }
+
+// fakeBus is a minimal in-process event bus that only implements what
+// the Component needs. Using the real local bus would work too but
+// couples these tests to its internals.
+type fakeBus struct {
+	mu       sync.Mutex
+	handlers map[string][]events.Handler
+}
+
+func newFakeBus() *fakeBus { return &fakeBus{handlers: map[string][]events.Handler{}} }
+
+func (b *fakeBus) Publish(topic string, ev events.Event) {
+	b.mu.Lock()
+	hs := append([]events.Handler(nil), b.handlers[topic]...)
+	b.mu.Unlock()
+	for _, h := range hs {
+		h(ev)
+	}
+}
+
+func (b *fakeBus) Subscribe(topic string, h events.Handler) events.Subscription {
+	b.mu.Lock()
+	b.handlers[topic] = append(b.handlers[topic], h)
+	b.mu.Unlock()
+	return &fakeSub{bus: b, topic: topic, handler: h}
+}
+
+func (b *fakeBus) SubscribeAll(events.Handler) events.Subscription { return noopSub{} }
+func (b *fakeBus) Stats() events.Stats                             { return events.Stats{} }
+func (b *fakeBus) SetDebugTopics([]string)                         {}
+func (b *fakeBus) DebugTopics() []string                           { return nil }
+func (b *fakeBus) Close() error                                    { return nil }
+
+type fakeSub struct {
+	bus     *fakeBus
+	topic   string
+	handler events.Handler
+}
+
+// Unsubscribe is a no-op for fakeBus — tests drive events explicitly
+// and stop the worker via channel close, so we don't exercise the
+// bus-side unsubscription path here.
+func (s *fakeSub) Unsubscribe() {}
+
+type noopSub struct{}
+
+func (noopSub) Unsubscribe() {}
+
+// sampleMapping returns a deterministic CGNATMapping for fixture use.
+func sampleMapping() *models.CGNATMapping {
+	return &models.CGNATMapping{
+		SessionID:      "sess-1",
+		PoolName:       "cgnat-syd-01",
+		PoolID:         7,
+		InsideIP:       net.ParseIP("10.50.14.9"),
+		InsideVRFID:    42,
+		OutsideIP:      net.ParseIP("100.64.12.7"),
+		PortBlockStart: 49152,
+		PortBlockEnd:   49351,
+		SwIfIndex:      3,
+	}
+}
+
+// TestComponent_EndToEnd drives one allocate + one release event
+// through a Component wired to a local httptest server and asserts
+// both land at the endpoint with the expected JSON shape.
+func TestComponent_EndToEnd(t *testing.T) {
+	var mu sync.Mutex
+	var bodies [][]byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, b)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := testConfig(srv.URL)
+	cfg.Workers = 1
+	cfg.MaxRetries = 0
+	cl, _ := newClient(cfg)
+
+	c := &Component{
+		logger: loggerForTest(),
+		cfg:    cfg,
+		bus:    newFakeBus(),
+		client: cl,
+		queue:  make(chan []byte, cfg.QueueSize),
+	}
+	// Use a raw manual lifecycle so the test doesn't need a full
+	// component.Base wired to a runtime.
+	ctx, cancel := context.WithCancel(context.Background())
+	c.cancel = cancel
+	c.wg.Add(1)
+	go c.worker(ctx)
+
+	c.bus.Subscribe(events.TopicCGNATMapping, c.handleEvent)
+
+	// Publish allocate + release.
+	c.bus.Publish(events.TopicCGNATMapping, events.Event{
+		Source: "cgnat",
+		Data:   &events.CGNATMappingEvent{SRGName: "default", SessionID: "sess-1", Mapping: sampleMapping(), IsAdd: true},
+	})
+	c.bus.Publish(events.TopicCGNATMapping, events.Event{
+		Source: "cgnat",
+		Data:   &events.CGNATMappingEvent{SRGName: "default", SessionID: "sess-1", Mapping: sampleMapping(), IsAdd: false},
+	})
+
+	// Wait for both to land at the server, with a generous bound.
+	waitFor(t, 2*time.Second, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(bodies) == 2
+	})
+
+	// Drain and stop cleanly.
+	close(c.queue)
+	cancel()
+	c.wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(bodies) != 2 {
+		t.Fatalf("got %d bodies, want 2", len(bodies))
+	}
+
+	events := []string{"allocate", "release"}
+	for i, b := range bodies {
+		var got payload
+		if err := json.Unmarshal(b, &got); err != nil {
+			t.Fatalf("body[%d]: %v", i, err)
+		}
+		if got.Event != events[i] {
+			t.Errorf("body[%d].event = %q, want %q", i, got.Event, events[i])
+		}
+		if got.OutsideIP != "100.64.12.7" || got.PortBlockStart != 49152 || got.PortBlockEnd != 49351 {
+			t.Errorf("body[%d] mapping fields wrong: %+v", i, got)
+		}
+		if got.SessionID != "sess-1" || got.PoolName != "cgnat-syd-01" {
+			t.Errorf("body[%d] session/pool fields wrong: %+v", i, got)
+		}
+		if got.InsideIP != "10.50.14.9" {
+			t.Errorf("body[%d] inside_ip = %q, want 10.50.14.9", i, got.InsideIP)
+		}
+	}
+
+	stats := c.GetStats()
+	if stats.Received != 2 || stats.Sent != 2 || stats.Failed != 0 || stats.Dropped != 0 {
+		t.Errorf("stats: %+v, want received=2 sent=2", stats)
+	}
+}
+
+// TestComponent_IncludeInsideIP_False ensures the inside IP is omitted
+// from the payload when operators disable that for privacy reasons.
+func TestComponent_IncludeInsideIP_False(t *testing.T) {
+	var body []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := testConfig(srv.URL)
+	no := false
+	cfg.IncludeInsideIP = &no
+	cl, _ := newClient(cfg)
+
+	c := &Component{
+		logger: loggerForTest(),
+		cfg:    cfg,
+		bus:    newFakeBus(),
+		client: cl,
+		queue:  make(chan []byte, 4),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	c.cancel = cancel
+	c.wg.Add(1)
+	go c.worker(ctx)
+
+	c.handleEvent(events.Event{
+		Source: "cgnat",
+		Data:   &events.CGNATMappingEvent{SessionID: "s", Mapping: sampleMapping(), IsAdd: true},
+	})
+
+	waitFor(t, time.Second, func() bool { return len(body) > 0 })
+
+	close(c.queue)
+	cancel()
+	c.wg.Wait()
+
+	var got payload
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.InsideIP != "" || got.InsideVRFID != 0 {
+		t.Errorf("inside fields leaked when IncludeInsideIP=false: %+v", got)
+	}
+	if got.OutsideIP == "" {
+		t.Errorf("outside_ip missing — should still be present")
+	}
+}
+
+// TestComponent_DropOnFull verifies the subscribe handler doesn't block
+// when the queue is saturated; it increments the drop counter instead.
+// This is the contract that keeps the CGNAT mapping hot path safe.
+func TestComponent_DropOnFull(t *testing.T) {
+	// Stall the server forever so the worker can't drain.
+	block := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		<-block
+	}))
+	defer func() { close(block); srv.Close() }()
+
+	cfg := testConfig(srv.URL)
+	cfg.QueueSize = 2
+	cfg.Workers = 1
+	cl, _ := newClient(cfg)
+
+	c := &Component{
+		logger: loggerForTest(),
+		cfg:    cfg,
+		bus:    newFakeBus(),
+		client: cl,
+		queue:  make(chan []byte, cfg.QueueSize),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c.cancel = cancel
+	c.wg.Add(1)
+	go c.worker(ctx)
+
+	// Push enough events that the queue must overflow. The first
+	// lands at the worker (in-flight, server is stalled), the next
+	// two fill the queue, then subsequent ones get dropped.
+	for range 10 {
+		c.handleEvent(events.Event{
+			Source: "cgnat",
+			Data:   &events.CGNATMappingEvent{SessionID: "x", Mapping: sampleMapping(), IsAdd: true},
+		})
+	}
+
+	if got := c.received.Load(); got != 10 {
+		t.Errorf("received = %d, want 10", got)
+	}
+	if c.dropped.Load() == 0 {
+		t.Errorf("expected some drops when queue is saturated; dropped=0")
+	}
+}
+
+// TestComponent_Marshal_NilMapping is a defensive test: bad event data
+// must not crash the handler. The CGNAT component always sets Mapping,
+// but if that invariant ever breaks we want the exporter to log and
+// move on, not take the BNG process with it.
+func TestComponent_Marshal_NilMapping(t *testing.T) {
+	cfg := testConfig("http://ignored")
+	cl, _ := newClient(cfg)
+	c := &Component{
+		logger: loggerForTest(),
+		cfg:    cfg,
+		bus:    newFakeBus(),
+		client: cl,
+		queue:  make(chan []byte, 1),
+	}
+	c.handleEvent(events.Event{Source: "cgnat", Data: &events.CGNATMappingEvent{Mapping: nil}})
+	c.handleEvent(events.Event{Source: "cgnat", Data: nil})
+	if c.received.Load() != 0 {
+		t.Errorf("expected received=0 for malformed events, got %d", c.received.Load())
+	}
+}
+
+// waitFor polls predicate up to d; fails the test if it never becomes true.
+func waitFor(t *testing.T, d time.Duration, ok func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if ok() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("condition not met within %v", d)
+}
+
+// Counter touch so linters notice sync/atomic usage even if future
+// refactors swap the specific atomic we import here.
+var _ = atomic.Uint64{}


### PR DESCRIPTION
## Summary

Adds a new community plugin `exporter.cgnat.http` at `plugins/community/cgnat-http-exporter/`. It subscribes to `TopicCGNATMapping` and POSTs each port-block allocate / release event to a configured HTTP endpoint.

The use case is **metadata retention + lawful-intercept correlation**: downstream portals persist the POSTs into an append-only log and serve "at time T, who had outside-IP:port?" reverse lookups. `show cgnat lookup` already covers live mappings — this covers the historical side.

No existing osvbng behaviour changes. No core files are touched beyond three docs pages, `mkdocs.yml`, and `plugins/community/all/` registration.

## Design

- **Hot path safety** — the CGNAT component publishes `TopicCGNATMapping` synchronously during mapping allocation. The subscribe handler marshals + non-blocking-sends onto a bounded channel, workers drain the channel and POST. If the queue is full, events are dropped and counted (`dropped` atomic) rather than blocking the publisher. This preserves the mapping hot-path performance contract.
- **Retry** — exponential backoff (configurable initial/max). 5xx and network errors retry up to `max_retries`; 4xx responses are non-retryable (bad payload or bad auth — retrying won't fix it).
- **Config shape** mirrors `subscriber.auth.http` (TLS, auth, headers) for operator familiarity.
- **Privacy opt-out** — `include_inside_ip` (default true) controls whether the subscriber's inside IP is sent. Outside IP + port range + session_id are always sent so downstream can still correlate.

## Tests

`plugins/community/cgnat-http-exporter/*_test.go` — all `go test` and `go vet` clean locally.

- `TestClient_Post_Success` / `_4xx_NotRetryable` / `_5xx_Retryable` — response classification
- `TestClient_SetHeaders_BearerAndCustom` / `_Basic` — auth header rendering
- `TestNextBackoff` / `TestSleepCtx_*` — pure helpers
- `TestComponent_EndToEnd` — drive allocate + release through an `httptest.Server` via an in-process fake event bus; assert JSON shape + counters
- `TestComponent_IncludeInsideIP_False` — privacy flag is respected
- `TestComponent_DropOnFull` — subscribe handler never blocks when the queue is saturated (the hot-path guarantee)
- `TestComponent_Marshal_NilMapping` — defensive: malformed events can't crash the handler

(`make test` on my macOS workstation fails for `pkg/southbound/vpp` due to linux-only `netlink.SetPromiscOn` — pre-existing on plain v0.10.0 main; unaffected by this PR. CI runs on linux.)

## End-to-end validation

Tested on a live BNG (demo deployment in Sydney):

1. Built osvbngd from this branch, swapped on the BNG (`v0.9.0` → `v0.10.0-warp-cgnat-http-exporter`).
2. Added `exporter.cgnat.http` block to `/etc/osvbng/osvbng.yaml` pointing at a receiver portal.
3. Restarted `vpp osvbng frr`. Plugin started cleanly:
   ```
   INF Subscribed to topic component=events topic=osvbng:events:cgnat:mapping
   INF cgnat-http-exporter started endpoint=https://...  workers=2 queue_size=10000
   INFO Plugin ready name=exporter.cgnat.http
   ```
4. Driven by bngblaster (IPoE + DHCP + `icmp-client` to 1.1.1.1), a real CGNAT port-block was allocated and the event landed at the receiving portal's retention table:
   ```
   session_id:  0e41a1ff-987c-4ccb-a7ac-17e81496d800
   outside_ip:  157.20.112.0
   port_range:  1424-1623
   allocated:   2026-04-20 11:38:56Z
   ```
5. Reverse lookup by (outside_ip, port, timestamp) resolves to the original session via the retention log's B-tree index.

## Docs

- `docs/configuration/plugins.md` — added under **Exporters**
- `docs/configuration/plugins/exporter-cgnat-http.md` — full schema, reliability semantics, example config
- `docs/architecture/EVENTS.md` — added CGNAT port-block logging as a common plugin use case
- `mkdocs.yml` — nav entry

## Breaking changes

None.

## AI / LLM usage

Per CONTRIBUTING.md: the plugin scaffolding (config / component / client) and tests were drafted with Claude, using the internal event bus + component interfaces plus `plugins/auth/http/` as the reference pattern. All code was reviewed, iterated on, and deployment-tested on a real BNG by the author.

## Notes for reviewers

- Happy to move under `plugins/exporter/` if you'd prefer to treat this as a certified exporter instead of community — I defaulted to `community/` since I'm external, per the guidance in `docs/architecture/PLUGINS.md`.
- The `session_id` fan-out — linking the CGNAT event back to the subscriber session — is done entirely on the receiver side by matching against subscriber-auth accounting events. Nothing osvbng-side needed.
- No integration test added; tested end-to-end with bngblaster as described above. Happy to add a qa/ case if useful.