### PR TITLE
fix(dhcpv6): send LDRA Relay-Reply to port 547, not 546

### DIFF
--- a/internal/ipoe/dhcpv6.go
+++ b/internal/ipoe/dhcpv6.go
@@ -747,7 +747,12 @@ func (c *Component) sendDHCPv6Response(sess *SessionState, rawDHCPv6 []byte) err
 		return fmt.Errorf("no client link-local address for session %s", sess.SessionID)
 	}
 
-	frame := dhcp.BuildIPv6UDPFrame(srcIP, dstIP, 547, 546, rawDHCPv6)
+	dstPort := uint16(546)
+	if len(rawDHCPv6) > 0 && dhcp6.MessageType(rawDHCPv6[0]) == dhcp6.MsgTypeRelayReply {
+		dstPort = 547
+	}
+
+	frame := dhcp.BuildIPv6UDPFrame(srcIP, dstIP, 547, dstPort, rawDHCPv6)
 	if frame == nil {
 		return fmt.Errorf("failed to build IPv6/UDP frame")
 	}


### PR DESCRIPTION
Found this bug when testing DHCPv6 on NBN in AU. They use LDRA's to inject Interface-ID information.

An LDRA has no address of its own. It reuses the client’s link-local and listens on 547, because it is a relay agent. RFC 9915 §7.2 is the normative rule:

> Clients MUST listen for DHCP messages on UDP port 546. Servers and relay agents MUST listen for DHCP messages on UDP port 547.

A Relay-Reply must therefore go back to 547 so the LDRA can strip the wrapper and hand the inner message to the client on 546. 