### PR TITLE
fix(bgp): drop direct vtysh from instance Apply so ASN changes survive osvbngd restart

### DIFF
--- a/internal/routing/component.go
+++ b/internal/routing/component.go
@@ -49,21 +49,6 @@ func (c *Component) Stop(ctx context.Context) error {
 	return nil
 }
 
-func (c *Component) ConfigureBGP(asn uint32, routerID string) error {
-	args := []string{"-c", "configure terminal", "-c", fmt.Sprintf("router bgp %d", asn)}
-	if routerID != "" {
-		args = append(args, "-c", fmt.Sprintf("bgp router-id %s", routerID))
-	}
-
-	_, err := c.execVtysh(args...)
-	return err
-}
-
-func (c *Component) RemoveBGP(asn uint32) error {
-	_, err := c.execVtysh("-c", "configure terminal", "-c", fmt.Sprintf("no router bgp %d", asn))
-	return err
-}
-
 func (c *Component) AdvertiseBGPNetwork(asn uint32, vrf string, prefix string, ipv6 bool) error {
 	af := "ipv4"
 	routeCmd := fmt.Sprintf("ip route %s Null0", prefix)

--- a/pkg/handlers/conf/protocols/bgp/instance.go
+++ b/pkg/handlers/conf/protocols/bgp/instance.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	routingcomp "github.com/veesix-networks/osvbng/internal/routing"
 	"github.com/veesix-networks/osvbng/pkg/config/protocols"
 	"github.com/veesix-networks/osvbng/pkg/deps"
 	"github.com/veesix-networks/osvbng/pkg/handlers/conf"
@@ -15,14 +14,10 @@ func init() {
 	conf.RegisterFactory(NewBGPInstanceHandler)
 }
 
-type BGPInstanceHandler struct {
-	routing *routingcomp.Component
-}
+type BGPInstanceHandler struct{}
 
-func NewBGPInstanceHandler(deps *deps.ConfDeps) conf.Handler {
-	return &BGPInstanceHandler{
-		routing: deps.Routing,
-	}
+func NewBGPInstanceHandler(_ *deps.ConfDeps) conf.Handler {
+	return &BGPInstanceHandler{}
 }
 
 func (h *BGPInstanceHandler) Validate(ctx context.Context, hctx *conf.HandlerContext) error {
@@ -39,25 +34,11 @@ func (h *BGPInstanceHandler) Validate(ctx context.Context, hctx *conf.HandlerCon
 }
 
 func (h *BGPInstanceHandler) Apply(ctx context.Context, hctx *conf.HandlerContext) error {
-	cfg, ok := hctx.NewValue.(*protocols.BGPConfig)
-	if !ok {
-		return fmt.Errorf("expected *protocols.BGPConfig, got %T", hctx.NewValue)
-	}
-	return h.routing.ConfigureBGP(cfg.ASN, cfg.RouterID)
+	return nil
 }
 
 func (h *BGPInstanceHandler) Rollback(ctx context.Context, hctx *conf.HandlerContext) error {
-	// Rolling back a freshly-added instance has no OldValue; undo it using the
-	// value that was applied. Without this guard the nil type assertion panics
-	// and crashes the daemon mid-rollback, masking the error that triggered it.
-	cfg, ok := hctx.OldValue.(*protocols.BGPConfig)
-	if !ok {
-		cfg, ok = hctx.NewValue.(*protocols.BGPConfig)
-	}
-	if !ok {
-		return nil
-	}
-	return h.routing.RemoveBGP(cfg.ASN)
+	return nil
 }
 
 func (h *BGPInstanceHandler) PathPattern() paths.Path {


### PR DESCRIPTION
Fixes #367

We just let the FRR reload handle instance changes.