### PR TITLE
fix(scripts): avoid set -e death in deploy-vm.sh on hosts without SMT

### DIFF
--- a/scripts/qemu/deploy-vm.sh
+++ b/scripts/qemu/deploy-vm.sh
@@ -195,10 +195,16 @@ build_topology() {
                 if [[ $s == *-* ]]; then
                     local a=${s%-*} b=${s#*-} i
                     for ((i=a; i<=b; i++)); do
-                        [ "$i" != "$cpu" ] && CPU_SIBLING[$cpu]=$i && break
+                        if [ "$i" != "$cpu" ]; then
+                            CPU_SIBLING[$cpu]=$i
+                            break
+                        fi
                     done
                 else
-                    [ "$s" != "$cpu" ] && CPU_SIBLING[$cpu]=$s && break
+                    if [ "$s" != "$cpu" ]; then
+                        CPU_SIBLING[$cpu]=$s
+                        break
+                    fi
                 fi
             done
         fi
@@ -283,7 +289,9 @@ auto_pick_host_cores() {
                 taken[$sib]=1
             fi
             taken_count=$((taken_count + 1))
-            [ $taken_count -ge 2 ] && break
+            if [ $taken_count -ge 2 ]; then
+                break
+            fi
         done
     done
 


### PR DESCRIPTION
## Problem

`deploy-vm.sh` exits with code 1 and prints nothing on hosts without SMT
(SMT disabled in BIOS, or a VM with 1 thread per core). The script dies
before the first whiptail screen.

## Cause

The sibling scan in `build_topology()` uses this pattern:

```bash
[ "$s" != "$cpu" ] && CPU_SIBLING[$cpu]=$s && break
```

On a host without SMT, `thread_siblings_list` for each CPU contains only
the CPU itself. The test fails, and the failed test is the last command
in the loop. The loop returns 1, so `build_topology` returns 1.

`set -e` exempts a failed command on the left of `&&`. The exemption
does not carry through a function's return status. The bare
`build_topology` call then kills the script.

Minimal reproduction (bash 5.2):

```bash
bash -c 'set -e; f(){ for s in 0; do [ "$s" != 0 ] && break; done; }; f; echo ok'
# exits 1, prints nothing
```

Hosts with SMT never hit this path, because a sibling always matches
before the loop ends. Hosts tuned for VPP/DPDK often run with SMT off,
so this hits the target audience of the script.

## Fix

Replace the `&&` chains with `if` blocks, so a non-match does not become
the loop's exit status:

- `build_topology()`: both sibling-scan branches
- `auto_pick_host_cores()`: the `[ $taken_count -ge 2 ] && break` line,
  which has the same failure mode on a NUMA node with fewer than
  2 free physical cores

## Test

On a host with SMT disabled:

- Before: `sudo ./deploy-vm.sh` exits 1 with no output.
  `bash -x` shows the last executed command as `'[' 0 '!=' 0 ']'`
  inside `build_topology`.
- After: the script shows the "osvbng KVM Deployment" banner and the
  full TUI flow completes.
- `bash -n` passes. Behavior on SMT hosts is unchanged: the sibling
  map is identical for both list formats (`0,64` and `0-1`).

## Possible follow-up (not in this PR)

A `trap 'echo "deploy-vm.sh: died at line $LINENO" >&2' ERR` near the
top would make any future `set -e` death visible instead of silent.