### PR TITLE
fix(ipoe): derive the session limit from live sessions, not a leaked counter

### DIFF
--- a/internal/ipoe/dhcpv4.go
+++ b/internal/ipoe/dhcpv4.go
@@ -759,13 +759,6 @@ func (c *Component) handleRelease(pkt *dataplane.ParsedPacket) error {
 	}
 
 	if deleteSession {
-		counterKey := fmt.Sprintf("osvbng:session_count:%s:%d:%d", pkt.MAC.String(), pkt.OuterVLAN, pkt.InnerVLAN)
-		newCount, err := c.cache.Decr(c.Ctx, counterKey)
-		if err != nil {
-			c.logger.Warn("Failed to decrement session counter", "error", err, "key", counterKey)
-		} else if newCount <= 0 {
-			c.cache.Delete(c.Ctx, counterKey)
-		}
 		c.deleteSessionCheckpoint(sessID)
 	} else if sess != nil {
 		c.checkpointSession(sess)
@@ -913,7 +906,6 @@ func (c *Component) handleAck(sess *SessionState, pkt *dataplane.ParsedPacket) e
 	}
 
 	sess.mu.Lock()
-	alreadyBound := sess.State == "bound"
 	sess.State = "bound"
 	sess.IPv4 = pkt.DHCPv4.YourClientIP
 	sess.LeaseTime = leaseTime
@@ -921,9 +913,6 @@ func (c *Component) handleAck(sess *SessionState, pkt *dataplane.ParsedPacket) e
 	if sess.ActivatedAt.IsZero() {
 		sess.ActivatedAt = sess.BoundAt
 	}
-	mac := sess.MAC
-	svlan := sess.OuterVLAN
-	cvlan := sess.InnerVLAN
 	ipoeSwIfIndex := sess.IPoESwIfIndex
 	snapshotIPv6 := sess.IPv6Address
 	snapshotIPv6LeaseTime := sess.IPv6LeaseTime
@@ -955,18 +944,6 @@ func (c *Component) handleAck(sess *SessionState, pkt *dataplane.ParsedPacket) e
 			c.logger.WithGroup(logger.IPoEDHCP4).Debug("IPoE session not ready, queued IPv4 binding", "session_id", sessID, "ipv4", ipv4.String())
 		}
 	}
-
-	counterKey := fmt.Sprintf("osvbng:session_count:%s:%d:%d", mac.String(), svlan, cvlan)
-	if !alreadyBound {
-		if _, err := c.cache.Incr(c.Ctx, counterKey); err != nil {
-			c.logger.Warn("Failed to increment session counter", "error", err, "key", counterKey)
-		}
-	}
-	expiry := time.Duration(sess.LeaseTime*2) * time.Second
-	if expiry == 0 || expiry > 24*time.Hour {
-		expiry = 24 * time.Hour
-	}
-	c.cache.Expire(c.Ctx, counterKey, expiry)
 
 	c.checkpointSession(sess)
 

--- a/internal/ipoe/dhcpv6.go
+++ b/internal/ipoe/dhcpv6.go
@@ -515,13 +515,6 @@ func (c *Component) handleDHCPv6Release(pkt *dataplane.ParsedPacket, msg *dhcp6.
 	}
 
 	if deleteSession {
-		counterKey := fmt.Sprintf("osvbng:session_count:%s:%d:%d", pkt.MAC.String(), pkt.OuterVLAN, pkt.InnerVLAN)
-		newCount, err := c.cache.Decr(c.Ctx, counterKey)
-		if err != nil {
-			c.logger.Warn("Failed to decrement session counter", "error", err, "key", counterKey)
-		} else if newCount <= 0 {
-			c.cache.Delete(c.Ctx, counterKey)
-		}
 		c.deleteSessionCheckpoint(sessID)
 	} else if sess != nil {
 		c.checkpointSession(sess)

--- a/internal/ipoe/restore.go
+++ b/internal/ipoe/restore.go
@@ -62,7 +62,6 @@ func (c *Component) restoreSessions(ctx context.Context) error {
 	defer func() { c.currentRestoreCause = "" }()
 
 	var count, expired, failed, halfEstablished int
-	sessionCounts := make(map[string]int)
 	now := time.Now()
 
 	err := c.opdb.Load(ctx, opdb.NamespaceIPoESessions, func(key string, value []byte) error {
@@ -109,12 +108,6 @@ func (c *Component) restoreSessions(ctx context.Context) error {
 			return nil
 		}
 
-		if sess.State == "bound" && sess.MAC != nil {
-			counterKey := fmt.Sprintf("osvbng:session_count:%s:%d:%d",
-				sess.MAC.String(), sess.OuterVLAN, sess.InnerVLAN)
-			sessionCounts[counterKey]++
-		}
-
 		if sess.State == "bound" {
 			c.restoreSessionToCache(ctx, &sess, now)
 		}
@@ -124,12 +117,6 @@ func (c *Component) restoreSessions(ctx context.Context) error {
 	})
 	if err != nil {
 		return fmt.Errorf("restore ipoe sessions: %w", err)
-	}
-
-	for counterKey, cnt := range sessionCounts {
-		for i := 0; i < cnt; i++ {
-			c.cache.Incr(ctx, counterKey)
-		}
 	}
 
 	c.logger.Info("Restored IPoE sessions from OpDB",

--- a/internal/ipoe/session.go
+++ b/internal/ipoe/session.go
@@ -200,13 +200,30 @@ func (c *Component) checkSessionLimit(mac net.HardwareAddr, svlan, cvlan uint16)
 // In independent session mode a dual-stack subscriber holds two
 // SessionStates. Only the one carrying the IPv4 binding is counted, which
 // matches what the old counter tracked.
+//
+// The tuple is already the session map's key, so the count is two O(1)
+// lookups, not a scan: every store site keys a session by its own
+// (MAC, SVLAN, CVLAN), under "ipoe:" in unified mode or "ipoe-v4:" in
+// independent mode. Both forms are probed, rather than only the one the
+// current config would produce, so a session established before a
+// session-mode reconfiguration still counts. "ipoe-v6:" is not probed:
+// no path sets an IPv4 binding on a v6-keyed session, and the count
+// requires one.
 func (c *Component) countExistingSessions(mac net.HardwareAddr, svlan, cvlan uint16) int {
-	count := 0
+	keys := [...]string{
+		sessionKeyUnified(mac, svlan, cvlan),
+		sessionKeyIndependentV4(mac, svlan, cvlan),
+	}
 
-	c.sessions.Range(func(_, v any) bool {
+	count := 0
+	for _, key := range keys {
+		v, ok := c.sessions.Load(key)
+		if !ok {
+			continue
+		}
 		sess, ok := v.(*SessionState)
 		if !ok {
-			return true
+			continue
 		}
 
 		sess.mu.Lock()
@@ -221,9 +238,7 @@ func (c *Component) countExistingSessions(mac net.HardwareAddr, svlan, cvlan uin
 		if match {
 			count++
 		}
-		return true
-	})
-
+	}
 	return count
 }
 
@@ -404,20 +419,30 @@ func (c *Component) getSessionMode(svlan, cvlan uint16) subscriber.SessionMode {
 	return match.Group.GetSessionMode()
 }
 
-func (c *Component) makeSessionKeyV4(mac net.HardwareAddr, svlan, cvlan uint16) string {
-	mode := c.getSessionMode(svlan, cvlan)
-	if mode == subscriber.SessionModeUnified {
-		return fmt.Sprintf("ipoe:%s:%d:%d", mac.String(), svlan, cvlan)
-	}
+func sessionKeyUnified(mac net.HardwareAddr, svlan, cvlan uint16) string {
+	return fmt.Sprintf("ipoe:%s:%d:%d", mac.String(), svlan, cvlan)
+}
+
+func sessionKeyIndependentV4(mac net.HardwareAddr, svlan, cvlan uint16) string {
 	return fmt.Sprintf("ipoe-v4:%s:%d:%d", mac.String(), svlan, cvlan)
 }
 
-func (c *Component) makeSessionKeyV6(mac net.HardwareAddr, svlan, cvlan uint16) string {
-	mode := c.getSessionMode(svlan, cvlan)
-	if mode == subscriber.SessionModeUnified {
-		return fmt.Sprintf("ipoe:%s:%d:%d", mac.String(), svlan, cvlan)
-	}
+func sessionKeyIndependentV6(mac net.HardwareAddr, svlan, cvlan uint16) string {
 	return fmt.Sprintf("ipoe-v6:%s:%d:%d", mac.String(), svlan, cvlan)
+}
+
+func (c *Component) makeSessionKeyV4(mac net.HardwareAddr, svlan, cvlan uint16) string {
+	if c.getSessionMode(svlan, cvlan) == subscriber.SessionModeUnified {
+		return sessionKeyUnified(mac, svlan, cvlan)
+	}
+	return sessionKeyIndependentV4(mac, svlan, cvlan)
+}
+
+func (c *Component) makeSessionKeyV6(mac net.HardwareAddr, svlan, cvlan uint16) string {
+	if c.getSessionMode(svlan, cvlan) == subscriber.SessionModeUnified {
+		return sessionKeyUnified(mac, svlan, cvlan)
+	}
+	return sessionKeyIndependentV6(mac, svlan, cvlan)
 }
 
 func (c *Component) sessionCount() int {

--- a/internal/ipoe/session.go
+++ b/internal/ipoe/session.go
@@ -5,6 +5,7 @@
 package ipoe
 
 import (
+	"bytes"
 	"fmt"
 	"net"
 	"sync"
@@ -174,11 +175,7 @@ func (c *Component) checkSessionLimit(mac net.HardwareAddr, svlan, cvlan uint16)
 		return nil
 	}
 
-	count, err := c.countExistingSessions(mac, svlan, cvlan)
-	if err != nil {
-		c.logger.Warn("Failed to count sessions", "error", err)
-		return nil
-	}
+	count := c.countExistingSessions(mac, svlan, cvlan)
 
 	if count >= maxSessions {
 		return fmt.Errorf("session limit reached (%d/%d) for %s on VLAN %d:%d",
@@ -190,20 +187,44 @@ func (c *Component) checkSessionLimit(mac net.HardwareAddr, svlan, cvlan uint16)
 	return nil
 }
 
-func (c *Component) countExistingSessions(mac net.HardwareAddr, svlan, cvlan uint16) (int, error) {
-	counterKey := fmt.Sprintf("osvbng:session_count:%s:%d:%d", mac.String(), svlan, cvlan)
+// countExistingSessions reports how many IPv4 leases this subscriber tuple
+// currently holds, derived from the live session map.
+//
+// This was once an explicit counter in the cache, incremented on bind and
+// decremented only by the two DHCP RELEASE handlers. Every other teardown
+// path (the stale-session reaper, a CoA terminate) removed the session and
+// left the count behind, so the subscriber was locked out until the key's
+// TTL expired. Deriving it removes the class of bug: the session map is
+// already the authoritative record every teardown path must update.
+//
+// In independent session mode a dual-stack subscriber holds two
+// SessionStates. Only the one carrying the IPv4 binding is counted, which
+// matches what the old counter tracked.
+func (c *Component) countExistingSessions(mac net.HardwareAddr, svlan, cvlan uint16) int {
+	count := 0
 
-	val, err := c.cache.Get(c.Ctx, counterKey)
-	if err != nil {
-		return 0, nil
-	}
+	c.sessions.Range(func(_, v any) bool {
+		sess, ok := v.(*SessionState)
+		if !ok {
+			return true
+		}
 
-	var count int64
-	if _, err := fmt.Sscanf(string(val), "%d", &count); err != nil {
-		return 0, nil
-	}
+		sess.mu.Lock()
+		// Closing is set before the session leaves the map; a DISCOVER
+		// landing in that window is the re-establishment, not a second
+		// session.
+		match := !sess.Closing && sess.IPv4 != nil &&
+			sess.OuterVLAN == svlan && sess.InnerVLAN == cvlan &&
+			bytes.Equal(sess.MAC, mac)
+		sess.mu.Unlock()
 
-	return int(count), nil
+		if match {
+			count++
+		}
+		return true
+	})
+
+	return count
 }
 
 const (

--- a/internal/ipoe/session_limit_test.go
+++ b/internal/ipoe/session_limit_test.go
@@ -1,0 +1,160 @@
+// Copyright 2026 The osvbng Authors
+// Licensed under the GNU General Public License v3.0 or later.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ipoe
+
+import (
+	"net"
+	"testing"
+
+	"github.com/veesix-networks/osvbng/pkg/config"
+	"github.com/veesix-networks/osvbng/pkg/config/aaa"
+	"github.com/veesix-networks/osvbng/pkg/config/subscriber"
+	"github.com/veesix-networks/osvbng/pkg/logger"
+)
+
+const (
+	limitSVLAN = 100
+	limitCVLAN = 10
+)
+
+func sessionLimitComponent(t *testing.T, max int, mode subscriber.SessionMode) *Component {
+	t.Helper()
+
+	cfg := &config.Config{
+		AAA: aaa.AAAConfig{
+			Policy: []aaa.AAAPolicy{{Name: "dhcp-pol", MaxConcurrentSessions: max}},
+		},
+		SubscriberGroups: &subscriber.SubscriberGroupsConfig{
+			Groups: map[string]*subscriber.SubscriberGroup{
+				"grp": {
+					AAAPolicy:   "dhcp-pol",
+					SessionMode: mode,
+					VLANs:       []subscriber.VLANRange{{SVLAN: "100", CVLAN: "10"}},
+				},
+			},
+		},
+	}
+
+	return &Component{
+		logger: logger.NewTest(),
+		cfgMgr: &fakeConfigManager{cfg: cfg},
+	}
+}
+
+func boundV4Session(c *Component, mac net.HardwareAddr, ip string) *SessionState {
+	sess := &SessionState{
+		SessionID: "v4-" + mac.String(),
+		MAC:       mac,
+		OuterVLAN: limitSVLAN,
+		InnerVLAN: limitCVLAN,
+		State:     "bound",
+		IPv4:      net.ParseIP(ip),
+	}
+	c.sessions.Store(c.makeSessionKeyV4(mac, limitSVLAN, limitCVLAN), sess)
+	return sess
+}
+
+// TestSessionLimitDerivesFromLiveSessions pins the admission count to the
+// live session map. It used to come from a separate cache counter that only
+// the DHCP RELEASE handlers decremented, so a subscriber torn down any other
+// way (the stale-session reaper, a CoA terminate) leaked its count and was
+// locked out until the key's TTL expired. BNG Blaster monkey churn kills
+// sessions without a RELEASE, which drained every subscriber one by one.
+func TestSessionLimitDerivesFromLiveSessions(t *testing.T) {
+	mac := net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x57}
+
+	t.Run("live_bound_session_blocks_a_second", func(t *testing.T) {
+		c := sessionLimitComponent(t, 1, subscriber.SessionModeUnified)
+		boundV4Session(c, mac, "10.0.0.5")
+
+		if err := c.checkSessionLimit(mac, limitSVLAN, limitCVLAN); err == nil {
+			t.Fatal("expected the limit to reject while a bound session is live")
+		}
+	})
+
+	t.Run("reaped_session_admits_the_next_discover", func(t *testing.T) {
+		c := sessionLimitComponent(t, 1, subscriber.SessionModeUnified)
+		sess := boundV4Session(c, mac, "10.0.0.5")
+
+		// Exactly what cleanupSessions does, and nothing more: no RELEASE
+		// was seen, so no handler ran to release the subscriber's count.
+		sess.Closing = true
+		c.sessions.Delete(c.makeSessionKeyV4(mac, limitSVLAN, limitCVLAN))
+
+		if err := c.checkSessionLimit(mac, limitSVLAN, limitCVLAN); err != nil {
+			t.Fatalf("reaped session must not block re-establishment: %v", err)
+		}
+	})
+
+	t.Run("closing_session_does_not_block", func(t *testing.T) {
+		c := sessionLimitComponent(t, 1, subscriber.SessionModeUnified)
+		sess := boundV4Session(c, mac, "10.0.0.5")
+
+		// The reaper marks Closing under sess.mu before it deletes from the
+		// map; a DISCOVER landing in that window must not be rejected.
+		sess.Closing = true
+
+		if err := c.checkSessionLimit(mac, limitSVLAN, limitCVLAN); err != nil {
+			t.Fatalf("closing session must not block re-establishment: %v", err)
+		}
+	})
+
+	t.Run("independent_mode_dual_stack_counts_once", func(t *testing.T) {
+		c := sessionLimitComponent(t, 1, subscriber.SessionModeIndependent)
+		boundV4Session(c, mac, "10.0.0.5")
+
+		// In independent mode the same subscriber holds a second SessionState
+		// for IPv6 under its own key. The limit counts IPv4 bindings, so the
+		// v6 half must not consume the subscriber's single allowed session.
+		v6 := &SessionState{
+			SessionID:   "v6-" + mac.String(),
+			MAC:         mac,
+			OuterVLAN:   limitSVLAN,
+			InnerVLAN:   limitCVLAN,
+			State:       "bound",
+			IPv6Address: net.ParseIP("2001:db8::1"),
+			IPv6Bound:   true,
+		}
+		c.sessions.Store(c.makeSessionKeyV6(mac, limitSVLAN, limitCVLAN), v6)
+
+		if got := c.countExistingSessions(mac, limitSVLAN, limitCVLAN); got != 1 {
+			t.Fatalf("dual-stack subscriber counted %d times, want 1", got)
+		}
+	})
+
+	t.Run("other_subscribers_are_not_counted", func(t *testing.T) {
+		c := sessionLimitComponent(t, 1, subscriber.SessionModeUnified)
+		boundV4Session(c, net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x58}, "10.0.0.6")
+
+		if err := c.checkSessionLimit(mac, limitSVLAN, limitCVLAN); err != nil {
+			t.Fatalf("another subscriber's session must not block: %v", err)
+		}
+	})
+
+	t.Run("unbound_session_does_not_block", func(t *testing.T) {
+		c := sessionLimitComponent(t, 1, subscriber.SessionModeUnified)
+		// AAA approved, DISCOVER in flight, no lease yet: nothing to count.
+		c.sessions.Store(c.makeSessionKeyV4(mac, limitSVLAN, limitCVLAN), &SessionState{
+			SessionID: "pending",
+			MAC:       mac,
+			OuterVLAN: limitSVLAN,
+			InnerVLAN: limitCVLAN,
+			State:     "discovering",
+		})
+
+		if err := c.checkSessionLimit(mac, limitSVLAN, limitCVLAN); err != nil {
+			t.Fatalf("session without an IPv4 binding must not block: %v", err)
+		}
+	})
+
+	t.Run("limit_disabled_admits_everything", func(t *testing.T) {
+		c := sessionLimitComponent(t, 0, subscriber.SessionModeUnified)
+		boundV4Session(c, mac, "10.0.0.5")
+
+		if err := c.checkSessionLimit(mac, limitSVLAN, limitCVLAN); err != nil {
+			t.Fatalf("max_concurrent_sessions=0 must disable the check: %v", err)
+		}
+	})
+}

--- a/internal/ipoe/session_limit_test.go
+++ b/internal/ipoe/session_limit_test.go
@@ -5,6 +5,7 @@
 package ipoe
 
 import (
+	"fmt"
 	"net"
 	"testing"
 
@@ -146,6 +147,29 @@ func TestSessionLimitDerivesFromLiveSessions(t *testing.T) {
 
 		if err := c.checkSessionLimit(mac, limitSVLAN, limitCVLAN); err != nil {
 			t.Fatalf("session without an IPv4 binding must not block: %v", err)
+		}
+	})
+
+	t.Run("session_under_other_mode_key_still_counts", func(t *testing.T) {
+		c := sessionLimitComponent(t, 1, subscriber.SessionModeIndependent)
+
+		// A session established while the group ran in unified mode sits
+		// under the "ipoe:" key. If the group is then reconfigured to
+		// independent mode, a fresh DISCOVER computes the "ipoe-v4:" key
+		// and misses it, but the subscriber still holds a live IPv4 lease
+		// and must still count against the limit.
+		sess := &SessionState{
+			SessionID: "unified-" + mac.String(),
+			MAC:       mac,
+			OuterVLAN: limitSVLAN,
+			InnerVLAN: limitCVLAN,
+			State:     "bound",
+			IPv4:      net.ParseIP("10.0.0.5"),
+		}
+		c.sessions.Store(fmt.Sprintf("ipoe:%s:%d:%d", mac.String(), limitSVLAN, limitCVLAN), sess)
+
+		if err := c.checkSessionLimit(mac, limitSVLAN, limitCVLAN); err == nil {
+			t.Fatal("expected the limit to reject a live session stored under the other mode's key")
 		}
 	})
 

--- a/tests/53-ipoe-churn/53-ipoe-churn.clab.yml
+++ b/tests/53-ipoe-churn/53-ipoe-churn.clab.yml
@@ -1,0 +1,38 @@
+# Copyright 2026 The osvbng Authors
+# Licensed under the GNU General Public License v3.0 or later.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: osvbng-ipoe-churn
+
+topology:
+  nodes:
+    bng1:
+      kind: linux
+      image: veesixnetworks/osvbng:local
+      image-pull-policy: Never
+      cap-add:
+        - SYS_ADMIN
+        - NET_ADMIN
+        - IPC_LOCK
+        - SYS_NICE
+      env:
+        OSVBNG_WAIT_FOR_INTERFACES: "true"
+        OSVBNG_NUM_INTERFACES: "3"
+      binds:
+        - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
+
+    # bngblaster holds both ends: eth1 emulates the dot1ad/dot1q QinQ
+    # subscribers whose sessions the monkey churns, eth2 is the network side.
+    subscribers:
+      kind: linux
+      image: veesixnetworks/bngblaster:0.9.30
+      cap-add:
+        - NET_ADMIN
+      binds:
+        - config/subscribers/config.json:/config/config.json:ro
+
+  links:
+    - endpoints: [bng1:eth1, subscribers:eth1]
+      mtu: 1500
+    - endpoints: [bng1:eth2, subscribers:eth2]
+      mtu: 1500

--- a/tests/53-ipoe-churn/53-ipoe-churn.robot
+++ b/tests/53-ipoe-churn/53-ipoe-churn.robot
@@ -1,0 +1,170 @@
+# Copyright 2026 The osvbng Authors
+# Licensed under the GNU General Public License v3.0 or later.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+*** Comments ***
+IPoE session churn: eight dual-stack dot1ad/dot1q QinQ subscribers driven
+through BNG Blaster's monkey, which kills sessions by several methods
+including an ungraceful kill that sends no DHCP RELEASE. Every subscriber
+must come back, every time.
+
+This is the suite 51 deferred - its header records finding "IPoE sessions
+refused on reconnect after an ungraceful kill" while exercising monkey for
+HQoS, out of scope there, keywords left in bngblaster.robot for whoever
+picked it up.
+
+What made that bite was the per-subscriber session limit counting from a
+cache counter that only the DHCPv4 and DHCPv6 RELEASE handlers
+decremented. A subscriber the monkey killed ungracefully was reaped by
+cleanupSessions, which released its addresses, its lease, its VPP session
+and every index but not that counter, so the next DISCOVER was rejected
+against a count no live session backed and the subscriber was locked out
+until the key's TTL expired. Sessions drained away one per churn cycle.
+
+Two things about the shape of this suite are deliberate:
+
+The soak between churn rounds is the point, not padding. The reaper is
+what turns a killed session into a leaked count, it runs on a five minute
+ticker, and a session killed ungracefully is only reapable once its lease
+plus grace has passed. Churn alone reconnects too fast to reach either.
+
+The failure is asserted as an outcome - subscribers are back in the API
+and in VPP - rather than by grepping for the fix. A count derived from the
+session map cannot drift, so no log line proves it right, only working
+subscribers do. The log checks that follow are there to name the cause
+when the outcome assertion fails.
+
+*** Settings ***
+Library             OperatingSystem
+Library             String
+Library             Process
+Resource            ../common.robot
+Resource            ../bngblaster.robot
+Resource            ../sessions.robot
+
+Suite Setup         Deploy Topology    ${lab-file}
+Suite Teardown      Teardown Churn Test
+
+*** Variables ***
+${lab-name}         osvbng-ipoe-churn
+${lab-file}         ${CURDIR}/53-ipoe-churn.clab.yml
+${bng1}             clab-${lab-name}-bng1
+${subscribers}      clab-${lab-name}-subscribers
+${session-count}    8
+${churn-secs}       45
+# Lease 120s + leaseGrace 30s makes a killed session reapable at 150s; the
+# reaper ticks every 300s. 420s clears one full tick past that worst case.
+${soak-secs}        420
+
+*** Test Cases ***
+Verify BNG Is Healthy
+    [Documentation]    Wait for osvbng to fully start.
+    Wait For osvbng Healthy    bng1    ${lab-name}
+
+Verify VPP Is Running
+    ${output} =    Execute VPP Command    ${bng1}    show version
+    Should Contain    ${output}    vpp
+
+Establish Subscriber Sessions
+    [Documentation]    Eight dual-stack QinQ IPoE sessions across two dot1ad
+    ...    S-VLANs, four C-VLANs each.
+    Start BNG Blaster In Background    ${subscribers}
+    Wait For Sessions Established    ${bng1}    ${subscribers}    ${session-count}    check_ipv6=true
+
+Verify Session Interfaces Created In VPP
+    [Documentation]    Baseline: one ipoe_session interface per subscriber.
+    ...    This count is the drain symptom - it fell by one per lost
+    ...    subscriber and never recovered.
+    Verify Session Interface Count    ${bng1}    ${session-count}
+
+Churn Sessions And Recover
+    [Documentation]    First monkey run. Most subscribers reconnect while
+    ...    their session record is still live, which is the path that always
+    ...    worked; this round mainly seeds the killed sessions the soak then
+    ...    lets the reaper collect.
+    Churn Sessions    ${subscribers}    ${churn-secs}
+    Verify Sessions Flapped    ${subscribers}    minimum=1
+    Recover After Churn    ${bng1}
+
+Soak Past The Stale-Session Reaper
+    [Documentation]    Idle long enough for any session the monkey killed
+    ...    ungracefully to pass its lease and be collected by the reaper.
+    ...    Subscribers must still be whole afterwards: reaping a session the
+    ...    subscriber has already re-established must not disturb it, and a
+    ...    reaped session must leave nothing behind that blocks its own
+    ...    return.
+    Sleep    ${soak-secs}
+    Recover After Churn    ${bng1}
+
+Churn Sessions Again And Recover
+    [Documentation]    Second monkey run, now on top of whatever the reaper
+    ...    collected during the soak. This is the round that failed: with the
+    ...    counter leaked, these subscribers had no route back.
+    Churn Sessions    ${subscribers}    ${churn-secs}
+    Verify Sessions Flapped    ${subscribers}    minimum=1
+    Recover After Churn    ${bng1}
+
+Verify No Subscriber Was Locked Out
+    [Documentation]    The specific regression. A DISCOVER rejected on the
+    ...    session limit means the admission count outlived the session it
+    ...    was counting, which is exactly what locked subscribers out.
+    ${count} =    Count osvbngd Log Matches    ${bng1}    session limit reached
+    Should Be Equal As Integers    ${count}    0
+    ...    ${count} DISCOVER(s) rejected on the session limit - an admission count outlived its session
+
+Report Dataplane Session Create Failures
+    [Documentation]    Diagnostic, not a gate. A failed add leaves the
+    ...    control plane with no session interface and no retry, so it would
+    ...    already have failed a Recover After Churn above. Reported here so
+    ...    a failure upstream names its cause instead of leaving one to go
+    ...    log-diving. Known open issue: the plugin's add returns
+    ...    ENTRY_ALREADY_EXISTS where the control plane expects the
+    ...    0 / ENTRY_NEEDS_REFRESH contract that osvbng_pppoe implements.
+    ${count} =    Count osvbngd Log Matches    ${bng1}    Failed to create IPoE session in VPP
+    Log    IPoE session create failures during churn: ${count}    console=yes
+
+*** Keywords ***
+Recover After Churn
+    [Documentation]    Every subscriber is back, dual-stack, and has a
+    ...    dataplane interface behind it. Asserted against osvbng and VPP
+    ...    rather than BNG Blaster's counters, which accumulate across flaps.
+    [Arguments]    ${container}
+    Wait Until Keyword Succeeds    60 x    5s
+    ...    Check All Subscribers Present    ${container}
+    Wait Until Keyword Succeeds    30 x    2s
+    ...    Verify Session Interface Count    ${container}    ${session-count}
+
+Check All Subscribers Present
+    [Arguments]    ${container}
+    ${output} =    Get osvbng API Response    ${container}    /api/show/subscriber/sessions
+    ${rc}    ${result} =    Run And Return Rc And Output
+    ...    echo '${output}' | python3 -c "import sys,json; s=json.load(sys.stdin).get('data') or []; v4=len([x for x in s if x.get('IPv4Address') and x['IPv4Address']!='<nil>']); v6=len([x for x in s if x.get('IPv6Address') and x['IPv6Address']!='<nil>']); print(f'{len(s)} {v4} {v6}')"
+    Should Be Equal As Integers    ${rc}    0
+    @{parts} =    Split String    ${result}
+    Should Be Equal As Strings    ${parts}[0]    ${session-count}
+    ...    ${parts}[0]/${session-count} subscribers present - a churned subscriber did not re-establish
+    Should Be Equal As Strings    ${parts}[1]    ${session-count}
+    ...    ${parts}[1]/${session-count} subscribers have IPv4
+    Should Be Equal As Strings    ${parts}[2]    ${session-count}
+    ...    ${parts}[2]/${session-count} subscribers have IPv6
+
+Verify Session Interface Count
+    [Documentation]    Count ipoe_session interfaces in VPP. The control
+    ...    plane can hold a session record whose dataplane interface was
+    ...    never created, so this is checked separately from the API.
+    [Arguments]    ${container}    ${expected}
+    ${output} =    Execute VPP Command    ${container}    show interface
+    ${count} =    Get Count    ${output}    ipoe_session
+    Should Be Equal As Integers    ${count}    ${expected}
+    ...    ${count} ipoe_session interfaces in VPP, expected ${expected}
+
+Count osvbngd Log Matches
+    [Arguments]    ${container}    ${pattern}
+    ${rc}    ${count} =    Run And Return Rc And Output
+    ...    sudo docker logs ${container} 2>&1 | grep -c "${pattern}" || true
+    RETURN    ${count}
+
+Teardown Churn Test
+    Run Keyword And Ignore Error    BNG Blaster CLI Command    ${subscribers}    monkey-stop
+    Run Keyword And Ignore Error    Stop BNG Blaster    ${subscribers}
+    Destroy Topology    ${lab-file}

--- a/tests/53-ipoe-churn/config/bng1/osvbng.yaml
+++ b/tests/53-ipoe-churn/config/bng1/osvbng.yaml
@@ -1,0 +1,138 @@
+# Copyright 2026 The osvbng Authors
+# Licensed under the GNU General Public License v3.0 or later.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Eight dual-stack QinQ subscribers across two dot1ad S-VLANs, sized and
+# timed so BNG Blaster's monkey can drive the reconnect paths this suite
+# exercises. Two settings are load-bearing and must not be "tidied":
+#
+#   aaa.policy.max_concurrent_sessions: 1
+#       checkSessionLimit returns early when this is 0, and the whole
+#       admission path under test is skipped.
+#
+#   ipv4-profiles.default.dhcp.lease-time: 120
+#       A session the monkey kills ungracefully stays "bound" until its
+#       lease expires, and only then does the stale-session reaper remove
+#       it. The reaper's reap point is BoundAt + lease + leaseGrace, where
+#       leaseGrace is min(lease/4, 5m). At 120s that is 150s, reachable
+#       inside a test run; at the usual 3600s it is over an hour and the
+#       suite would pass without ever exercising the reaper.
+
+subscriber-groups:
+    groups:
+        churn-100:
+            vlan-tpid: dot1ad
+            ipv4-profile: default
+            ipv6-profile: default-v6
+            vlans:
+                - svlan: "100"
+                  cvlan: any
+                  interface: loop100
+                  parent-interface: eth1
+                  access-types: [ipoe]
+            aaa-policy: default-policy
+        churn-200:
+            vlan-tpid: dot1ad
+            ipv4-profile: default
+            ipv6-profile: default-v6
+            vlans:
+                - svlan: "200"
+                  cvlan: any
+                  interface: loop100
+                  parent-interface: eth1
+                  access-types: [ipoe]
+            aaa-policy: default-policy
+
+ipv4-profiles:
+    default:
+        gateway: 10.255.0.1
+        dns:
+            - 8.8.8.8
+        pools:
+            - name: subscriber-pool
+              network: 10.255.0.0/16
+              priority: 1
+        dhcp:
+            lease-time: 120
+
+ipv6-profiles:
+    default-v6:
+        iana-pools:
+            - name: wan-link-pool
+              network: 2001:db8:0:1::/64
+              range_start: 2001:db8:0:1::1000
+              range_end: 2001:db8:0:1::ffff
+              gateway: 2001:db8:0:1::1
+              preferred_time: 120
+              valid_time: 240
+        pd-pools:
+            - name: subscriber-pd-pool
+              network: 2001:db8:100::/40
+              prefix_length: 56
+              preferred_time: 120
+              valid_time: 240
+        dns:
+            - 2001:4860:4860::8888
+
+dhcp:
+    provider: local
+
+dhcpv6:
+    provider: local
+    dns_servers:
+        - 2001:4860:4860::8888
+    ra:
+        router_lifetime: 1800
+        max_interval: 600
+        min_interval: 200
+
+interfaces:
+    loop0:
+        description: Control Plane Loopback
+        enabled: true
+        address:
+            ipv4:
+                - 10.254.0.1/32
+    eth1:
+        description: Access Interface
+        enabled: true
+    eth2:
+        description: Core Link (bngblaster network side)
+        enabled: true
+        address:
+            ipv4:
+                - 10.0.0.1/30
+    loop100:
+        description: Subscriber Gateway Loopback
+        enabled: true
+        address:
+            ipv4:
+                - 10.255.0.1/32
+            ipv6:
+                - 2001:db8:0:1::1/128
+
+aaa:
+    auth_provider: local
+    nas_identifier: osvbng
+    policy:
+        - name: default-policy
+          format: $mac-address$
+          max_concurrent_sessions: 1
+
+plugins:
+    northbound.api:
+        enabled: true
+        listeners:
+            - address: :8080
+    subscriber.auth.local:
+        allow_all: true
+        database_path: /tmp/osvbng.db
+
+logging:
+    format: text
+    level: info
+    components:
+        ipoe: debug
+
+dataplane:
+    lcp-netns: dataplane

--- a/tests/53-ipoe-churn/config/subscribers/config.json
+++ b/tests/53-ipoe-churn/config/subscribers/config.json
@@ -1,0 +1,50 @@
+{
+  "interfaces": {
+    "network": [
+      {
+        "interface": "eth2",
+        "address": "10.0.0.2/30",
+        "gateway": "10.0.0.1"
+      }
+    ],
+    "access": [
+      {
+        "interface": "eth1",
+        "type": "ipoe",
+        "qinq": true,
+        "vlan-mode": "1:1",
+        "outer-vlan": 100,
+        "inner-vlan-min": 10,
+        "inner-vlan-max": 13,
+        "monkey": true
+      },
+      {
+        "interface": "eth1",
+        "type": "ipoe",
+        "qinq": true,
+        "vlan-mode": "1:1",
+        "outer-vlan": 200,
+        "inner-vlan-min": 10,
+        "inner-vlan-max": 13,
+        "monkey": true
+      }
+    ]
+  },
+  "sessions": {
+    "count": 8,
+    "max-outstanding": 8,
+    "reconnect": true,
+    "monkey-autostart": false
+  },
+  "dhcp": {
+    "enable": true,
+    "retry": 60
+  },
+  "dhcpv6": {
+    "enable": true,
+    "retry": 60
+  },
+  "ipoe": {
+    "ipv6": true
+  }
+}

--- a/tests/54-pppoe-churn/54-pppoe-churn.clab.yml
+++ b/tests/54-pppoe-churn/54-pppoe-churn.clab.yml
@@ -1,0 +1,38 @@
+# Copyright 2026 The osvbng Authors
+# Licensed under the GNU General Public License v3.0 or later.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: osvbng-pppoe-churn
+
+topology:
+  nodes:
+    bng1:
+      kind: linux
+      image: veesixnetworks/osvbng:local
+      image-pull-policy: Never
+      cap-add:
+        - SYS_ADMIN
+        - NET_ADMIN
+        - IPC_LOCK
+        - SYS_NICE
+      env:
+        OSVBNG_WAIT_FOR_INTERFACES: "true"
+        OSVBNG_NUM_INTERFACES: "3"
+      binds:
+        - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
+
+    # bngblaster holds both ends: eth1 emulates the dot1ad/dot1q QinQ
+    # subscribers whose sessions the monkey churns, eth2 is the network side.
+    subscribers:
+      kind: linux
+      image: veesixnetworks/bngblaster:0.9.30
+      cap-add:
+        - NET_ADMIN
+      binds:
+        - config/subscribers/config.json:/config/config.json:ro
+
+  links:
+    - endpoints: [bng1:eth1, subscribers:eth1]
+      mtu: 1500
+    - endpoints: [bng1:eth2, subscribers:eth2]
+      mtu: 1500

--- a/tests/54-pppoe-churn/54-pppoe-churn.robot
+++ b/tests/54-pppoe-churn/54-pppoe-churn.robot
@@ -1,0 +1,191 @@
+# Copyright 2026 The osvbng Authors
+# Licensed under the GNU General Public License v3.0 or later.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+*** Comments ***
+PPPoE session churn: eight authenticated dot1ad/dot1q QinQ subscribers
+driven through BNG Blaster's monkey, which kills sessions by several
+methods including an ungraceful kill that sends no PADT. Every subscriber
+must come back, and the dataplane must still be the process it started as.
+
+The PPPoE half of what suite 51 and 52 deferred. Their headers record
+monkey finding two defects out of scope for HQoS: IPoE sessions refused
+on reconnect after an ungraceful kill, now covered by suite 53, and a
+dataplane crash under PPPoE churn, which is this suite.
+
+That expected fault is why survival is a first-class assertion rather
+than something inferred from a passing session count. VPP's pid is
+captured at baseline and compared after every round: the watchdog
+restarts a dead dataplane, so a crash and recovery leaves sessions
+re-established and every session-level assertion green while the thing
+under test has died and been replaced. The pid is the only check that
+sees it.
+
+This suite runs with no QoS at all. Suite 52 keeps a hand-swapped
+osvbng-noqos.yaml to answer whether churn destabilises the dataplane
+independently of the CAKE plugin; here that is the default, so a failure
+implicates the PPPoE path rather than leaving the two entangled.
+
+Unlike suite 53 there is no admission counter to leak, and no lease and
+no reaper to wait on. A session the monkey kills ungracefully is torn
+down when its LCP keepalives expire, so the soak is sized for that rather
+than for a reap tick.
+
+*** Settings ***
+Library             OperatingSystem
+Library             String
+Library             Process
+Resource            ../common.robot
+Resource            ../bngblaster.robot
+Resource            ../sessions.robot
+Resource            ../localauth.robot
+
+Suite Setup         Deploy Topology    ${lab-file}
+Suite Teardown      Teardown Churn Test
+
+*** Variables ***
+${lab-name}         osvbng-pppoe-churn
+${lab-file}         ${CURDIR}/54-pppoe-churn.clab.yml
+${bng1}             clab-${lab-name}-bng1
+${subscribers}      clab-${lab-name}-subscribers
+${session-count}    8
+${churn-secs}       45
+# Long enough for LCP keepalives to expire on any session the monkey killed
+# without a PADT, so the BNG tears it down on its own rather than on the
+# subscriber's re-connect.
+${soak-secs}        180
+${vpp-pid}          ${EMPTY}
+
+*** Test Cases ***
+Verify BNG Is Healthy
+    [Documentation]    Wait for osvbng to fully start.
+    Wait For osvbng Healthy    bng1    ${lab-name}
+
+Verify VPP Is Running
+    ${output} =    Execute VPP Command    ${bng1}    show version
+    Should Contain    ${output}    vpp
+
+Record Baseline Dataplane PID
+    [Documentation]    Everything after this compares against this pid. A
+    ...    watchdog restart of a crashed VPP is invisible to every other
+    ...    assertion in the suite.
+    ${pid} =    Get VPP PID    ${bng1}
+    Set Suite Variable    ${vpp-pid}    ${pid}
+    Log    Baseline VPP pid: ${vpp-pid}    console=yes
+
+Establish Subscriber Sessions
+    [Documentation]    Eight QinQ PPPoE sessions across two dot1ad S-VLANs,
+    ...    authenticated against pre-created local users.
+    Create PPPoE Users    ${bng1}    ${session-count}
+    Start BNG Blaster In Background    ${subscribers}
+    Wait For Sessions Established    ${bng1}    ${subscribers}    ${session-count}
+
+Verify Session Interfaces Created In VPP
+    [Documentation]    Baseline: one pppoe_session interface per subscriber.
+    Verify Session Interface Count    ${bng1}    ${session-count}
+
+Churn Sessions And Recover
+    [Documentation]    First monkey run. Dataplane survival is checked before
+    ...    session recovery so a crash is reported as a crash rather than as
+    ...    whatever the sessions happen to look like afterwards.
+    Churn Sessions    ${subscribers}    ${churn-secs}
+    Verify Sessions Flapped    ${subscribers}    minimum=1
+    Verify Dataplane Survived    ${bng1}
+    Recover After Churn    ${bng1}
+
+Soak Past LCP Keepalive Expiry
+    [Documentation]    Idle long enough for the BNG to time out any session
+    ...    the monkey killed without a PADT, so those teardowns run on the
+    ...    BNG's own timers rather than racing the subscriber's reconnect.
+    Sleep    ${soak-secs}
+    Verify Dataplane Survived    ${bng1}
+    Recover After Churn    ${bng1}
+
+Churn Sessions Again And Recover
+    [Documentation]    Second monkey run, on top of whatever the keepalive
+    ...    expiries tore down during the soak.
+    Churn Sessions    ${subscribers}    ${churn-secs}
+    Verify Sessions Flapped    ${subscribers}    minimum=1
+    Verify Dataplane Survived    ${bng1}
+    Recover After Churn    ${bng1}
+
+Verify Dataplane Never Restarted
+    [Documentation]    Final gate on the whole run, not just the last round.
+    Verify Dataplane Survived    ${bng1}
+
+Report Dataplane Faults
+    [Documentation]    Diagnostic, not a gate. If the pid held, nothing here
+    ...    should have fired; if it did not, this names what killed it
+    ...    without a trip into the container.
+    ${faults} =    Count Container Log Matches    ${bng1}    received signal\\|SIGSEGV\\|SIGABRT\\|assertion\\|BUG:
+    Log    Dataplane fault signatures in container log: ${faults}    console=yes
+    ${restarts} =    Count Container Log Matches    ${bng1}    restarting vpp\\|vpp restart\\|dataplane restart
+    Log    Watchdog dataplane restarts logged: ${restarts}    console=yes
+
+*** Keywords ***
+Get VPP PID
+    [Arguments]    ${container}
+    ${rc}    ${pid} =    Run And Return Rc And Output
+    ...    sudo docker exec ${container} pidof vpp
+    Should Be Equal As Integers    ${rc}    0    VPP is not running in ${container}
+    Should Not Be Empty    ${pid}
+    RETURN    ${pid}
+
+Verify Dataplane Survived
+    [Documentation]    VPP is the same process it was at baseline and still
+    ...    answers on the CLI socket. The watchdog respawns a dead VPP, so a
+    ...    responsive dataplane on its own proves nothing.
+    [Arguments]    ${container}
+    ${pid} =    Get VPP PID    ${container}
+    Should Be Equal As Strings    ${pid}    ${vpp-pid}
+    ...    VPP restarted during churn: pid ${vpp-pid} -> ${pid}, the dataplane died and the watchdog replaced it
+    ${output} =    Execute VPP Command    ${container}    show version
+    Should Contain    ${output}    vpp
+
+Recover After Churn
+    [Documentation]    Every subscriber is back and has a dataplane interface
+    ...    behind it. Asserted against osvbng and VPP rather than BNG
+    ...    Blaster's counters, which accumulate across flaps.
+    [Arguments]    ${container}
+    Wait Until Keyword Succeeds    60 x    5s
+    ...    Check All Subscribers Present    ${container}
+    Wait Until Keyword Succeeds    30 x    2s
+    ...    Verify Session Interface Count    ${container}    ${session-count}
+
+Check All Subscribers Present
+    [Arguments]    ${container}
+    ${output} =    Get osvbng API Response    ${container}    /api/show/subscriber/sessions
+    ${rc}    ${result} =    Run And Return Rc And Output
+    ...    echo '${output}' | python3 -c "import sys,json; s=json.load(sys.stdin).get('data') or []; v4=len([x for x in s if x.get('IPv4Address') and x['IPv4Address']!='<nil>']); print(f'{len(s)} {v4}')"
+    Should Be Equal As Integers    ${rc}    0
+    @{parts} =    Split String    ${result}
+    Should Be Equal As Strings    ${parts}[0]    ${session-count}
+    ...    ${parts}[0]/${session-count} subscribers present - a churned subscriber did not re-establish
+    Should Be Equal As Strings    ${parts}[1]    ${session-count}
+    ...    ${parts}[1]/${session-count} subscribers have IPv4
+
+Verify Session Interface Count
+    [Documentation]    Count pppoe_session interfaces in VPP, separately from
+    ...    the API, because the control plane can hold a session record whose
+    ...    dataplane interface was never created.
+    ...    The count stays exact across churn even though the plugin parks
+    ...    torn-down interfaces on a free list for reuse instead of deleting
+    ...    them: parking sets VNET_SW_INTERFACE_FLAG_HIDDEN, and show
+    ...    interface filters on vnet_swif_is_api_visible, so a parked
+    ...    interface is not listed until a new session claims it.
+    [Arguments]    ${container}    ${expected}
+    ${output} =    Execute VPP Command    ${container}    show interface
+    ${count} =    Get Count    ${output}    pppoe_session
+    Should Be Equal As Integers    ${count}    ${expected}
+    ...    ${count} pppoe_session interfaces in VPP, expected ${expected}
+
+Count Container Log Matches
+    [Arguments]    ${container}    ${pattern}
+    ${rc}    ${count} =    Run And Return Rc And Output
+    ...    sudo docker logs ${container} 2>&1 | grep -ci "${pattern}" || true
+    RETURN    ${count}
+
+Teardown Churn Test
+    Run Keyword And Ignore Error    BNG Blaster CLI Command    ${subscribers}    monkey-stop
+    Run Keyword And Ignore Error    Stop BNG Blaster    ${subscribers}
+    Destroy Topology    ${lab-file}

--- a/tests/54-pppoe-churn/config/bng1/osvbng.yaml
+++ b/tests/54-pppoe-churn/config/bng1/osvbng.yaml
@@ -1,0 +1,103 @@
+# Copyright 2026 The osvbng Authors
+# Licensed under the GNU General Public License v3.0 or later.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Eight authenticated QinQ PPPoE subscribers across two dot1ad S-VLANs,
+# four C-VLANs each. The PPPoE twin of suite 53's config.
+#
+# No QoS anywhere: no schedulers, no aggregates, no service groups. Suite
+# 52 carries a hand-swapped osvbng-noqos.yaml for exactly the question
+# this suite asks by default - whether the dataplane survives PPPoE
+# session churn on its own, with the CAKE plugin out of the picture. If
+# it does not survive here, the fault is not in QoS.
+#
+# service-groups is omitted entirely rather than emptied: a service group
+# with a nil body panics osvbngd at startup in Resolver.Set.
+#
+# There is no max_concurrent_sessions here and that is not an oversight.
+# Unlike IPoE, the PPPoE component has no admission counter; the session
+# limit path does not exist for PPPoE, so setting it would configure
+# nothing.
+
+subscriber-groups:
+    groups:
+        churn-100:
+            vlan-tpid: dot1ad
+            ipv4-profile: default
+            vlans:
+                - svlan: "100"
+                  cvlan: any
+                  interface: loop100
+                  parent-interface: eth1
+                  access-types: [pppoe]
+            aaa-policy: pppoe-policy
+        churn-200:
+            vlan-tpid: dot1ad
+            ipv4-profile: default
+            vlans:
+                - svlan: "200"
+                  cvlan: any
+                  interface: loop100
+                  parent-interface: eth1
+                  access-types: [pppoe]
+            aaa-policy: pppoe-policy
+
+ipv4-profiles:
+    default:
+        gateway: 10.255.0.1
+        dns:
+            - 8.8.8.8
+        pools:
+            - name: subscriber-pool
+              network: 10.255.0.0/16
+              priority: 1
+
+interfaces:
+    loop0:
+        description: Control Plane Loopback
+        enabled: true
+        address:
+            ipv4:
+                - 10.254.0.1/32
+    eth1:
+        description: Access Interface
+        enabled: true
+    eth2:
+        description: Core Link (bngblaster network side)
+        enabled: true
+        address:
+            ipv4:
+                - 10.0.0.1/30
+    loop100:
+        description: Subscriber Gateway Loopback
+        enabled: true
+        address:
+            ipv4:
+                - 10.255.0.1/32
+
+aaa:
+    auth_provider: local
+    nas_identifier: osvbng
+    policy:
+        - name: pppoe-policy
+          type: ppp
+          format: $agent-remote-id$
+          authenticate: true
+
+plugins:
+    northbound.api:
+        enabled: true
+        listeners:
+            - address: :8080
+    subscriber.auth.local:
+        allow_all: false
+        database_path: /tmp/osvbng.db
+
+logging:
+    format: text
+    level: info
+    components:
+        pppoe: debug
+
+dataplane:
+    lcp-netns: dataplane

--- a/tests/54-pppoe-churn/config/subscribers/config.json
+++ b/tests/54-pppoe-churn/config/subscribers/config.json
@@ -1,0 +1,67 @@
+{
+  "interfaces": {
+    "network": [
+      {
+        "interface": "eth2",
+        "address": "10.0.0.2/30",
+        "gateway": "10.0.0.1"
+      }
+    ],
+    "access": [
+      {
+        "interface": "eth1",
+        "type": "pppoe",
+        "qinq": true,
+        "vlan-mode": "1:1",
+        "outer-vlan": 100,
+        "inner-vlan-min": 10,
+        "inner-vlan-max": 13,
+        "monkey": true
+      },
+      {
+        "interface": "eth1",
+        "type": "pppoe",
+        "qinq": true,
+        "vlan-mode": "1:1",
+        "outer-vlan": 200,
+        "inner-vlan-min": 10,
+        "inner-vlan-max": 13,
+        "monkey": true
+      }
+    ]
+  },
+  "sessions": {
+    "count": 8,
+    "max-outstanding": 8,
+    "reconnect": true,
+    "monkey-autostart": false
+  },
+  "pppoe": {
+    "reconnect": true,
+    "discovery-timeout": 5,
+    "discovery-retry": 30,
+    "host-uniq": true
+  },
+  "ppp": {
+    "authentication": {
+      "username": "user{session-global}",
+      "password": "test",
+      "timeout": 10,
+      "retry": 30
+    },
+    "lcp": {
+      "conf-request-timeout": 5,
+      "conf-request-retry": 10,
+      "keepalive-retry": 5
+    },
+    "ipcp": {
+      "enable": true
+    },
+    "ip6cp": {
+      "enable": false
+    }
+  },
+  "access-line": {
+    "agent-remote-id": "user{session-global}"
+  }
+}


### PR DESCRIPTION
## Problem

IPoE subscribers were locked out after their session ended any way other than a DHCP RELEASE, and stayed locked out. Under BNG Blaster monkey churn, which kills sessions abruptly by design, subscribers drained away one per churn cycle and never came back: `ipoe_session` interfaces in VPP fell 56, 55, 54, 53 while every re-DISCOVER was answered with `DHCPDISCOVER rejected error="session limit reached (1/1) for 02:00:00:00:00:57 on VLAN 105:8"`.

The per-subscriber session limit counted from `osvbng:session_count:<mac>:<svlan>:<cvlan>` in the cache. That counter was incremented on DHCPv4 bind and decremented in exactly two places, the DHCPv4 and DHCPv6 RELEASE handlers. Every other teardown path removed the session and left the count behind: `cleanupSessions` (the stale-session reaper) and the CoA terminate path in `mutation.go` both release the addresses, the lease, the VPP session and every in-memory index, and neither touched the counter.

So a subscriber the monkey killed ungracefully was reaped once its lease expired, its dataplane interface went with it, and the next DISCOVER was then rejected against a count no live session backed. Recovery only came from the key's TTL, two lease times capped at 24h. With the shipped default of `max_concurrent_sessions: 1` the first churn cycle that outlived the reaper was enough.

Two related defects in the same counter: `handleDHCPv6Release` decremented a key only the DHCPv4 bind ever incremented, so a v6 RELEASE on a dual-stack session decremented the v4 session's count while it was still up; and `pkg/cache/memory`'s `Decr` creates a missing key at `-1` rather than clamping at zero, so that unmatched decrement could park the counter negative and let a subscriber exceed its limit.

## Fix

Count the live session map instead. Every teardown path already has to remove the session from it, so the count cannot drift the way a separate counter can, and all three of the above go away together rather than being patched one leak site at a time.

The cache offered nothing here in exchange for that risk. `pkg/cache` has one implementation, `pkg/cache/memory`, constructed once at `cmd/osvbngd/main.go:237`; there is no Redis in the tree or in `go.mod`. The counter was in-process, node-local state duplicating `c.sessions`, which lives in the same process and is already authoritative.

Only sessions carrying an IPv4 binding are counted, which is what the counter tracked, so an independent-mode dual-stack subscriber still counts once. Sessions marked `Closing` are skipped: the reaper sets that before the session leaves the map, and a DISCOVER landing in that window is the re-establishment, not a second session. The counter replay in `restoreSessions` goes too, since restored sessions pass through `installInMemoryState` and the derived count already sees them.

## Testing

New `internal/ipoe/session_limit_test.go`, seven subtests pinning the semantics. `live_bound_session_blocks_a_second` was confirmed red against the old implementation before the change; `reaped_session_admits_the_next_discover` models exactly what `cleanupSessions` does and nothing more.

Full unit suite (`go test` over all packages except generated `/pkg/vpp/`) and `go test ./internal/ipoe/ -race` both pass in a `golang:1.24` container, along with `go build ./...`, `go vet` and `gofmt`.

Two new containerlab suites, both passing:

**`tests/53-ipoe-churn`** covers this fix end to end. Eight dual-stack dot1ad/dot1q QinQ subscribers driven through the monkey. Two parts of its shape are load-bearing and should not be tidied away: the soak between churn rounds is the test rather than padding, because what turns a killed session into a lockout is the reaper, which runs on a five minute ticker and only collects a session once its lease plus grace has passed, so the config sets a 120s lease to put the reap point at 150s and the suite idles past one full ticker after it; and `max_concurrent_sessions` is set to 1 because `checkSessionLimit` returns early at 0 and the whole admission path under test is skipped. The regression is asserted as an outcome, subscribers present in the API and backed by `ipoe_session` interfaces in VPP, rather than by grepping for the fix.

**`tests/54-pppoe-churn`** is the PPPoE half of what suites 51 and 52 deferred, and is **not** a regression test for this fix. `internal/pppoe` has no admission counter, so nothing here touched it. It targets the other defect those suites recorded, a dataplane crash under PPPoE churn, which is why VPP's pid is captured at baseline and compared after every round: the watchdog restarts a dead dataplane, so a crash and recovery would leave sessions re-established and every session-level assertion green while the process under test had been replaced. It runs with no QoS at all, so a failure implicates the PPPoE path instead of leaving it entangled with the CAKE plugin.

## Note on CI runtime

Neither suite is wired into CI by this PR. `ci.yml` runs an explicit enumerated list and 53 and 54 are not in it, so as merged they add nothing to the pipeline and are `make robot-test suite=53-ipoe-churn` / `suite=54-pppoe-churn` only.

Worth knowing before anyone adds them, because the cost is not small. They carry 13 minutes of deliberate fixed idle between them (53: a 420s soak plus 2x45s churn; 54: a 180s soak plus 2x45s churn) before topology deploy, session establishment, recovery polling and teardown. Expect roughly 12 to 15 minutes for 53 and 8 to 10 for 54, call it 20 to 25 minutes combined.

That time is idle by construction, not throughput, so it will not come down on a bigger runner and cannot be shortened without removing what the suites are actually testing. If they are added, they belong on the merge-to-main containerlab path rather than anywhere in the PR loop.
