### PR TITLE
fix(qos): convert AAA download-rate from bps to kbps without truncation

### DIFF
--- a/internal/subscriber/component.go
+++ b/internal/subscriber/component.go
@@ -502,7 +502,9 @@ func (c *Component) activateSession(sess models.SubscriberSession) error {
 	if egress != nil && egress.Scheduler != nil {
 		downloadRate := egress.CIR
 		if sg.QoS.DownloadRate > 0 {
-			downloadRate = uint32(sg.QoS.DownloadRate)
+			// DownloadRate is bps (docs/configuration/service-groups.md);
+			// the scheduler takes kbps.
+			downloadRate = uint32(sg.QoS.DownloadRate / 1000)
 		}
 
 		if downloadRate > 0 {

--- a/pkg/svcgroup/apply.go
+++ b/pkg/svcgroup/apply.go
@@ -89,7 +89,9 @@ func ApplyToSession(sb PolicyApplier, swIfIndex uint32, sg ServiceGroup, qosPoli
 	if egress != nil && egress.Scheduler != nil {
 		downloadRate := egress.CIR
 		if sg.DownloadRate > 0 {
-			downloadRate = uint32(sg.DownloadRate)
+			// DownloadRate is bps (docs/configuration/service-groups.md);
+			// the scheduler takes kbps.
+			downloadRate = uint32(sg.DownloadRate / 1000)
 		}
 		if downloadRate > 0 {
 			if err := sb.ApplyScheduler(swIfIndex, downloadRate, egress.Scheduler); err != nil {

--- a/pkg/svcgroup/apply_test.go
+++ b/pkg/svcgroup/apply_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 The osvbng Authors
+// Licensed under the GNU General Public License v3.0 or later.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package svcgroup
+
+import (
+	"testing"
+
+	"github.com/veesix-networks/osvbng/pkg/config/qos"
+)
+
+type fakeApplier struct {
+	schedulerCalls int
+	schedulerRate  uint32
+}
+
+func (f *fakeApplier) ApplyIngressACL(uint32, string) error            { return nil }
+func (f *fakeApplier) ApplyEgressACL(uint32, string) error             { return nil }
+func (f *fakeApplier) RemoveIngressACL(uint32) error                   { return nil }
+func (f *fakeApplier) RemoveEgressACL(uint32) error                    { return nil }
+func (f *fakeApplier) EnableSourceVerify(uint32, bool) error           { return nil }
+func (f *fakeApplier) DisableSourceVerify(uint32) error                { return nil }
+func (f *fakeApplier) ApplyQoS(uint32, *qos.Policy, *qos.Policy) error { return nil }
+func (f *fakeApplier) RemoveQoS(uint32) error                          { return nil }
+func (f *fakeApplier) RemoveScheduler(uint32) error                    { return nil }
+
+func (f *fakeApplier) ApplyScheduler(_ uint32, rateKbps uint32, _ *qos.SchedulerConfig) error {
+	f.schedulerCalls++
+	f.schedulerRate = rateKbps
+	return nil
+}
+
+// The service-group DownloadRate is bps (docs/configuration/service-groups.md);
+// ApplyScheduler takes kbps. A 10 Gbit/s AAA ad-hoc rate must arrive as
+// 10,000,000 kbps, not be truncated through uint32 or passed through as bps.
+func TestApplyToSessionDownloadRateBpsToKbps(t *testing.T) {
+	sb := &fakeApplier{}
+	sg := ServiceGroup{
+		Name:         "test",
+		QoSEgress:    "plan",
+		DownloadRate: 10_000_000_000,
+	}
+	policies := map[string]*qos.Policy{
+		"plan": {CIR: 100_000, Scheduler: &qos.SchedulerConfig{}},
+	}
+
+	if err := ApplyToSession(sb, 1, sg, policies); err != nil {
+		t.Fatalf("ApplyToSession: %v", err)
+	}
+	if sb.schedulerCalls != 1 {
+		t.Fatalf("ApplyScheduler calls = %d, want 1", sb.schedulerCalls)
+	}
+	if sb.schedulerRate != 10_000_000 {
+		t.Errorf("scheduler rate = %d kbps, want 10000000", sb.schedulerRate)
+	}
+}
+
+func TestApplyToSessionSchedulerRateFallsBackToCIR(t *testing.T) {
+	sb := &fakeApplier{}
+	sg := ServiceGroup{
+		Name:      "test",
+		QoSEgress: "plan",
+	}
+	policies := map[string]*qos.Policy{
+		"plan": {CIR: 100_000, Scheduler: &qos.SchedulerConfig{}},
+	}
+
+	if err := ApplyToSession(sb, 1, sg, policies); err != nil {
+		t.Fatalf("ApplyToSession: %v", err)
+	}
+	if sb.schedulerCalls != 1 {
+		t.Fatalf("ApplyScheduler calls = %d, want 1", sb.schedulerCalls)
+	}
+	if sb.schedulerRate != 100_000 {
+		t.Errorf("scheduler rate = %d kbps, want CIR passthrough 100000", sb.schedulerRate)
+	}
+}


### PR DESCRIPTION
## Problem

`ServiceGroup.DownloadRate` is documented as bits per second (`docs/configuration/service-groups.md`, `docs/configuration/provisioning.md`), but both scheduler-apply paths cast it straight to `uint32` and passed it as the `rateKbps` argument of `ApplyScheduler`. Two bugs stacked: any rate above 4.29 Gbit/s wrapped through the cast (10 Gbit/s became 1,410,065,408), and the surviving value was then interpreted as kbps, 1000x too high, leaving AAA ad-hoc rates effectively unshaped.

## Fix

Divide by 1000 at both call sites (`pkg/svcgroup/apply.go`, `internal/subscriber/component.go` - the latter still serves HA-restored and L2TP-LNS sessions) so a 10 Gbit/s attribute programs a 10,000,000 kbps scheduler. No interface or northbound schema changes: after conversion, `uint32` kbps reaches ~4.29 Tbit/s, so 10/40/100G rates fit without widening.

Note for operators: anyone who has been supplying `download-rate` in kbps to match the old behaviour will see rates change - the documented bps unit is now authoritative.

## Testing

New `pkg/svcgroup/apply_test.go` with a fake `PolicyApplier`: asserts the bps-to-kbps conversion (failed with `scheduler rate = 1410065408 kbps, want 10000000` before the fix) and the CIR fallback passthrough. Full unit suite (`go test` over all packages except generated `/pkg/vpp/`) passes in a `golang:1.24` container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYazH57aDR4kpdhHR7eqQg