### PR TITLE
fix(shm): drain one punt ring per VPP thread for the v2 punt protocol

### DIFF
--- a/pkg/dataplane/shm/client.go
+++ b/pkg/dataplane/shm/client.go
@@ -17,13 +17,14 @@ type Client struct {
 	puntEventfd   int
 	egressEventfd int
 
-	header      *ShmHeader
-	puntRing    *AtomicRingHeader
-	puntDescs   []PuntDesc
+	header *ShmHeader
+	// One punt ring per VPP thread; puntRings[t] and puntDescs[t]
+	// belong to thread t. The egress ring stays single.
+	puntRings   []*AtomicRingHeader
+	puntDescs   [][]PuntDesc
 	egressRing  *AtomicRingHeader
 	egressDescs []EgressDesc
 
-	puntDataOffset   uint32
 	egressDataOffset uint32
 }
 
@@ -134,14 +135,23 @@ func (c *Client) mapStructures() error {
 		return fmt.Errorf("version mismatch: %d", c.header.Version)
 	}
 
-	puntRingHdr := (*RingHeader)(unsafe.Pointer(&c.shmData[c.header.PuntRingOffset]))
-	c.puntRing = NewAtomicRingHeader(puntRingHdr)
-
-	puntDescsOffset := c.header.PuntRingOffset + uint32(unsafe.Sizeof(RingHeader{}))
-	c.puntDescs = unsafe.Slice(
-		(*PuntDesc)(unsafe.Pointer(&c.shmData[puntDescsOffset])),
-		c.header.PuntRingSize,
-	)
+	n := c.header.NPuntRings
+	if n == 0 {
+		return fmt.Errorf("shm reports zero punt rings")
+	}
+	c.puntRings = make([]*AtomicRingHeader, n)
+	c.puntDescs = make([][]PuntDesc, n)
+	for t := uint32(0); t < n; t++ {
+		ringOff := c.header.PuntRingOffset + t*c.header.PuntRingStride
+		c.puntRings[t] = NewAtomicRingHeader(
+			(*RingHeader)(unsafe.Pointer(&c.shmData[ringOff])),
+		)
+		descsOff := ringOff + uint32(unsafe.Sizeof(RingHeader{}))
+		c.puntDescs[t] = unsafe.Slice(
+			(*PuntDesc)(unsafe.Pointer(&c.shmData[descsOff])),
+			c.header.PuntRingSize,
+		)
+	}
 
 	egressRingHdr := (*RingHeader)(unsafe.Pointer(&c.shmData[c.header.EgressRingOffset]))
 	c.egressRing = NewAtomicRingHeader(egressRingHdr)
@@ -152,8 +162,10 @@ func (c *Client) mapStructures() error {
 		c.header.EgressRingSize,
 	)
 
-	c.puntDataOffset = c.header.DataRegionOffset
-	c.egressDataOffset = c.header.DataRegionOffset + c.header.PuntDataSlots*c.header.SlotSize
+	// Descriptors carry an absolute data_offset from the shm base, so
+	// punt reads need no base of their own; egress writes still index
+	// slots relative to the egress data region.
+	c.egressDataOffset = c.header.EgressDataOffset
 
 	return nil
 }

--- a/pkg/dataplane/shm/egress_writer.go
+++ b/pkg/dataplane/shm/egress_writer.go
@@ -23,7 +23,8 @@ func NewEgressWriter(client *Client) *EgressWriter {
 		head:      client.egressRing.LoadHead(),
 		mask:      RingMask(client.header.EgressRingSize),
 		slotIndex: 0,
-		slotCount: client.header.EgressDataSlots,
+		// v2 lays out exactly one data slot per egress descriptor.
+		slotCount: client.header.EgressRingSize,
 	}
 }
 

--- a/pkg/dataplane/shm/ingress.go
+++ b/pkg/dataplane/shm/ingress.go
@@ -48,6 +48,7 @@ func (i *Ingress) Init(_ string) error {
 		i.reader = NewPuntReader(i.client)
 
 		i.logger.Info("Connected to VPP shared memory",
+			"punt_rings", i.client.header.NPuntRings,
 			"punt_ring_size", i.client.header.PuntRingSize,
 			"egress_ring_size", i.client.header.EgressRingSize,
 			"slot_size", i.client.header.SlotSize,
@@ -206,6 +207,7 @@ func (i *Ingress) Reconnect() error {
 	i.reader = NewPuntReader(i.client)
 
 	i.logger.Info("SHM ingress reconnected",
+		"punt_rings", i.client.header.NPuntRings,
 		"punt_ring_size", i.client.header.PuntRingSize,
 		"egress_ring_size", i.client.header.EgressRingSize,
 	)

--- a/pkg/dataplane/shm/punt_reader.go
+++ b/pkg/dataplane/shm/punt_reader.go
@@ -9,32 +9,39 @@ type PuntPacket struct {
 	Data      []byte
 }
 
+// PuntReader drains one punt ring per VPP thread. Each ring is SPSC
+// (its owning worker is the only producer), so the reader keeps a tail
+// per ring and clears each ring's interrupt flag on commit. `cur`
+// round-robins the starting ring so no ring is starved under load.
 type PuntReader struct {
 	client *Client
-	tail   uint64
+	tails  []uint64
 	mask   uint64
+	cur    int
 }
 
 func NewPuntReader(client *Client) *PuntReader {
+	tails := make([]uint64, len(client.puntRings))
+	for i, ring := range client.puntRings {
+		tails[i] = ring.LoadTail()
+	}
 	return &PuntReader{
 		client: client,
-		tail:   client.puntRing.LoadTail(),
+		tails:  tails,
 		mask:   RingMask(client.header.PuntRingSize),
 	}
 }
 
 func (r *PuntReader) Available() uint64 {
-	head := r.client.puntRing.LoadHead()
-	return head - r.tail
+	var total uint64
+	for i, ring := range r.client.puntRings {
+		total += ring.LoadHead() - r.tails[i]
+	}
+	return total
 }
 
-func (r *PuntReader) Read() (*PuntPacket, bool) {
-	head := r.client.puntRing.LoadHead()
-	if r.tail == head {
-		return nil, false
-	}
-
-	desc := &r.client.puntDescs[r.tail&r.mask]
+func (r *PuntReader) readDesc(ring int) *PuntPacket {
+	desc := &r.client.puntDescs[ring][r.tails[ring]&r.mask]
 
 	pkt := &PuntPacket{
 		SwIfIndex: desc.SwIfIndex,
@@ -46,46 +53,49 @@ func (r *PuntReader) Read() (*PuntPacket, bool) {
 	}
 	copy(pkt.Data, r.client.GetPuntData(desc.DataOffset, desc.DataLength))
 
-	r.tail++
+	r.tails[ring]++
+	return pkt
+}
 
-	return pkt, true
+func (r *PuntReader) Read() (*PuntPacket, bool) {
+	n := len(r.client.puntRings)
+	for i := 0; i < n; i++ {
+		ring := (r.cur + i) % n
+		if r.tails[ring] == r.client.puntRings[ring].LoadHead() {
+			continue
+		}
+		pkt := r.readDesc(ring)
+		// Resume from the next ring so a busy ring can't monopolise.
+		r.cur = (ring + 1) % n
+		return pkt, true
+	}
+	return nil, false
 }
 
 func (r *PuntReader) ReadBatch(max int) []*PuntPacket {
-	head := r.client.puntRing.LoadHead()
-	available := head - r.tail
-	if available == 0 {
+	n := len(r.client.puntRings)
+	packets := make([]*PuntPacket, 0, max)
+
+	for i := 0; i < n && len(packets) < max; i++ {
+		ring := (r.cur + i) % n
+		head := r.client.puntRings[ring].LoadHead()
+		for r.tails[ring] != head && len(packets) < max {
+			packets = append(packets, r.readDesc(ring))
+		}
+	}
+
+	if len(packets) == 0 {
 		return nil
 	}
-
-	count := int(available)
-	if count > max {
-		count = max
-	}
-
-	packets := make([]*PuntPacket, count)
-	for i := 0; i < count; i++ {
-		desc := &r.client.puntDescs[r.tail&r.mask]
-
-		packets[i] = &PuntPacket{
-			SwIfIndex: desc.SwIfIndex,
-			Protocol:  Protocol(desc.Protocol),
-			OuterVLAN: desc.OuterVLAN,
-			InnerVLAN: desc.InnerVLAN,
-			Timestamp: desc.Timestamp,
-			Data:      make([]byte, desc.DataLength),
-		}
-		copy(packets[i].Data, r.client.GetPuntData(desc.DataOffset, desc.DataLength))
-
-		r.tail++
-	}
-
+	r.cur = (r.cur + 1) % n
 	return packets
 }
 
 func (r *PuntReader) Commit() {
-	r.client.puntRing.StoreTail(r.tail)
-	r.client.puntRing.StoreInterruptPending(0)
+	for i, ring := range r.client.puntRings {
+		ring.StoreTail(r.tails[i])
+		ring.StoreInterruptPending(0)
+	}
 }
 
 func (r *PuntReader) Wait() error {

--- a/pkg/dataplane/shm/punt_reader_test.go
+++ b/pkg/dataplane/shm/punt_reader_test.go
@@ -1,0 +1,163 @@
+package shm
+
+import (
+	"testing"
+	"unsafe"
+)
+
+// buildRegion lays out a v2 shm region by hand using the same offset
+// math the VPP plugin uses, so the test exercises the real header
+// parsing and per-ring pointer setup rather than a mock.
+func buildRegion(t *testing.T, nRings, ringSize, egressRingSize, slotSize uint32) *Client {
+	t.Helper()
+
+	ringHdrSize := uint32(unsafe.Sizeof(RingHeader{}))
+	puntDescSize := uint32(unsafe.Sizeof(PuntDesc{}))
+	egressDescSize := uint32(unsafe.Sizeof(EgressDesc{}))
+
+	stride := ringHdrSize + ringSize*puntDescSize
+
+	puntRingOffset := uint32(unsafe.Sizeof(ShmHeader{}))
+	egressRingOffset := puntRingOffset + nRings*stride
+	puntDataOffset := egressRingOffset + ringHdrSize + egressRingSize*egressDescSize
+	egressDataOffset := puntDataOffset + nRings*ringSize*slotSize
+	total := egressDataOffset + egressRingSize*slotSize
+
+	data := make([]byte, total)
+	c := &Client{shmData: data, shmSize: len(data)}
+
+	hdr := (*ShmHeader)(unsafe.Pointer(&data[0]))
+	hdr.Magic = ShmMagic
+	hdr.Version = ShmVersion
+	hdr.NPuntRings = nRings
+	hdr.PuntRingSize = ringSize
+	hdr.PuntRingStride = stride
+	hdr.PuntRingOffset = puntRingOffset
+	hdr.EgressRingOffset = egressRingOffset
+	hdr.EgressRingSize = egressRingSize
+	hdr.PuntDataOffset = puntDataOffset
+	hdr.EgressDataOffset = egressDataOffset
+	hdr.SlotSize = slotSize
+
+	if err := c.mapStructures(); err != nil {
+		t.Fatalf("mapStructures: %v", err)
+	}
+	return c
+}
+
+// publish writes one descriptor + its payload into ring `ring` at the
+// producer head and bumps the head, mimicking osvbng_punt_to_shm.
+func publish(c *Client, ring uint32, proto Protocol, swIfIndex uint32, payload []byte) {
+	head := c.puntRings[ring].LoadHead()
+	slot := head & RingMask(c.header.PuntRingSize)
+
+	dataOff := c.header.PuntDataOffset +
+		(ring*c.header.PuntRingSize+uint32(slot))*c.header.SlotSize
+	copy(c.shmData[dataOff:dataOff+uint32(len(payload))], payload)
+
+	desc := &c.puntDescs[ring][slot]
+	desc.DataOffset = dataOff
+	desc.SwIfIndex = swIfIndex
+	desc.DataLength = uint16(len(payload))
+	desc.Protocol = uint8(proto)
+
+	c.puntRings[ring].StoreHead(head + 1)
+	c.puntRings[ring].StoreInterruptPending(1)
+}
+
+func TestShmHeaderIs64Bytes(t *testing.T) {
+	if got := unsafe.Sizeof(ShmHeader{}); got != 64 {
+		t.Fatalf("ShmHeader size = %d, want 64", got)
+	}
+}
+
+func TestPuntReaderRefusesV1(t *testing.T) {
+	c := buildRegion(t, 2, 4, 4, 64)
+	c.header.Version = 1
+	if err := c.mapStructures(); err == nil {
+		t.Fatal("mapStructures accepted a v1 region")
+	}
+}
+
+func TestPuntReaderDrainsAllRings(t *testing.T) {
+	c := buildRegion(t, 3, 8, 8, 128)
+	r := NewPuntReader(c)
+
+	// Punt lands only on worker rings 1 and 2; ring 0 (main) stays empty,
+	// the exact shape the live ARP smoke test produced.
+	publish(c, 1, ProtoARP, 10, []byte("arp-a"))
+	publish(c, 2, ProtoDHCPv4, 20, []byte("dhcp-b"))
+	publish(c, 1, ProtoARP, 11, []byte("arp-c"))
+
+	seen := map[string]uint32{}
+	for {
+		pkt, ok := r.Read()
+		if !ok {
+			break
+		}
+		seen[string(pkt.Data)] = pkt.SwIfIndex
+	}
+
+	if len(seen) != 3 {
+		t.Fatalf("drained %d packets, want 3: %v", len(seen), seen)
+	}
+	if seen["arp-a"] != 10 || seen["arp-c"] != 11 || seen["dhcp-b"] != 20 {
+		t.Fatalf("wrong sw_if_index mapping: %v", seen)
+	}
+
+	// Commit must advance every ring tail to its head and clear the
+	// interrupt flag so the next 0->1 edge re-signals.
+	r.Commit()
+	for i, ring := range c.puntRings {
+		if h, tl := ring.LoadHead(), ring.LoadTail(); h != tl {
+			t.Fatalf("ring %d not drained: head=%d tail=%d", i, h, tl)
+		}
+		if ring.LoadInterruptPending() != 0 {
+			t.Fatalf("ring %d interrupt not cleared", i)
+		}
+	}
+}
+
+func TestPuntReaderRoundRobinFairness(t *testing.T) {
+	c := buildRegion(t, 2, 8, 8, 64)
+	r := NewPuntReader(c)
+
+	// Ring 0 is backlogged; ring 1 has one packet. Round-robin must not
+	// let ring 0 starve ring 1.
+	for i := 0; i < 4; i++ {
+		publish(c, 0, ProtoARP, 100, []byte{byte('0'), byte('a' + i)})
+	}
+	publish(c, 1, ProtoARP, 200, []byte("1x"))
+
+	first, ok := r.Read()
+	if !ok {
+		t.Fatal("expected a packet")
+	}
+	// cur starts at 0, so the first Read pulls from ring 0, then advances
+	// cur to ring 1; the second Read must come from ring 1.
+	second, ok := r.Read()
+	if !ok {
+		t.Fatal("expected a second packet")
+	}
+	if first.SwIfIndex != 100 || second.SwIfIndex != 200 {
+		t.Fatalf("round-robin broken: first=%d second=%d", first.SwIfIndex, second.SwIfIndex)
+	}
+}
+
+func TestPuntReaderBatchAcrossRings(t *testing.T) {
+	c := buildRegion(t, 3, 8, 8, 64)
+	r := NewPuntReader(c)
+
+	publish(c, 0, ProtoARP, 1, []byte("a"))
+	publish(c, 1, ProtoARP, 2, []byte("b"))
+	publish(c, 2, ProtoARP, 3, []byte("c"))
+
+	batch := r.ReadBatch(10)
+	if len(batch) != 3 {
+		t.Fatalf("batch drained %d, want 3", len(batch))
+	}
+
+	if got := r.ReadBatch(10); got != nil {
+		t.Fatalf("expected empty batch after drain, got %d", len(got))
+	}
+}

--- a/pkg/dataplane/shm/types.go
+++ b/pkg/dataplane/shm/types.go
@@ -6,8 +6,11 @@ import (
 )
 
 const (
-	ShmMagic   = 0x4F53564E47424E47
-	ShmVersion = 1
+	ShmMagic = 0x4F53564E47424E47
+	// Version 2: one punt ring per VPP thread (was a single ring shared
+	// by every worker, a publish race). The egress ring stays single.
+	// This reader refuses a v1 region rather than misread its header.
+	ShmVersion = 2
 
 	DefaultPuntRingSize   = 4096
 	DefaultEgressRingSize = 4096
@@ -32,19 +35,23 @@ const (
 	ProtoCount       Protocol = 8
 )
 
+// ShmHeader mirrors osvbng_shm_header_t (v2) byte for byte. One punt
+// ring per VPP thread laid out at PuntRingOffset with PuntRingStride
+// between them; a single egress ring; punt data slots for every ring
+// then the egress data slots.
 type ShmHeader struct {
 	Magic            uint64
 	Version          uint32
 	Flags            uint32
-	PuntRingOffset   uint32
+	NPuntRings       uint32
 	PuntRingSize     uint32
+	PuntRingStride   uint32
+	PuntRingOffset   uint32
 	EgressRingOffset uint32
 	EgressRingSize   uint32
-	DataRegionOffset uint32
-	DataRegionSize   uint32
+	PuntDataOffset   uint32
+	EgressDataOffset uint32
 	SlotSize         uint32
-	PuntDataSlots    uint32
-	EgressDataSlots  uint32
 	Reserved         [12]byte
 }
 


### PR DESCRIPTION
## Problem

The shm punt reader assumed a single punt ring. The VPP plugin shared that one
ring across every worker, which is a multi-writer publish race on any
`corelist-workers` deployment (see veesix-networks/osvbng-vpp). The fix on the
plugin side is one ring per VPP thread, which changes the shm layout, so the
daemon has to parse the new header and drain every ring.

## Change

Shared memory protocol goes to version 2:

- `ShmHeader` mirrors the v2 `osvbng_shm_header_t` byte for byte: `n_punt_rings`,
  `punt_ring_stride`, and split `punt_data_offset` / `egress_data_offset`
  replace the single-ring and single data-region fields.
- The client maps one ring plus descriptor array per thread at
  `PuntRingOffset + t * PuntRingStride`. Punt descriptors carry an absolute
  data offset, so reads need no per-ring data base.
- `PuntReader` keeps a tail per ring and drains them round-robin so no busy ring
  starves the others; `Commit` advances every ring's tail and clears every
  ring's interrupt flag. `Read`, `ReadBatch`, and `Available` span all rings.
- The reader refuses a v1 region (`ShmVersion` is now 2); v1 and v2 do not
  interoperate.

## Coordination

Paired change with the plugin
(veesix-networks/osvbng-vpp `feat/per-worker-punt-rings`). Land together: the
version check makes a mixed pair fail closed rather than misread.

## Test

New `pkg/dataplane/shm/punt_reader_test.go` builds a v2 region by hand with the
same offset math the plugin uses and covers: the 64-byte header layout, v1
refusal, draining packets that land only on worker rings (the shape the live
plugin smoke test produced), round-robin fairness, and batch drain across rings.
`go build ./...`, `go vet`, and the package tests pass.
