### PR TITLE
test: poll readiness conditions at finer intervals

### DIFF
--- a/tests/01-smoke/01-smoke.robot
+++ b/tests/01-smoke/01-smoke.robot
@@ -43,12 +43,12 @@ Verify FRR Is Running On BNG
 
 Verify OSPF Adjacency Established
     [Documentation]    Wait for OSPF adjacency between bng1 and corerouter1.
-    Wait Until Keyword Succeeds    12 x    10s
+    Wait Until Keyword Succeeds    60 x    2s
     ...    Verify OSPF Adjacency On Router    ${corerouter1}
 
 Verify BGP Session Established
     [Documentation]    Wait for BGP session from bng1 (10.254.0.1) on corerouter1.
-    Wait Until Keyword Succeeds    12 x    10s
+    Wait Until Keyword Succeeds    60 x    2s
     ...    Verify BGP Session On Router    ${corerouter1}    10.254.0.1
 
 Verify REST API Responds
@@ -73,7 +73,7 @@ Verify Sessions Have IPv4
 
 Verify Traffic Flowing
     [Documentation]    Verify end-to-end traffic between access and network interfaces.
-    Wait Until Keyword Succeeds    6 x    10s
+    Wait Until Keyword Succeeds    30 x    2s
     ...    Verify Traffic Flowing    ${subscribers}    expected_flows=${session-count}
 
 *** Keywords ***

--- a/tests/common.robot
+++ b/tests/common.robot
@@ -12,8 +12,12 @@ Library             Collections
 ${CLAB_BIN}             sudo containerlab
 ${runtime}              docker
 ${OSVBNG_API_PORT}      8080
-${HEALTH_RETRIES}       60
-${HEALTH_INTERVAL}      5s
+# 300 x 1s keeps the same 5-minute budget as the previous 60 x 5s but
+# stops quantizing readiness to 5s steps: the daemon typically goes
+# healthy 11-15s after deploy, and a coarse poll pays up to a full
+# interval past that in every suite.
+${HEALTH_RETRIES}       300
+${HEALTH_INTERVAL}      1s
 ${VPPCTL_SOCK}          /run/osvbng/cli.sock
 ${TEST_LOG_DIR}         /tmp/test-logs
 


### PR DESCRIPTION
Suite wall-clock is dominated by polling waits whose intervals quantize short conditions up to the interval: health polls every 5s, adjacency and traffic checks every 10s, so a condition that turns true at 6s still costs 10.1s. The same 15s health, 10s OSPF, 10s traffic signature repeats across nearly every suite in past aggregate results.

This keeps every timeout budget identical and only polls finer: HEALTH_RETRIES/HEALTH_INTERVAL go from 60 x 5s to 300 x 1s in common.robot (same 5-minute budget, applies to all suites), and 01-smoke's three Wait Until Keyword Succeeds calls go from 12 x 10s and 6 x 10s to 60 x 2s and 30 x 2s (same 2-minute and 1-minute budgets). The checks are cheap docker execs, so finer polling adds no meaningful load. 01-smoke is the demonstrated pattern; rolling the 2s interval out to the remaining suites is mechanical follow-up, done per file.

Verified by running 01-smoke against veesixnetworks/osvbng:local before and after on the dev machine, both 10/10 pass. Robot suite elapsed 54.6s before, 46.9s after. Per test: BNG healthy 15.1s to 13.4s, OSPF adjacency 10.1s to 6.2s, traffic flowing 10.1s to 8.3s, so those waits now track the real condition times (13s, 6s, 8s) instead of the poll grid. Not verified: no other suite was run; the common.robot change affects all suites' health wait but only 01-smoke was exercised.