### PR TITLE
docs: correct configuration examples and stale capability claims

### DIFF
--- a/docs/configuration/cgnat.md
+++ b/docs/configuration/cgnat.md
@@ -3,9 +3,9 @@
 !!! warning
     CGNAT is under active development and not yet feature-complete. PBA mode is functional for IPoE and PPPoE. Deterministic mode, ALG, IPFIX logging, HA sync, and standalone CGNAT mode are not yet available. This documentation may be incomplete. Full CGNAT support is planned for v0.6.0.
 
-Carrier-Grade NAT enables multiple subscribers to share a smaller pool of public IPv4 addresses. osvbng supports two NAT modes: Port Block Allocation (PBA) and Deterministic. Pools can be assigned per subscriber group or per subscriber via AAA, with NAT bypass for public IP customers and configurable session timeouts.
+Carrier-Grade NAT enables multiple subscribers to share a smaller pool of public IPv4 addresses. osvbng supports two NAT modes: Port Block Allocation (PBA) and Deterministic, with NAT bypass for public IP customers and configurable session timeouts.
 
-CGNAT is assigned to subscribers through [subscriber groups](subscriber-groups.md) or [service groups](service-groups.md), and can be overridden per subscriber via AAA.
+A session is bound to a pool either by the [service group](service-groups.md) it resolves to, or by matching the subscriber's inside address against a pool's `inside-prefixes`. See [pool selection](#pool-selection).
 
 ## Outside interfaces
 
@@ -77,7 +77,7 @@ cgnat:
         - 198.51.100.0/24
 ```
 
-The CGNAT plugin keys mappings on `(inside_ip, inside_fib_index)` and stores per-pool outside FIB indices, so sessions from ISP A and ISP B are isolated end-to-end even with overlapping inside addresses. Subscribers map to a specific pool via [subscriber groups](subscriber-groups.md) or [service groups](service-groups.md).
+The CGNAT plugin keys mappings on `(inside_ip, inside_fib_index)` and stores per-pool outside FIB indices, so sessions from ISP A and ISP B are isolated end-to-end even with overlapping inside addresses. With overlapping inside space the pool must be pinned by [service group](service-groups.md) unless each customer sits in its own VRF, since the inside prefixes alone no longer identify the pool.
 
 An outside interface may appear in more than one pool's list, but only if those pools target the same outside VRF.
 
@@ -180,30 +180,26 @@ cgnat:
 !!! note
     Deterministic mode translation is not yet available. Configuration is accepted but translation will not occur until a future release.
 
-## Subscriber Assignment
+## Pool selection
 
-### Via subscriber group
+A session is classified once, at activation, in this order:
 
-Assign a CGNAT pool to all subscribers in a group:
+1. The subscriber's [service group](service-groups.md), if it carries a `cgnat` block. `bypass: true` wins outright; otherwise `policy` names the pool.
+2. The inside address, matched against every pool's `inside-prefixes` in the session's VRF.
 
-```yaml
-subscriber-groups:
-  groups:
-    default:
-      access-types: [ipoe]
-      ipv4-profile: shared-pool
-      vlans:
-        - svlan: "100-110"
-          cvlan: any
-          interface: loop100
-      aaa-policy: default-policy
-      cgnat:
-        policy: residential
-```
+If neither matches, the session is not translated.
+
+!!! note
+    The `cgnat` block on a subscriber group is parsed but never read. Use a service group or inside-prefix matching. There is no AAA attribute for CGNAT policy or bypass either, so AAA cannot set the pool directly; it can only place the subscriber in a different service group via the `service-group` attribute.
 
 ### Via service group
 
-Service groups support both policy assignment and bypass. See [service groups](service-groups.md) for full details on attribute merging and AAA override.
+A service group is the explicit way to pin subscribers to a pool or exempt them from NAT. See [service groups](service-groups.md) for how service groups are selected and merged.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `policy` | string | Name of the `cgnat.pools` entry to use for subscribers in this group |
+| `bypass` | bool | Skip translation for subscribers in this group |
 
 ```yaml
 service-groups:
@@ -216,13 +212,25 @@ service-groups:
       bypass: true
 ```
 
+### Via inside prefix
+
+With no service-group `cgnat` block, the subscriber's inside address selects the pool. This is the usual arrangement when subscriber addressing already separates the NATed ranges from the public ones.
+
+```yaml
+cgnat:
+  pools:
+    residential:
+      inside-prefixes:
+        - prefix: 100.64.0.0/16
+```
+
+A subscriber addressed out of `100.64.0.0/16` lands in the `residential` pool; a subscriber with a public address matches no pool and is forwarded untranslated.
+
+Inside-prefix matching is VRF-aware: a prefix entry with a `vrf` only matches sessions in that VRF.
+
 ### Bypass
 
 When `bypass: true` is set on a service group, the subscriber's address is added to the NAT bypass table. Traffic from bypass subscribers passes through without translation. This is used for business customers with public IP addresses.
-
-### AAA override
-
-AAA can assign a CGNAT policy or enable bypass per subscriber, overriding the subscriber group or service group defaults.
 
 ## Outside address advertisement
 
@@ -259,7 +267,7 @@ curl "http://localhost:8080/api/show/cgnat/sessions?inside-ip=100.64.0.2"
 curl http://localhost:8080/api/show/cgnat/mappings
 curl http://localhost:8080/api/show/cgnat/statistics
 curl "http://localhost:8080/api/show/cgnat/lookup?ip=203.0.113.1&port=2048"
-curl -X POST http://localhost:8080/api/oper/cgnat/test-mapping -d '{"inside_ip": "100.64.0.2"}'
+curl -X POST http://localhost:8080/api/exec/cgnat/test-mapping -d '{"inside_ip": "100.64.0.2"}'
 ```
 
 ## Full example
@@ -289,15 +297,14 @@ cgnat:
 subscriber-groups:
   groups:
     default:
-      access-types: [ipoe]
       ipv4-profile: shared-pool
       vlans:
         - svlan: "100-110"
           cvlan: any
+          access-types: [ipoe]
           interface: loop100
+          parent-interface: eth1
       aaa-policy: default-policy
-      cgnat:
-        policy: residential
 
 service-groups:
   business:

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -19,6 +19,8 @@ osvbngd config > /etc/osvbng/osvbng.yaml
 - [DHCP](dhcp.md) - DHCPv4 provider configuration
 - [DHCPv6](dhcpv6.md) - DHCPv6 provider configuration
 - [AAA](aaa.md) - Authentication and policies
+- [L2TP](l2tp.md) - L2TPv2 tunnel pools, profiles, and peer policies
+- [L2GW (L2 Wholesale)](l2gw.md) - Layer 2 wholesale cross-connects and handoff groups
 - [CGNAT](cgnat.md) - Carrier-Grade NAT with PBA and Deterministic modes
 - [QoS Policies](qos.md) - Per-subscriber rate limiting (policer) and traffic shaping (CAKE scheduler)
 - [Service Groups](service-groups.md) - Named per-subscriber attribute bundles (VRF, ACL, QoS)
@@ -27,6 +29,7 @@ osvbngd config > /etc/osvbng/osvbng.yaml
 - [Routing Policies](routing-policies.md) - Prefix-sets, community-sets, AS-path-sets, route-policies
 - [Protocols](protocols.md) - BGP, OSPF, OSPFv3, IS-IS, static routes
 - [MPLS](mpls.md) - LDP, Segment Routing, SRv6 (in development)
+- [High Availability](ha.md) - Active/standby nodes and Subscriber Redundancy Groups
 - [System](system.md) - System-level settings and control plane protection
 - [Monitoring](monitoring.md) - Metrics collection
 - [Plugins](plugins.md) - Plugin configuration

--- a/docs/configuration/l2tp.md
+++ b/docs/configuration/l2tp.md
@@ -1,12 +1,16 @@
 # L2TP
 
-L2TPv2 (RFC 2661) configuration. osvbng supports the **LAC** role — terminating
-PPPoE locally and tunnelling the subscriber's PPP frames over L2TP to a remote
-LNS. The LNS role is on the roadmap.
+L2TPv2 (RFC 2661) configuration. osvbng supports both roles:
 
-The block configures three things: per-LNS endpoint pools (`tunnel-pools`),
-behavioural profiles (`profiles`), and authorization for inbound LAC peers
-(`peer-policies`, LNS-only).
+- **LAC**: terminate PPPoE locally and tunnel the subscriber's PPP frames over
+  L2TP to a remote LNS.
+- **LNS**: accept tunnels from remote LACs, terminate the PPP session, and
+  address the subscriber from local pools.
+
+The block configures three things: per-LNS endpoint pools (`tunnel-pools`,
+LAC-only), behavioural profiles (`profiles`), and authorization for inbound LAC
+peers (`peer-policies`, LNS-only). A subscriber group selects the role through
+its `access-types` and binds a profile through `l2tp.profile`.
 
 ## `l2tp.tunnel-pools`
 
@@ -91,12 +95,18 @@ Binds a subscriber group to an L2TP profile.
 |-------|------|-------------|
 | `profile` | string | Name of the `l2tp.profiles` entry. |
 
-For `access-types: [lac]` the AAA policy attached to the group maps the
+A LAC group declares `access-types: [lac]` on each `vlans` entry, like any
+other subscriber-facing protocol. The AAA policy attached to the group maps the
 subscriber to Tunnel-* attributes (local DB by `agent-remote-id` /
-username, or RADIUS Access-Accept). For `access-types: [lns]` the
-subscriber-group's `default-service-group` selects the loopback used as
-unnumbered for per-session vnet interfaces (must point at a configured
-service group with an `unnumbered` field).
+username, or RADIUS Access-Accept).
+
+An LNS group is the one case that declares `access-types: [lns]` at group level
+and must not declare `vlans` at all: LNS subscribers arrive inside an L2TP
+tunnel, not over an SVLAN. The group's `default-service-group` selects the
+loopback used as unnumbered for per-session vnet interfaces, so it must point at
+a service group carrying an `unnumbered` field. Any other placement is rejected
+at load: group-level `access-types` is valid only for LNS-only groups, and every
+other protocol declares `access-types` per VLAN range.
 
 ## AAA contract (RFC 2868)
 
@@ -117,18 +127,19 @@ Attributes can be tagged (e.g. `tunnel.server-endpoint:1`,
 Access-Accept; the LAC tries them in `Tunnel-Preference` order and
 denylists failures per the profile's `denylist` block.
 
-## Example
+## LAC example
 
 ```yaml
 subscriber-groups:
   groups:
     pppoe-lac:
-      access-types: [lac]
       vlan-tpid: dot1q
       vlans:
         - svlan: "200-210"
           cvlan: any
+          access-types: [lac]
           interface: loop100
+          parent-interface: eth1
       aaa-policy: pppoe-policy
       l2tp:
         profile: L2TP_LAC_DEFAULT
@@ -165,6 +176,53 @@ aaa:
       max_concurrent_sessions: 1
 ```
 
+## LNS example
+
+No `tunnel-pools` block: the LNS does not originate tunnels. The group carries
+group-level `access-types` and no `vlans`, and `default-service-group` supplies
+the unnumbered loopback for per-session interfaces.
+
+```yaml
+service-groups:
+  lns-default:
+    unnumbered: loop100
+
+subscriber-groups:
+  groups:
+    lns:
+      access-types: [lns]
+      ipv4-profile: default
+      ipv6-profile: default-v6
+      aaa-policy: lns-policy
+      default-service-group: lns-default
+      l2tp:
+        profile: LNS_DEFAULT
+
+l2tp:
+  profiles:
+    LNS_DEFAULT:
+      receive-window-size: 16
+      hello-interval: 60s
+      challenge-required: false
+      proxy-lcp-mode: forward
+  peer-policies:
+    xl2tpd:
+      hostname: "lac"
+      secret: "shared"
+      profile: LNS_DEFAULT
+
+aaa:
+  auth_provider: local
+  nas_identifier: osvbng
+  policy:
+    # LNS mode: osvbng terminates PPP, so it authenticates the subscriber
+    # itself unless the LAC forwarded proxy-auth AVPs.
+    - name: lns-policy
+      type: ppp
+      authenticate: true
+      max_concurrent_sessions: 1
+```
+
 ## Show commands
 
 ```
@@ -181,6 +239,7 @@ alongside the existing PPPoE fields rather than as a separate listing.
 ## See also
 
 - [LAC deployment example](../examples/l2tp-lac.md)
+- [LNS deployment example](../examples/l2tp-lns.md)
 - [AAA configuration](aaa.md)
 - [Subscriber groups](subscriber-groups.md)
 - RFC 2661, RFC 2868, RFC 3437

--- a/docs/configuration/logging.md
+++ b/docs/configuration/logging.md
@@ -18,6 +18,8 @@ Available components for per-component log levels:
 | `aaa` | AAA (authentication, authorization, accounting) |
 | `ipoe` | IPoE sessions |
 | `pppoe` | PPPoE sessions |
+| `l2tp` | L2TPv2 tunnels and sessions (LAC and LNS) |
+| `l2gw` | Layer 2 wholesale gateway |
 | `arp` | ARP handling |
 | `dataplane` | Dataplane management |
 | `subscriber` | Subscriber management |
@@ -26,11 +28,16 @@ Available components for per-component log levels:
 | `egress` | Egress processing |
 | `events` | Event system |
 | `srg` | Session Redundancy Group |
+| `ha` | High availability |
+| `cgnat` | CGNAT |
+| `watchdog` | Watchdog and health endpoints |
 | `bootstrap` | Bootstrap/startup |
 | `monitor` | Monitoring |
 | `confmgr` | Configuration manager |
 | `gateway` | Gateway |
-| `northbound` | Northbound interface |
+| `nb` | Northbound interface |
+| `svcgroup` | Service groups |
+| `telemetry` | Telemetry registry |
 | `dhcp4` | IPoE DHCPv4 |
 | `dhcp6` | IPoE DHCPv6 |
 | `session` | IPoE session handling |

--- a/docs/configuration/monitoring.md
+++ b/docs/configuration/monitoring.md
@@ -1,17 +1,16 @@
 # Monitoring
 
-Metrics collection configuration.
+There is nothing to configure here. Metrics collection has no operator knobs.
 
-| Field | Type | Description | Example |
-|-------|------|-------------|---------|
-| `disabled_collectors` | array | Collectors to disable | `[memory]` |
-| `collect_interval` | duration | Collection interval | `10s` |
+Show handlers register the metrics they can produce with the telemetry registry at startup. The registry polls every registered handler on a fixed 10 second cadence and caches the result. Handlers whose component is disabled return nothing and are skipped, so metrics appear only for the features actually in use.
 
-## Example
+Exposing those metrics is a plugin's job. Enable [`exporter.prometheus`](plugins/exporter-prometheus.md) to serve them for scraping:
 
 ```yaml
-monitoring:
-  collect_interval: 10s
-  disabled_collectors:
-    - memory
+plugins:
+  exporter.prometheus:
+    enabled: true
+    listen_address: ":9090"
 ```
+
+The `monitoring` block in `osvbng.yaml` is accepted by the config loader for backwards compatibility, but neither `collect_interval` nor `disabled_collectors` is read by anything. Setting them has no effect.

--- a/docs/configuration/mpls.md
+++ b/docs/configuration/mpls.md
@@ -1,12 +1,100 @@
 # MPLS <span class="version-badge">v0.2.0</span>
 
-!!! warning "In development"
-    MPLS is currently in development. This page documents the planned capabilities.
+MPLS label switching. osvbng uses [FRR](https://docs.frrouting.org/) as the control plane and VPP as the dataplane. Labels are distributed by LDP; transport labels combine with BGP VPN labels to carry [L3VPN](../examples/l3vpn.md) traffic.
 
-MPLS configuration for label switching, traffic engineering, and segment routing. osvbng uses [FRR](https://docs.frrouting.org/) as the control plane and VPP as the dataplane.
+Enabling MPLS creates the MPLS FIB, sets the kernel platform label limit, and enables MPLS forwarding on every interface that runs OSPF or IS-IS. There is no per-interface MPLS key: the IGP interface set is the MPLS interface set.
 
-## Planned Capabilities
+## `protocols.mpls`
 
-- **LDP** — Label Distribution Protocol for automatic label assignment and distribution
-- **Segment Routing (IS-IS)** — Segment Routing with IS-IS as per [RFC 8667](https://datatracker.ietf.org/doc/html/rfc8667)
-- **SRv6** — Segment Routing over IPv6
+| Field | Type | Default | Description | Example |
+|-------|------|---------|-------------|---------|
+| `enabled` | bool | `false` | Enable MPLS forwarding in the dataplane | `true` |
+| `platform-labels` | uint32 | `1048575` | Highest usable platform label. Must be at least 16 | `1048575` |
+
+```yaml
+protocols:
+  mpls:
+    enabled: true
+```
+
+## `protocols.ldp`
+
+Label Distribution Protocol. Fields follow [FRR LDP conventions](https://docs.frrouting.org/en/latest/ldpd.html). LDP requires `protocols.mpls.enabled: true`.
+
+| Field | Type | Description | Example |
+|-------|------|-------------|---------|
+| `enabled` | bool | Enable the LDP instance | `true` |
+| `router-id` | string | LDP router ID in A.B.C.D format | `10.254.0.1` |
+| `address-families` | [LDPAddressFamilies](#ldp-address-families) | Per-address-family transport and label advertisement | |
+| `discovery-hello-holdtime` | uint32 | Hold time advertised in discovery Hellos, in seconds | `15` |
+| `discovery-hello-interval` | uint32 | Interval between discovery Hellos, in seconds | `5` |
+| `ordered-control` | bool | Use ordered label distribution control instead of independent | `true` |
+| `dual-stack-prefer-ipv4` | bool | Prefer IPv4 for the transport connection when both families are configured | `true` |
+| `neighbors` | [LDPNeighbor](#ldp-neighbors) | Per-neighbor overrides, keyed by neighbor LSR ID | |
+
+### LDP Address Families
+
+Keys are `ipv4` and `ipv6`. An address family must be present for LDP to run over it. The interfaces enrolled in each address family are taken from the non-passive OSPF and IS-IS interfaces, not listed here.
+
+| Field | Type | Description | Example |
+|-------|------|-------------|---------|
+| `transport-address` | string | Address advertised as the LDP transport endpoint. Normally the loopback carrying the router ID | `10.254.0.1` |
+| `label-local-advertise` | string | Passed through to FRR's `label local advertise` for this address family | `explicit-null` |
+
+### LDP Neighbors
+
+Keyed by the neighbor's LSR ID.
+
+| Field | Type | Description | Example |
+|-------|------|-------------|---------|
+| `password` | string | TCP MD5 signature (RFC 2385) for the session with this neighbor | `s3cret` |
+| `session-holdtime` | uint32 | Session hold time for this neighbor, in seconds | `180` |
+
+## Example
+
+```yaml
+protocols:
+  mpls:
+    enabled: true
+  ldp:
+    enabled: true
+    router-id: 10.254.0.1
+    address-families:
+      ipv4:
+        transport-address: 10.254.0.1
+  ospf:
+    enabled: true
+    router-id: 10.254.0.1
+    areas:
+      "0.0.0.0":
+        interfaces:
+          eth1:
+            network: point-to-point
+          loop0:
+            passive: true
+```
+
+`eth1` runs OSPF and is therefore MPLS-enabled and enrolled in LDP. `loop0` is passive, so it is MPLS-enabled but does not form LDP adjacencies.
+
+## Show commands
+
+| Path | Description |
+|------|-------------|
+| `protocols.mpls.table` | MPLS forwarding table |
+| `protocols.mpls.interfaces` | Interfaces with MPLS forwarding enabled |
+| `protocols.ldp.neighbors` | LDP neighbors, with `detail` and `capabilities` sub-paths |
+| `protocols.ldp.bindings` | Label bindings, filterable by prefix |
+| `protocols.ldp.discovery` | Discovery Hello adjacencies |
+| `protocols.ldp.capabilities` | Capabilities advertised by this LSR |
+| `protocols.ldp.igp-sync` | LDP/IGP synchronisation state |
+| `protocols.ldp.interface` | Per-interface LDP state |
+
+## Not implemented
+
+Segment Routing (SR-MPLS and SRv6) is not configurable. There is no `segment-routing` block in the config schema, and neither IS-IS nor OSPF accepts SR parameters.
+
+## See also
+
+- [MPLS L3VPN example](../examples/l3vpn.md)
+- [Protocols](protocols.md) for BGP VPN address families and IGP configuration
+- [VRFs](vrfs.md)

--- a/docs/configuration/qos.md
+++ b/docs/configuration/qos.md
@@ -111,18 +111,18 @@ service-groups:
 View active CAKE scheduler state via the show API:
 
 ```bash
-curl http://localhost:8080/api/show/qos.scheduler
+curl http://localhost:8080/api/show/qos/scheduler
 ```
 
 Modify or disable a scheduler at runtime via the operational API:
 
 ```bash
 # Change rate
-curl -X POST http://localhost:8080/api/oper/qos.scheduler.set \
+curl -X POST http://localhost:8080/api/exec/qos/scheduler/set \
   -d '{"sw_if_index": 5, "rate_kbps": 200000, "tin_mode": "diffserv4"}'
 
 # Disable
-curl -X POST http://localhost:8080/api/oper/qos.scheduler.set \
+curl -X POST http://localhost:8080/api/exec/qos/scheduler/set \
   -d '{"sw_if_index": 5, "disable": true}'
 ```
 

--- a/docs/configuration/subscriber-groups.md
+++ b/docs/configuration/subscriber-groups.md
@@ -1,22 +1,47 @@
 # Subscriber Groups
 
-Defines how subscribers are grouped and configured based on VLAN. Each group binds a set of VLANs to one or more access types (IPoE, PPPoE, LAC, LNS), address profiles, service group, and AAA policy. Both IPoE and PPPoE sessions use the same profile and service group resolution.
+Defines how subscribers are grouped and configured based on VLAN. Each group binds a set of VLANs to one or more access types (IPoE, PPPoE, LAC, LNS, L2GW), address profiles, service group, and AAA policy. Both IPoE and PPPoE sessions use the same profile and service group resolution.
+
+## Where access-types is declared
+
+`access-types` belongs on each entry in `vlans`, not on the group. A group that declares `access-types` at the top level is rejected at config load, with one exception: an LNS-only group sets `access-types: [lns]` at the group level and must not declare `vlans`, because L2TP-terminated subscribers do not arrive by S-VLAN demux.
+
+```yaml
+subscriber-groups:
+  groups:
+    residential:
+      vlans:
+        - svlan: "100-199"
+          cvlan: any
+          access-types: [ipoe]      # per VLAN range
+          interface: loop100
+          parent-interface: eth1
+    wholesale-lns:
+      access-types: [lns]           # group level, LNS only, no vlans
+      ipv4-profile: residential
+```
 
 ## Group Settings
 
 | Field | Type | Description | Example |
 |-------|------|-------------|---------|
-| `access-types` | []string | One or more of `ipoe`, `pppoe`, `lac`, `lns`. The only valid multi-element combination is `[ipoe, pppoe]` (mixed-access on a shared SVLAN range); `lac` and `lns` are single-element only. | `[ipoe, pppoe]` |
+| `access-types` | []string | LNS-only groups. Must be exactly `[lns]`, and the group must not declare `vlans`. Every other access type declares access-types per VLAN range. | `[lns]` |
 | `vlans` | [VLANRule](#vlan-rules) | VLAN matching rules | |
+| `vlan-tpid` | string | Outer TPID for subscriber traffic: `dot1ad` (0x88A8, default) or `dot1q` (0x8100) | `dot1ad` |
 | `ipv4-profile` | string | [IPv4 profile](ipv4-profiles.md) name | `residential` |
 | `ipv6-profile` | string | [IPv6 profile](ipv6-profiles.md) name | `default-v6` |
 | `session-mode` | string | Session mode: `unified` or `independent` | `unified` |
+| `vrf` | string | VRF for subscribers in this group | `customers` |
 | `default-service-group` | string | Default [service group](service-groups.md) for subscribers | `cgnat-residential` |
 | `aaa-policy` | string | Default AAA policy name | `default-policy` |
 | `ipv6` | [GroupIPv6](#group-ipv6) | IPv6 settings for this group | |
 | `bgp` | [GroupBGP](#group-bgp) | BGP settings for this group | |
 | `pppoe` | [GroupPPPoE](#group-pppoe) | PPPoE settings for this group | |
 | `mss-clamp` | [GroupMSSClamp](#group-mss-clamp) | TCP MSS clamping for this group | |
+| `dhcpv6.allow-relay-forward` | bool | Accept DHCPv6 Relay-Forward messages for this group (LDRA). Default `true`. See [DHCPv6](dhcpv6.md) | `true` |
+| `l2tp.profile` | string | L2TP profile name for `lac` or `lns` ranges. See [L2TP](l2tp.md) | `wholesale` |
+| `l2gw.handoff-group` | string | Default handoff group for `l2gw` ranges. See [L2GW](l2gw.md) | `isp-blue` |
+| `l2gw.idle-timeout` | uint32 | Tear down a dynamic l2gw circuit after this many seconds with no traffic in either direction. `0` disables. | `3600` |
 
 ## VLAN Rules
 
@@ -24,9 +49,17 @@ Defines how subscribers are grouped and configured based on VLAN. Each group bin
 |-------|------|-------------|---------|
 | `svlan` | string | S-VLAN match: single ID or range | `100-199` |
 | `cvlan` | string | C-VLAN match: single, range, or `any` | `any` |
+| `access-types` | []string | Required. One or more of `ipoe`, `pppoe`, `lac`, `lns`, `l2gw`. The only valid multi-element combination is `[ipoe, pppoe]` (mixed access on a shared S-VLAN range); `lac`, `lns` and `l2gw` are single-element only. | `[ipoe]` |
 | `interface` | string | Gateway interface for matched subscribers | `loop100` |
-| `parent-interface` | string | Physical access interface where these subscribers arrive. Required for `ipoe`/`pppoe`/`lac`; optional for `lns`. All VLAN ranges across all groups must reference the same parent-interface (single-access-interface invariant). | `eth1` |
+| `parent-interface` | string | Access interface where these subscribers arrive. May be a physical port, a bond, a VXLAN tunnel (`l2gw`), or a pseudowire headend. Required for every access type except `lns`, and must name an interface defined in `interfaces`. See [Interfaces](interfaces.md) | `eth1` |
+| `vrf` | string | VRF override for this VLAN range | `customers` |
+| `dhcp` | string | Named DHCP server from the top-level `dhcp.servers` list | `upstream-dhcp` |
+| `trigger` | string | `l2gw` ranges only: `dhcp` (default) punts DHCPv4 and DHCPv6 on circuit miss, `packet` punts the first frame of any protocol. See [L2GW](l2gw.md) | `packet` |
 | `aaa.policy` | string | AAA policy override for this VLAN range | `custom-policy` |
+
+### One access interface
+
+All VLAN ranges across all groups must reference the same `parent-interface`, with one exception: `l2gw` ranges are exempt, because each wholesale access operator lands on its own NNI port. A configuration mixing two access interfaces for IPoE, PPPoE or LAC is rejected at load.
 
 ## Group IPv6
 
@@ -59,7 +92,7 @@ Defines how subscribers are grouped and configured based on VLAN. Each group bin
 
 ## Group PPPoE
 
-PPPoE-specific settings. Only consulted when `access-types: [pppoe]`.
+PPPoE-specific settings. Only consulted for VLAN ranges whose `access-types` include `pppoe`.
 
 | Field | Type | Description | Example |
 |-------|------|-------------|---------|
@@ -138,7 +171,6 @@ service-groups:
 subscriber-groups:
   groups:
     residential:
-      access-types: [ipoe]
       session-mode: unified
       ipv4-profile: residential
       ipv6-profile: default-v6
@@ -147,6 +179,7 @@ subscriber-groups:
       vlans:
         - svlan: "100-199"
           cvlan: any
+          access-types: [ipoe]
           interface: loop100
           parent-interface: eth1
       bgp:
@@ -154,13 +187,13 @@ subscriber-groups:
         advertise-pools: true
         network-route-policy: POOL-EXPORT
     residential-pppoe:
-      access-types: [pppoe]
       ipv4-profile: residential
       ipv6-profile: default-v6
       aaa-policy: default-policy
       vlans:
         - svlan: "200-299"
           cvlan: any
+          access-types: [pppoe]
           interface: loop100
           parent-interface: eth1
       pppoe:
@@ -170,4 +203,10 @@ interfaces:
   eth1:
     enabled: true
     mtu: 1512
+
+aaa:
+  auth_provider: local
+  policy:
+    - name: default-policy
+      format: $remote-id$
 ```

--- a/docs/contributing/please_read_first.md
+++ b/docs/contributing/please_read_first.md
@@ -18,12 +18,23 @@
 ## Clone and Build
 
 ```bash
-git clone https://github.com/veesix-networks/osvbng.git
+git clone --recurse-submodules https://github.com/veesix-networks/osvbng.git
 cd osvbng
 make build
 ```
 
 This produces `bin/osvbngd` and `bin/osvbngcli`.
+
+The repo has two submodules, `vpp/` (the dataplane tree) and `context/`. A clone without `--recurse-submodules` leaves both directories empty. On an existing clone, fetch them with:
+
+```bash
+git submodule update --init --recursive
+```
+
+!!! note "Submodule remotes are SSH URLs"
+    Both entries in `.gitmodules` use `git@github.com:` remotes, so the submodule step fails for contributors without SSH access to those repositories. The control plane still builds without them: `make build` only needs the top-level tree.
+
+To move the pins, run `make bump-submodules`. It updates `vpp` and `context` to the tip of their `main` branches and stages the new commits. Changes inside a submodule are branched and reviewed in that submodule's own repository; once they land there, bump the pin here in a separate commit.
 
 ## Running Locally
 
@@ -160,11 +171,11 @@ make test          # run unit tests
 make test-report   # run tests with JUnit XML report in build/reports/
 ```
 
-**Unit tests** (`make test`) validate individual packages in isolation - parsers, allocators, config handling, protocol logic. They run fast, require no infrastructure, and are the first gate in CI.
+**Unit tests** (`make test`) validate individual packages in isolation - parsers, allocators, config handling, protocol logic. They run fast, require no infrastructure, and are the CI gate on every PR.
 
 **Integration tests** (`tests/`) use containerlab and robot framework to spin up a full osvbng instance with BNGBlaster subscribers, verifying end-to-end functionality across all supported features. They require Docker and take longer to run.
 
-CI runs unit tests first. Integration tests will not run until unit tests pass. Both must pass before a PR can be merged.
+CI runs build and unit tests on every PR using GitHub shared runners, and that is the only automated gate a PR has to clear. Integration tests run on a self-hosted runner only when changes are merged to main, so they never run against a PR. Linting is not in CI either, so run `make lint` yourself. Run the integration suites locally before requesting a merge; see [Contribution Guidelines](guidelines.md#running-integration-tests-locally).
 
 !!! note "Future: Hardware and QEMU testing"
     We plan to build physical and QEMU-based test infrastructure for throughput and subscriber scaling validation on minor and major releases.

--- a/docs/examples/evpn-fabric.md
+++ b/docs/examples/evpn-fabric.md
@@ -136,10 +136,13 @@ osvbng consumes type-3 (IMET) routes with ingress replication - the
 baseline every mainstream NOS originates for a bridged L2 VNI. Notes
 for real fabrics:
 
-- **Set explicit route-targets per EVI** so both sides agree
-  (`protocols.bgp.l2vpn-evpn` neighbors plus FRR's per-VNI `rd` /
-  `route-target` overrides render from the config); auto-derived RTs
-  differ across vendors and ASNs.
+- **RD and route-targets are auto-derived and not configurable.**
+  osvbng renders only `advertise-all-vni` in the `l2vpn evpn` address
+  family, so FRR derives the RD and RT for each VNI itself. There is no
+  per-VNI `rd` or `route-target` in osvbng's config today. Auto-derived
+  values differ across vendors and ASNs, so where the leaf does not
+  agree with FRR's derivation, set the matching import and export RT on
+  the leaf side.
 - **One remote VTEP per VNI.** A dual-homed NNI on a leaf pair must
   present a shared anycast service VTEP (MLAG/vPC-style, universally
   supported); underlay ECMP spreads flows across the pair using the

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -4,16 +4,23 @@ Real-world configuration examples for common ISP deployment scenarios. Each exam
 
 ## BNG Deployments
 
-- [IPoE BNG](ipoe-bng.md) — Dual-stack IPoE with local auth, DHCP/DHCPv6, OSPF/BGP
-- [PPPoE BNG](pppoe-bng.md) — Dual-stack PPPoE with per-subscriber authentication
-- [IPoE + PPPoE BNG](ipoe-pppoe-bng.md) — Combined deployment serving both access types on the same node
-- [L2TP LAC (Wholesale)](l2tp-lac.md) — PPPoE termination + L2TPv2 tunnelling to a remote LNS for wholesale ISP deployments
-- [VXLAN Access (PWHE)](pwhe-access.md) — IPoE, PPPoE, and LAC subscribers arriving over a VXLAN access network via a pseudowire headend
+- [IPoE BNG](ipoe-bng.md) - dual-stack IPoE with local auth, DHCP/DHCPv6, OSPF/BGP
+- [PPPoE BNG](pppoe-bng.md) - dual-stack PPPoE with per-subscriber authentication
+- [IPoE + PPPoE BNG](ipoe-pppoe-bng.md) - combined deployment serving both access types on the same node
+- [L2TP LAC (Wholesale)](l2tp-lac.md) - PPPoE termination and L2TPv2 tunnelling to a remote LNS for wholesale ISP deployments
+- [L2TP LNS](l2tp-lns.md) - inbound L2TPv2 tunnels from remote LACs, local PPP termination, auth, and IP allocation
+- [L2 Wholesale (L2GW)](l2gw-wholesale.md) - layer 2 cross-connect between access network NNIs and retail ISP handoffs, RADIUS-driven per line
+- [VXLAN Access (PWHE)](pwhe-access.md) - IPoE, PPPoE, and LAC subscribers arriving over a VXLAN access network via a pseudowire headend
+
+## VRFs & L3VPN
+
+- [VRF-Lite](vrf-lite.md) - two customer VRFs on one BNG, per-VRF core sub-interfaces and iBGP sessions, no MPLS
+- [MPLS L3VPN](l3vpn.md) - VPNv4 iBGP between PEs with LDP transport labels, subscribers in a customer VRF
 
 ## Fabric & Overlay
 
-- [EVPN-VXLAN Fabric](evpn-fabric.md) — osvbng as a fabric VTEP: EVPN-discovered tunnels, anycast-VTEP HA with route-driven failover, vendor interop notes
+- [EVPN-VXLAN Fabric](evpn-fabric.md) - osvbng as a fabric VTEP: EVPN-discovered tunnels, anycast-VTEP HA with route-driven failover, vendor interop notes
 
 ## Policy & Filtering
 
-- [Routing Policies](routing-policies.md) — RTBH, bogon filtering, geographic communities, peering/transit policies, AS-path filtering, outbound scrubbing
+- [Routing Policies](routing-policies.md) - RTBH, bogon filtering, geographic communities, peering/transit policies, AS-path filtering, outbound scrubbing

--- a/docs/examples/ipoe-bng.md
+++ b/docs/examples/ipoe-bng.md
@@ -19,12 +19,12 @@ routing-policies:
 subscriber-groups:
   groups:
     residential:
-      access-types: [ipoe]
       ipv4-profile: residential-v4
       ipv6-profile: residential-v6
       vlans:
         - svlan: "100-199"
           cvlan: any
+          access-types: [ipoe]
           interface: loop100
           parent-interface: eth1
       bgp:
@@ -86,14 +86,12 @@ interfaces:
     address:
       ipv4:
         - 10.254.0.1/32
-    lcp: true
   eth1:
     description: Access Interface
     enabled: true
   eth2:
     description: Core Uplink
     enabled: true
-    lcp: true
     address:
       ipv4:
         - 10.0.0.1/30
@@ -107,7 +105,6 @@ interfaces:
         - 10.255.0.1/32
       ipv6:
         - 2001:db8:0:1::1/128
-    lcp: true
 
 protocols:
   bgp:
@@ -150,7 +147,8 @@ aaa:
 plugins:
   northbound.api:
     enabled: true
-    listen_address: :8080
+    listeners:
+      - address: :8080
   subscriber.auth.local:
     allow_all: true
     database_path: /var/lib/osvbng/subscribers.db

--- a/docs/examples/ipoe-pppoe-bng.md
+++ b/docs/examples/ipoe-pppoe-bng.md
@@ -19,12 +19,12 @@ routing-policies:
 subscriber-groups:
   groups:
     residential:
-      access-types: [ipoe, pppoe]
       ipv4-profile: residential-v4
       ipv6-profile: residential-v6
       vlans:
         - svlan: "100-299"
           cvlan: any
+          access-types: [ipoe, pppoe]
           interface: loop100
           parent-interface: eth1
       bgp:
@@ -86,14 +86,12 @@ interfaces:
     address:
       ipv4:
         - 10.254.0.1/32
-    lcp: true
   eth1:
     description: Access Interface
     enabled: true
   eth2:
     description: Core Uplink
     enabled: true
-    lcp: true
     address:
       ipv4:
         - 10.0.0.1/30
@@ -107,7 +105,6 @@ interfaces:
         - 10.255.0.1/32
       ipv6:
         - 2001:db8:0:1::1/128
-    lcp: true
 
 protocols:
   bgp:
@@ -152,7 +149,8 @@ aaa:
 plugins:
   northbound.api:
     enabled: true
-    listen_address: :8080
+    listeners:
+      - address: :8080
   subscriber.auth.local:
     allow_all: false
     database_path: /var/lib/osvbng/subscribers.db

--- a/docs/examples/l2gw-wholesale.md
+++ b/docs/examples/l2gw-wholesale.md
@@ -47,12 +47,13 @@ none of the access infrastructure.
 
 ```yaml
 interfaces:
-  eth1: {}          # Access Network 1 NNI
-  eth2: {}          # Access Network 2 NNI
-  eth3: {}          # Access Network 3 NNI
-  eth5: {}          # ISP Y NNI
-  eth6: {}          # ISP Z NNI
-  bond1:            # ISP X NNI (LACP)
+  eth1: {enabled: true}   # Access Network 1 NNI
+  eth2: {enabled: true}   # Access Network 2 NNI
+  eth3: {enabled: true}   # Access Network 3 NNI
+  eth5: {enabled: true}   # ISP Y NNI
+  eth6: {enabled: true}   # ISP Z NNI
+  bond1:                  # ISP X NNI (LACP)
+    enabled: true
     bond:
       mode: lacp
       members: [eth7, eth8]

--- a/docs/examples/l2tp-lac.md
+++ b/docs/examples/l2tp-lac.md
@@ -30,11 +30,11 @@ osvbng never validates the subscriber's password.
 subscriber-groups:
   groups:
     pppoe-lac:
-      access-types: [lac]
       vlan-tpid: dot1q
       vlans:
         - svlan: "200-210"
           cvlan: any
+          access-types: [lac]
           interface: loop100
           parent-interface: eth1
       aaa-policy: pppoe-policy

--- a/docs/examples/l3vpn.md
+++ b/docs/examples/l3vpn.md
@@ -24,6 +24,23 @@ vrfs:
     address-families:
       ipv4-unicast: {}
 
+ipv4-profiles:
+  default:
+    gateway: 10.255.0.1
+    pools:
+      - name: subscriber-pool
+        network: 10.255.0.0/16
+        priority: 1
+      - name: customer-a-pool
+        network: 192.168.123.0/24
+        range_start: 192.168.123.2
+        range_end: 192.168.123.254
+        gateway: 192.168.123.1
+        vrf: CUSTOMER-A
+        priority: 10
+    dhcp:
+      lease-time: 3600
+
 service-groups:
   customer-a:
     vrf: CUSTOMER-A
@@ -33,26 +50,28 @@ service-groups:
 subscriber-groups:
   groups:
     customer-a-ipoe:
-      access-types: [ipoe]
       vlan-tpid: dot1q
       ipv4-profile: default
       default-service-group: customer-a
       vlans:
         - svlan: "200-299"
           cvlan: any
+          access-types: [ipoe]
           interface: loop101
-          parent-interface: interfaces
+          parent-interface: eth1
       aaa-policy: default-policy
 
 interfaces:
-  loop0:   {address: {ipv4: [10.254.0.1/32]}}
-  loop100: {address: {ipv4: [10.255.0.1/32]}}
+  loop0:   {enabled: true, address: {ipv4: [10.254.0.1/32]}}
+  loop100: {enabled: true, address: {ipv4: [10.255.0.1/32]}}
   loop101:
+    enabled: true
     address: {ipv4: [192.168.123.1/32]}
     vrf: CUSTOMER-A
-  eth1: {}
+  eth1: {enabled: true}
   eth2:
     description: Core Link (p1)
+    enabled: true
     address: {ipv4: [10.0.0.1/30]}
 
 protocols:
@@ -89,6 +108,14 @@ protocols:
     address-families:
       ipv4:
         transport-address: 10.254.0.1
+
+aaa:
+  auth_provider: local
+  nas_identifier: osvbng
+  policy:
+    - name: default-policy
+      format: $remote-id$
+      max_concurrent_sessions: 1
 ```
 
 ## Key Points

--- a/docs/examples/pppoe-bng.md
+++ b/docs/examples/pppoe-bng.md
@@ -10,12 +10,12 @@ Subscribers connect via PPPoE discovery on QinQ double-tagged access ports. Each
 subscriber-groups:
   groups:
     residential:
-      access-types: [pppoe]
       ipv4-profile: residential-v4
       ipv6-profile: residential-v6
       vlans:
         - svlan: "200-299"
           cvlan: any
+          access-types: [pppoe]
           interface: loop100
           parent-interface: eth1
       aaa-policy: pppoe-policy
@@ -73,14 +73,12 @@ interfaces:
     address:
       ipv4:
         - 10.254.0.1/32
-    lcp: true
   eth1:
     description: Access Interface
     enabled: true
   eth2:
     description: Core Uplink
     enabled: true
-    lcp: true
     address:
       ipv4:
         - 10.0.0.1/30
@@ -94,7 +92,6 @@ interfaces:
         - 10.255.0.1/32
       ipv6:
         - 2001:db8:0:1::1/128
-    lcp: true
 
 protocols:
   bgp:
@@ -139,7 +136,8 @@ aaa:
 plugins:
   northbound.api:
     enabled: true
-    listen_address: :8080
+    listeners:
+      - address: :8080
   subscriber.auth.local:
     allow_all: false
     database_path: /var/lib/osvbng/subscribers.db

--- a/docs/examples/vrf-lite.md
+++ b/docs/examples/vrf-lite.md
@@ -30,26 +30,26 @@ service-groups:
 subscriber-groups:
   groups:
     default-ipoe:
-      access-types: [ipoe]
       vlan-tpid: dot1q
       ipv4-profile: default
       vlans:
         - svlan: "100-199"
           cvlan: any
+          access-types: [ipoe]
           interface: loop100
-          parent-interface: interfaces
+          parent-interface: eth1
       aaa-policy: default-policy
 
     customer-a-ipoe:
-      access-types: [ipoe]
       vlan-tpid: dot1q
       ipv4-profile: default
       default-service-group: customer-a
       vlans:
         - svlan: "200-299"
           cvlan: any
+          access-types: [ipoe]
           interface: loop101
-          parent-interface: interfaces
+          parent-interface: eth1
       aaa-policy: default-policy
 
 ipv4-profiles:
@@ -65,12 +65,13 @@ ipv4-profiles:
         priority: 10
 
 interfaces:
-  loop0:   {address: {ipv4: [10.254.0.1/32]}}
-  loop100: {address: {ipv4: [10.255.0.1/32]}}
+  loop0:   {enabled: true, address: {ipv4: [10.254.0.1/32]}}
+  loop100: {enabled: true, address: {ipv4: [10.255.0.1/32]}}
   loop101:
+    enabled: true
     address: {ipv4: [192.168.123.1/32]}
     vrf: CUSTOMER-A
-  eth1: {}
+  eth1: {enabled: true}
   eth2:
     enabled: true
     subinterfaces:
@@ -101,6 +102,14 @@ protocols:
           10.0.200.2:
             remote-as: 65000
             ipv4-unicast: {}
+
+aaa:
+  auth_provider: local
+  nas_identifier: osvbng
+  policy:
+    - name: default-policy
+      format: $remote-id$
+      max_concurrent_sessions: 1
 ```
 
 ## Key Points

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,13 @@
 - 20,000+ Subscriber Sessions
 - Plugin-based architecture
 - IPoE (DHCPv4 + DHCPv6) and PPPoE
+- L2TP LAC and LNS
+- L2 wholesale gateway (cross-connect subscriber circuits to a retail ISP)
+- Hierarchical QoS with port and S-VLAN aggregates
+- CGNAT with PBA and Deterministic modes
+- High availability with Subscriber Redundancy Groups
+- EVPN-VXLAN and pseudowire headend access
+- MPLS L3VPN and VRFs
 - Modern monitoring stack
 - Core implementation is fully open source
 - Docker and KVM support
@@ -287,5 +294,5 @@ What can you expect from the open source version of this project? Below are some
 - Authenticate customers via DHCPv4 Option 82 (Sub-options 1 and 2, Circuit ID and/or Remote ID)
 - BGP and OSPF support
 - Multi-VRF support
-- No QoS/HQoS support from day 1 of the v1.0.0 release
+- Per-subscriber QoS and hierarchical QoS with port and S-VLAN aggregates
 - Modern monitoring solution with Prometheus

--- a/docs/qa/testing-methodology.md
+++ b/docs/qa/testing-methodology.md
@@ -8,7 +8,7 @@ This page describes what we test, how we test it, and what we plan to improve. I
 
 ### Automated Integration Tests
 
-Every pull request and merge to main triggers a full integration test suite focused on control plane correctness using:
+The integration suites focus on control plane correctness. They run on a self-hosted runner when changes are merged to main, not on pull requests; a pull request is gated on build and unit tests only. The suites are built from:
 
 - **[Robot Framework](https://robotframework.org/)** for test orchestration
 - **[BNG Blaster](https://github.com/rtbrick/bngblaster)** (by RtBrick) for subscriber session simulation and basic traffic verification
@@ -16,6 +16,9 @@ Every pull request and merge to main triggers a full integration test suite focu
 - **[FRRouting](https://frrouting.org/)** for core router simulation (BGP, OSPF)
 - **[FreeRADIUS](https://freeradius.org/)** for AAA authentication testing
 - **[ISC Kea](https://www.isc.org/kea/)** for DHCP relay/proxy testing
+- **[xl2tpd](https://github.com/xelerance/xl2tpd)** for an external L2TPv2 LAC that dials the LNS suite, built from `test-infra/xl2tpd/`
+
+The dataplane the tests run against is the stock VPP image plus the twelve prebuilt osvbng plugins checked in under `test-infra/vpp-plugins/`, which the Docker build copies into `vpp_plugins/`.
 
 containerlab and BNG Blaster are primarily control plane testing tools. They verify session establishment, protocol negotiation, HA failover, and basic traffic forwarding. They are not used for dataplane throughput or performance benchmarking (see [Dataplane Performance Testing](#dataplane-performance-testing) below for that).
 
@@ -43,17 +46,47 @@ Each test deploys a complete network: BNG nodes, core routers, subscriber simula
 | 16 | HA Failover RADIUS | RADIUS-assigned pool attribute preserved across failover |
 | 17 | HA Tracker Promotion IPoE | Tracker-driven automatic promotion from STANDBY_ALONE to ACTIVE_SOLO on access interface failure |
 | 18 | IPoE Linux Client | Real Linux subscriber with QinQ VLANs, DHCP, ping, and iperf3 throughput |
+| 19 | IPoE Linux Client CAKE | Same topology with the CAKE scheduler applied to the session |
 | 20 | Routing Policy | Prefix-sets, community-sets, AS-path-sets, and route-policy application to BGP/OSPF |
 | 21 | CLI / OpenAPI | Northbound REST API generated from CLI handler registry; schema parity |
 | 22 | MSS Clamp | TCP MSS clamping with PPP MRU configuration (RFC 4638) |
 | 23 | RADIUS CoA | RADIUS Change-of-Authorization and Disconnect-Message per RFC 5176 |
 | 24 | VRF-Lite | End-to-end VRF-lite with subscriber-group VRF cascade onto access sub-interfaces |
+| 25 | L3VPN | MPLS L3VPN over LDP and VPNv4: per-VRF pool isolation, RD/RT advertisement, two-label stack |
 | 26 | DHCPv6 LDRA | Local DHCPv6 provider terminating RFC 6221 LDRA Relay-Forward from access |
 | 27 | API Pagination | Pagination across list-returning northbound show endpoints |
 | 28 | Northbound API TLS | Northbound API + Prometheus over TLS with HTTP auth; CGNAT exporter dialer |
 | 29 | RADIUS VRF | RADIUS auth/acct sockets pinned to MGMT-VRF with `SO_BINDTODEVICE` proof |
+| 30 | L2TP LNS | L2TPv2 LNS terminating an external xl2tpd LAC, PPP negotiated locally |
+| 31 | L2TP LAC | L2TPv2 LAC driven by AAA tunnel attributes, PPP bridged to a BNG Blaster LNS |
+| 32 | IPoE OpDB Restore | IPoE sessions restored from the operational database across osvbngd, VPP, and container restarts |
+| 33 | PPPoE OpDB Restore | Same restart matrix for PPPoE sessions |
+| 34 | CGNAT Restart Idempotent | CGNAT mappings preserved across restart with identical and with drifted config |
+| 35 | IPoE Family Disabled | Per-group address family gating: v4-only and v6-only groups reject the other family, drop counters increment |
+| 36 | AAA Empty Username | Sessions with an empty username are rejected and none establish |
+| 37 | HA Graceful Switchover IPoE | Operator-triggered switchover with CGNAT: session restore, GARP flood on access, hitless traffic |
+| 38 | L2GW Static | Layer 2 wholesale cross-connects from static circuit config, no local termination |
+| 39 | L2GW Dynamic | RADIUS-driven circuits with accounting, Prometheus metrics, restart survival, and CoA teardown |
+| 40 | L2GW Packet Trigger | Circuits created on the first PPPoE packet, with restart survival and idle timeout |
+| 40 | L2GW VXLAN | Wholesale circuits over static VXLAN tunnel interfaces |
+| 41 | Upgrade Tier A v2 | Tier A v2 upgrade pipeline on a QEMU image: apply, rollback, partial-apply guard, stepwise, session survival |
+| 42 | IPoE VXLAN PWHE | IPoE sessions terminated on a pseudowire headend over a static VXLAN transport |
+| 43 | PPPoE VXLAN PWHE | PPPoE sessions on a pseudowire headend over a static VXLAN transport |
+| 44 | LAC VXLAN PWHE | L2TP LAC subscriber arriving over a static VXLAN pseudowire |
+| 45 | HA PWHE IPoE | Graceful switchover with IPoE sessions on a pseudowire headend |
+| 46 | L2GW EVPN | Wholesale circuits over VXLAN tunnels programmed from EVPN VTEP discovery |
+| 47 | IPoE EVPN PWHE | IPoE sessions on a pseudowire headend bound by EVPN-discovered transport |
+| 48 | PPPoE EVPN PWHE | PPPoE sessions on a pseudowire headend bound by EVPN-discovered transport |
+| 49 | LAC EVPN PWHE | L2TP LAC subscriber arriving over an EVPN-discovered pseudowire |
+| 50 | HA EVPN PWHE | Anycast VTEP across both nodes, leaf reroutes on switchover, sessions restored hitless |
+| 51 | IPoE HQoS S-VLAN | Hierarchical QoS: per-session schedulers attached to S-VLAN aggregates, share distribution, drain on teardown |
+| 52 | PPPoE HQoS S-VLAN | Same hierarchical QoS checks for PPPoE sessions |
 
-1000+ tests across 27 integration suites.
+Number 40 is currently used by two directories on disk, `tests/40-l2gw-packet-trigger` and `tests/40-l2gw-vxlan`; both are listed above.
+
+That is 53 suite directories under `tests/`: 52 Robot suites holding 668 test cases, plus suite 41, which drives five shell scenarios against a QEMU image instead of Robot Framework.
+
+CI does not run all of them. 20 suites are wired into the workflows under `.github/workflows/`, so "all suites pass" is not an automated gate. The rest are run locally with `scripts/run-qa-tests.sh`, which picks up every suite directory that has a matching `.robot` file.
 
 ### What Gets Verified
 
@@ -152,7 +185,7 @@ This is not done yet. Today the performance testing is manual and results are ca
 |------|-------------|------------|
 | Build | Binary and Docker image build successfully | Yes (CI) |
 | Unit tests | All unit tests pass | Yes (CI) |
-| Integration tests | All 18 suites pass | Yes (CI) |
+| Integration tests | The 20 suites wired into CI pass on merge to main | Partly (CI) |
 | HA failover | Sessions survive hard BNG failure | Yes (CI) |
 | Changelog | Auto-generated via conventional commits | Yes (release-please) |
 | Docker image | Published to Docker Hub | Yes (CI) |

--- a/docs/roadmap/2026.md
+++ b/docs/roadmap/2026.md
@@ -1,28 +1,39 @@
 # The year is 2026
 
+Status is against the current `main` branch: shipped, in progress, or not started.
 
 ## Core
 
-- VRF Support
-- Bond support (VPP already supports bonding, and AF_PACKET mode bonding is handled within the OS)
-- MPLS Support (Core Facing Uplinks) (LDP and SR-MPLS)
-- Dataplane crash recovery improvements
-- High Availability / Geo Redundancy
-- Architect the AAA framework properly without having dependencies on RADIUS, a user of osvbng should be able to fully drop RADIUS with osvbng.
-- Automated performance tests in a physical lab (or at minimum, control plane testing)
-- Hardware availability (Test on more generic setups like Dell R'series, HP DLX GenY series, SuperMicro etc...)
-- Event Bus from plugins into core (for logging/alerts/traps/etc...)
-- Build/use a better test framework
-- Figure out how to improve operational insights on VPP, trace is very limited, but most interesting packets end up in control plane anyway so we have full visibility to expose metrics/debug tools
-- PPP LCP offload
-- Offload IPv6 RA (not fully, but programmable)
-- NAT/CGNAT implementation (potentially as a plugin)
-- General improvement of developer workflow / contributing
-- Public event presentation at least once this year (Telecoms/ISP meetup)
-- Get more general feedback from community/public
+- VRF Support - shipped
+- Bond support (VPP already supports bonding, and AF_PACKET mode bonding is handled within the OS) - shipped
+- MPLS Support (Core Facing Uplinks) (LDP and SR-MPLS) - in progress. LDP and MPLS L3VPN ship, SR-MPLS does not.
+- Dataplane crash recovery improvements - shipped. Sessions and CGNAT state are rebuilt from the operational database after a dataplane restart.
+- High Availability / Geo Redundancy - shipped. Active/standby with Subscriber Redundancy Groups, session sync and graceful switchover.
+- Architect the AAA framework properly without having dependencies on RADIUS, a user of osvbng should be able to fully drop RADIUS with osvbng. - shipped. Local and HTTP auth providers cover the RADIUS-free case.
+- Automated performance tests in a physical lab (or at minimum, control plane testing) - not started. The functional suite is automated, but it does not measure performance and there is no physical lab harness.
+- Hardware availability (Test on more generic setups like Dell R'series, HP DLX GenY series, SuperMicro etc...) - in progress. The hardware matrix and the validation process exist, with one reference design published so far.
+- Event Bus from plugins into core (for logging/alerts/traps/etc...) - shipped
+- Build/use a better test framework - shipped. Robot Framework based suite with over 50 end to end scenarios.
+- Figure out how to improve operational insights on VPP, trace is very limited, but most interesting packets end up in control plane anyway so we have full visibility to expose metrics/debug tools - in progress. State collectors, the Prometheus exporter and `show` commands cover most components. VPP level tracing is unchanged.
+- PPP LCP offload - not started. LCP, authentication and echo frames all punt to the control plane.
+- Offload IPv6 RA (not fully, but programmable) - in progress. Interface RAs are programmed into VPP, subscriber RAs are still built and sent by the control plane.
+- NAT/CGNAT implementation (potentially as a plugin) - shipped. PBA and deterministic modes in a VPP dataplane plugin, driven from core rather than from an osvbng plugin.
+- General improvement of developer workflow / contributing - in progress
+- Public event presentation at least once this year (Telecoms/ISP meetup) - not started
+- Get more general feedback from community/public - in progress
+
+## Delivered this year, not on the original list
+
+- Hierarchical QoS with port and S-VLAN aggregates - shipped
+- EVPN signalled VXLAN tunnels with dynamic VTEP discovery - shipped
+- Pseudowire headend (PWHE) access over VXLAN, carrying IPoE, PPPoE and L2TP LAC - shipped
+- L2 wholesale gateway (l2gw), static maps and AAA triggered circuits - shipped
+- RADIUS CoA and Disconnect-Message - shipped
+- L2TP LNS, alongside the existing LAC role - shipped
+- In-place upgrade tooling (`osvbngcli upgrade plan / apply / rollback / status`) - shipped
 
 ## Plugins
 
-- AuthProvider - RADIUS (Authentication and Accounting) 
-- CacheProvider - Redis
-- DHCPProvider - Relay mode for both v4 and v6
+- AuthProvider - RADIUS (Authentication and Accounting) - shipped. CoA and Disconnect-Message included.
+- CacheProvider - Redis - not started
+- DHCPProvider - Relay mode for both v4 and v6 - shipped. Relay and proxy providers exist for DHCPv4 and DHCPv6, with LDRA for v6.

--- a/docs/roadmap/overview.md
+++ b/docs/roadmap/overview.md
@@ -8,14 +8,22 @@ The concept of osvbng is simply to build a BNG targeted towards a typical deploy
 - Single Tagged (802.1Q - Not extremely rare, but not common)
 - Double Tagged (QinQ, 802.1AD + 802.1Q or 802.1Q + 802.1Q if you're weird and want more CPU cycles on layer 2 processing)
 
-The goal is not to support every single access network method, eg.
+The goal is still not to support every access network method, but the line has moved since this was first written. What osvbng terminates today:
 
-- VPLS bridges with LDP+BGP MPLS tunnels terminated directly on the BNG as a pseudowire/virtual interface
-- LDP/EVPN based VPWS terminated directly on the BNG
-- VXLAN termination
-- etc...
+- Ethernet handover (untagged, single tagged, QinQ). This is still the primary deployment model and everything else is built on it.
+- VXLAN transport terminated on the BNG, presented as a pseudowire headend so that IPoE, PPPoE and L2TP LAC terminate on it exactly as they do on a physical port.
+- EVPN signalling for those tunnels. FRR originates and consumes type-3 (IMET) routes, so remote VTEPs are discovered rather than provisioned per tunnel.
+- Layer 2 wholesale cross-connects (l2gw), where osvbng switches a subscriber circuit through to a retail ISP handoff instead of terminating it.
 
-BNGs in 2026 need to be dumb. Not have 500 different feature sets with 1000s of ways to configure it. There are pros and cons on both sides to keeping it as simple as an ethernet handover vs bringing in MPLS based tunnel termination directly into the BNG, this is NOT my vision of osvbng.
+What remains out of scope:
+
+- MPLS pseudowires terminated directly on the BNG, whether LDP signalled or EVPN-VPWS
+- VPLS bridging on the BNG
+- Shared bridge domains (E-LAN) and ESI all-active toward the BNG
+
+MPLS is used for core facing transport (LDP, L3VPN) and not as an access encapsulation terminated on a subscriber facing interface.
+
+BNGs in 2026 need to be dumb. Not have 500 different feature sets with 1000s of ways to configure it. There are pros and cons on both sides to keeping it as simple as an ethernet handover vs bringing in MPLS based tunnel termination directly into the BNG, this is NOT my vision of osvbng. VXLAN access does not change that position: the tunnel is presented as an access port and the headend behaves like one, so there is still a single subscriber termination path.
 
 The traditional deployments of bringing complex network overlays into the BNG is typically to solve problems of a network deployment architecture issue, not the actual BNG itself. Therefore a BNG done correctly (AAA, VLAN termination, Subscriber Management, QoS and DHCP/PPP processing) is more valuable in my eyes rather than a BNG that can support every type of network deployment architecture. osvbng could potentially expose the internals of the dataplane (via osvbng itself as an SDK) so that people can introduce new access termination methods, but it's not the core goal, I just simply want to build a fast, reliable, low-cost and dumb BNG.
 
@@ -23,11 +31,16 @@ Separating control and user plane (CUPS) in the BNG world is also not the direct
 
 ---
 
-The 3 main deployment methods are described in the following documents:
+The 3 reference Ethernet handover methods are described in the following documents:
 
-- [Single Tagged - N:1](../../architecture/REFERENCE_DEPLOYMENT_METHODS) 
-- [Double Tagged - N:1](../../architecture/REFERENCE_DEPLOYMENT_METHODS) 
-- [Double Tagged - 1:1](../../architecture/REFERENCE_DEPLOYMENT_METHODS)
+- [Single Tagged - N:1](../architecture/REFERENCE_DEPLOYMENT_METHODS.md)
+- [Double Tagged - N:1](../architecture/REFERENCE_DEPLOYMENT_METHODS.md)
+- [Double Tagged - 1:1](../architecture/REFERENCE_DEPLOYMENT_METHODS.md)
+
+Two further access models sit on top of those and reuse the same S/C-VLAN matching and subscriber groups:
+
+- Tunnel terminated access, where the handover arrives as a VXLAN tunnel instead of a physical port and terminates on a pseudowire headend. Remote VTEPs are either configured or discovered with BGP EVPN. See [VXLAN Access (PWHE)](../examples/pwhe-access.md) and [EVPN-VXLAN Fabric](../examples/evpn-fabric.md).
+- Wholesale layer 2 access, where circuits are cross-connected to a retail ISP handoff rather than terminated. See [L2 Wholesale (L2GW)](../examples/l2gw-wholesale.md).
 
 ---
 
@@ -40,7 +53,7 @@ So what is the plan? Initially I am winging it, however what I have in my head:
 #### Week
 
 - Re-evaluate/Add any top priority features/fixes for the following week
-- Community update (short status post - Slack/GitHub Discussions)
+- Community update (short status post - Discord/GitHub Discussions)
 - Triage new issues and PRs
 
 #### Fortnight

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: osvbng
-site_url: https://osvbng.veesix-networks.co.uk
+site_url: https://docs.osvbng.v6n.io/
 repo_url: https://github.com/veesix-networks/osvbng
 repo_name: veesix-networks/osvbng
 theme:
@@ -36,7 +36,6 @@ nav:
     - Intro: index.md
     - API: getting-started/api.md
     - Upgrades: operations/upgrade.md
-    - Testing & QA: qa/testing-methodology.md
   - Configuration:
     - Overview: configuration/index.md
     - Logging: configuration/logging.md
@@ -97,6 +96,7 @@ nav:
       - DHCP Relay & Proxy: architecture/DHCP_RELAY_PROXY.md
       - DHCPv6 LDRA: architecture/DHCPV6_LDRA.md
       - QoS: architecture/QOS.md
+      - VRF: architecture/VRF.md
       - Telemetry: architecture/TELEMETRY.md
   - Reference:
     - Overview: reference/index.md


### PR DESCRIPTION
Six of the twelve example configs did not load. They used the group-level `access-types` form that has been rejected since #308, two named `parent-interface: interfaces` which is not an interface, and three still carried the removed `lcp` key. Anyone copying an example got a validation error, and `subscriber-groups.md` taught the same invalid shape, so the reference page was the source of the bug rather than a casualty of it.

Alongside that, several pages described shipped capabilities as unshipped, documented config keys that nothing reads, and pointed operators at API paths that do not exist.

## Examples

Every example now loads through `config.Load`. `access-types` moved into the `vlans` entries, `parent-interface` corrected, `enabled: true` restored on interfaces that were left admin-down, `aaa` policy definitions added where the config referenced them, and the deprecated northbound `listen_address` replaced with the `listeners` list. `l3vpn.md` also gained the `ipv4-profiles` block it referenced but never defined.

## Reference pages

`subscriber-groups.md` now states where `access-types` belongs and why LNS-only groups are the exception, covers `l2gw`, records that `parent-interface` may be a bond, a VXLAN tunnel or a pseudowire headend rather than only a physical port, notes the l2gw exemption from the single-access-interface rule, and documents the VLAN range and group fields that were missing.

Corrected as shipped: L2TP LNS, MPLS and LDP (with a reference for the keys that exist, and an honest note that Segment Routing is not configurable), hierarchical QoS on the landing page, and VXLAN and EVPN access in the roadmap non-goals list. Corrected as not shipped: per-VNI EVPN `rd` and `route-target` overrides, which FRR derives automatically and osvbng does not render.

`monitoring.md` no longer presents `collect_interval` and `disabled_collectors` as working knobs, and `cgnat.md` no longer documents subscriber-group or AAA policy assignment, because in both cases nothing reads them.

## Contributing and QA

Integration tests run on merge to main on the self-hosted runner and never against a pull request; two pages claimed otherwise. The suite table now lists all 53 suites and says plainly that CI runs 20 of them, so a green PR is not evidence that every suite passes. Clone instructions now cover the `vpp` and `context` submodules, without which there is no dataplane tree.

## Verification

Every full-config yaml block in `docs/examples` and `docs/configuration` was extracted and loaded through `config.Load`, which is the real loader plus `Config.Validate`. All ten example pages pass. `mkdocs build --strict` passes. Three blocks that remain unloadable are deliberate fragments (`interfaces.md` and `l2gw.md`) whose supporting config is defined elsewhere on the page.

Not verified: prose accuracy on pages this PR does not touch. The audit behind this work found more, listed below, which is deliberately left for follow-ups.

## Known follow-ups, not in this PR

- `architecture/PLUGINS.md` and `architecture/COLLECTORS.md` document `pkg/state`, `pkg/cli` and the collector and cache layer, all of which have been deleted. A plugin written from those pages will not compile. This needs a rewrite against the current telemetry and CLI contract rather than a patch.
- No configuration page exists for `qos-aggregates`, the `watchdog` block, or the top-level `api` block.
- The inline netbind bindings (`vrf`, `source_ip`) are undocumented across the profile, auth and exporter pages.
- `architecture/EVENTS.md` prints topic strings without the `osvbng:events:` prefix, so a plugin copying them subscribes to nothing.
- Dead config surface worth a decision in code rather than docs: `system.MonitoringConfig`, `subscriber.SubscriberCGNATConfig`, the `provider` keys under `dhcp` and `dhcpv6`, and a registered `protocols.bfd.enabled` path with no backing field. Test fixtures still set `monitoring.collect_interval`, which does nothing.
- `tests/40-l2gw-packet-trigger` and `tests/40-l2gw-vxlan` share suite number 40.
- Em dashes appear throughout the older docs; normalising them is a mechanical pass better done on its own.