### PR TITLE
build: add make bump-submodules to move vpp and context pins to main

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "vpp"]
 	path = vpp
 	url = git@github.com:veesix-networks/osvbng-vpp.git
+	branch = main
 [submodule "context"]
 	path = context
 	url = git@github.com:veesix-networks/osvbng-context.git
+	branch = main

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Licensed under the GNU General Public License v3.0 or later.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-.PHONY: all build generate generate-proto clean run test cli build-cli docker-local docker-kea-local lint fmt robot-test clean-branches dev-vm dev-vm-sync validate-artifacts tarball-smoke
+.PHONY: all build generate generate-proto clean run test cli build-cli docker-local docker-kea-local lint fmt robot-test clean-branches dev-vm dev-vm-sync validate-artifacts tarball-smoke bump-submodules
 
 all: generate build
 
@@ -78,6 +78,17 @@ clean-branches:
 	git branch --format='%(refname:short)' | grep -v '^main$$' | while read branch; do \
 		git show-ref --verify --quiet "refs/remotes/origin/$$branch" || git branch -D "$$branch"; \
 	done
+
+# osvbng pins vpp and context at exact commits so a checkout builds
+# reproducibly. Pushing to those repos does not move the pin; this moves
+# it to the latest main of each (branch set in .gitmodules) and stages
+# the bump. Adopt deliberately: commit the result on a branch and PR it,
+# and keep the vpp and context bumps together when a change spans both.
+bump-submodules:
+	git submodule update --remote --init vpp context
+	@git add vpp context
+	@git submodule status vpp context
+	@echo "pins staged; commit on a branch and open a PR to adopt them"
 
 dev-vm:
 	@scripts/dev/dev-vm.sh


### PR DESCRIPTION
## Problem

osvbng pins the vpp and context submodules at exact commits. Pushing to
either child repo does not move the pin, and there was no one-command way to
adopt the latest, so a merged plugin or context change silently did not reach
osvbng until someone hand-updated the gitlink. The pins are stale right now:
vpp points at an ancestor of its current main.

## Change

- `.gitmodules` records `branch = main` for both submodules, so
  `git submodule update --remote` tracks main explicitly.
- `make bump-submodules` moves both pins to the latest main and stages the
  gitlink change. It does not commit: adopting a new dataplane or context is
  deliberate, so the bump lands on a branch by PR like any other change, and
  the vpp and context bumps stay together when a change spans both.

Pinning is kept on purpose; this only removes the friction of bumping. A given
osvbng checkout still determines exactly which vpp and context it was built
against.

## Test

Ran `make bump-submodules` on the stale tree: it moved the vpp pin from
bf05f31 to the current main and staged the gitlink, context already current.
Reverted the pin for this PR, which is the tooling only.
