### PR TITLE
fix(dhcpv6): reject overflowing option lengths instead of panicking

### DIFF
--- a/pkg/dhcp6/message.go
+++ b/pkg/dhcp6/message.go
@@ -122,10 +122,11 @@ func ParseOptions(data []byte) Options {
 	for len(data) >= 4 {
 		code := binary.BigEndian.Uint16(data[0:2])
 		length := binary.BigEndian.Uint16(data[2:4])
-		if len(data) < int(4+length) {
+		end := 4 + int(length)
+		if len(data) < end {
 			break
 		}
-		optData := data[4 : 4+length]
+		optData := data[4:end:end]
 		switch code {
 		case OptClientID:
 			opts.ClientID = optData
@@ -157,7 +158,7 @@ func ParseOptions(data []byte) Options {
 				}
 			}
 		}
-		data = data[4+length:]
+		data = data[end:]
 	}
 	return opts
 }
@@ -175,7 +176,8 @@ func parseIANA(data []byte) *IANAOption {
 	for len(sub) >= 4 {
 		subCode := binary.BigEndian.Uint16(sub[0:2])
 		subLen := binary.BigEndian.Uint16(sub[2:4])
-		if len(sub) < int(4+subLen) {
+		end := 4 + int(subLen)
+		if len(sub) < end {
 			break
 		}
 		if subCode == OptIAAddr && subLen >= 24 {
@@ -183,7 +185,7 @@ func parseIANA(data []byte) *IANAOption {
 			opt.PreferredTime = binary.BigEndian.Uint32(sub[20:24])
 			opt.ValidTime = binary.BigEndian.Uint32(sub[24:28])
 		}
-		sub = sub[4+subLen:]
+		sub = sub[end:]
 	}
 	return opt
 }
@@ -201,7 +203,8 @@ func parseIAPD(data []byte) *IAPDOption {
 	for len(sub) >= 4 {
 		subCode := binary.BigEndian.Uint16(sub[0:2])
 		subLen := binary.BigEndian.Uint16(sub[2:4])
-		if len(sub) < int(4+subLen) {
+		end := 4 + int(subLen)
+		if len(sub) < end {
 			break
 		}
 		if subCode == OptIAPrefix && subLen >= 25 {
@@ -210,7 +213,7 @@ func parseIAPD(data []byte) *IAPDOption {
 			opt.PrefixLen = sub[12]
 			opt.Prefix = net.IP(sub[13:29])
 		}
-		sub = sub[4+subLen:]
+		sub = sub[end:]
 	}
 	return opt
 }

--- a/pkg/dhcp6/message_test.go
+++ b/pkg/dhcp6/message_test.go
@@ -354,3 +354,58 @@ func TestSerializeNoExtrasUnchanged(t *testing.T) {
 		t.Fatalf("response with nil Extras differs from empty slice")
 	}
 }
+
+func TestParseOptionsLengthOverflow(t *testing.T) {
+	for _, length := range []uint16{0xFFFC, 0xFFFD, 0xFFFE, 0xFFFF} {
+		opt := []byte{0x00, 0x01, 0x00, 0x00}
+		binary.BigEndian.PutUint16(opt[2:4], length)
+
+		data := append([]byte{byte(MsgTypeSolicit), 0x00, 0x00, 0x01}, opt...)
+		msg, err := ParseMessage(data)
+		if err != nil {
+			t.Fatalf("length %#x: unexpected error: %v", length, err)
+		}
+		if msg.Options.ClientID != nil {
+			t.Fatalf("length %#x: overflowing option must not produce ClientID", length)
+		}
+	}
+}
+
+func TestParseIANALengthOverflow(t *testing.T) {
+	iana := make([]byte, 12)
+	binary.BigEndian.PutUint32(iana[0:4], 1)
+	iana = append(iana, 0x00, byte(OptIAAddr), 0xFF, 0xFF)
+
+	if opt := parseIANA(iana); opt == nil || opt.Address != nil {
+		t.Fatalf("overflowing IA_NA sub-option must not yield an address, got %+v", opt)
+	}
+}
+
+func TestParseIAPDLengthOverflow(t *testing.T) {
+	iapd := make([]byte, 12)
+	binary.BigEndian.PutUint32(iapd[0:4], 1)
+	iapd = append(iapd, 0x00, byte(OptIAPrefix), 0xFF, 0xFF)
+
+	if opt := parseIAPD(iapd); opt == nil || opt.Prefix != nil {
+		t.Fatalf("overflowing IA_PD sub-option must not yield a prefix, got %+v", opt)
+	}
+}
+
+func TestUnwrapRelayInnerLengthOverflow(t *testing.T) {
+	inner := []byte{byte(MsgTypeSolicit), 0x00, 0x00, 0x01, 0x00, 0x01, 0xFF, 0xFF}
+
+	relay := make([]byte, 0, 64)
+	relay = append(relay, byte(MsgTypeRelayForward))
+	relay = append(relay, 0)
+	relay = append(relay, make([]byte, 16)...)
+	relay = append(relay, make([]byte, 16)...)
+	relay = appendOption(relay, OptRelayMsg, inner)
+
+	msg, info := UnwrapRelay(relay)
+	if msg == nil || info == nil {
+		t.Fatal("relay unwrap should succeed; the inner option is malformed, the envelope is not")
+	}
+	if msg.Options.ClientID != nil {
+		t.Fatal("overflowing inner option must not produce ClientID")
+	}
+}


### PR DESCRIPTION
## Problem

A DHCPv6 option length of 65532 or above panics `osvbngd` and drops every session on the box. One small datagram, from any subscriber, before authentication.

`length` is `uint16`, and the bounds check was `if len(data) < int(4+length)`. The untyped constant `4` converts to `uint16`, so the addition wraps *before* the `int` conversion. At `length = 0xFFFF` the guard computes `3`, passes, and the following `data[4 : 4+length]` slices with a high bound below its low bound:

```
DHCPv6 body:  01 00 00 00 | 00 01 FF FF
panic: runtime error: slice bounds out of range [4:3]
```

Seven sites share the mistake, each in its guard, its slice and its advance: the option loop in `ParseOptions`, and the sub-option loops in `parseIANA` and `parseIAPD`. `UnwrapRelay` at `message.go:250` and `:276` already widens before adding, so the correct form was in the same file.

Nothing on the packet path recovers. `internal/ipoe.consumeDHCPv6Packets` dispatches each packet in a bare `go func`, and the only `recover()` outside tests is in `pkg/telemetry`, so the panic terminates the process rather than dropping one packet.

**gopacket does not prevent this.** It decodes only the outer TLV layer and treats option data as opaque, so two things reach the parser unvalidated:

- poisoned IA_NA or IA_PD sub-options inside an otherwise well-formed message, and
- a poisoned inner message inside a Relay-Forward, since the Relay Message option is just opaque option data to the outer decode.

The PPPoE path does not involve gopacket at all — `internal/pppoe/session.go` passes `udp.Payload` straight to `ParseMessage`.

Reproduced on a running BNG by injecting a Relay-Forward carrying an eight-byte inner message, which panics in `UnwrapRelay` → `ParseMessage` → `ParseOptions` and takes the daemon down.

## Change

Compute the end offset once in `int`, and use it for the guard, the slice and the advance in all three loops.

The option data now gets a capped three-index slice. The previous two-index slice left `cap(optData)` running to the end of the whole packet buffer, so a bounds slip could read into the neighbouring option rather than failing: with a malformed IA_PD sub-option, `binary.BigEndian.Uint32(sub[4:8])` succeeded on a four-byte `sub` and returned four bytes belonging to the next option, and only a later index panicked.

## Verification

Four regression tests: all four wrapping lengths (65532-65535) at the top level, the IA_NA sub-option level and the IA_PD sub-option level, plus the relay-encapsulated case. Each panics against the parser as it stands on `main` and passes with this change.

`make build` and `make test` pass. `golangci-lint run ./pkg/dhcp6/...` reports no issues, and the branch introduces no new lint findings against `main` — both are identical at 417 issues uncapped, so `make lint` already fails on `main` independently of this change.

Verified on hardware in both directions, not only by unit tests. A Relay-Forward carrying the malformed inner message reproduces the panic and daemon exit on an unpatched build of a running BNG, and a patched build handles the same input cleanly with the session intact and the daemon up.

**Not verified.** Whether the VPP punt plugins do any option-length validation before punting was not checked — if they do, that narrows the IPoE path, but not the PPPoE one, which bypasses gopacket entirely. The change was not run under containerlab or bngblaster specifically.
