### PR TITLE
build(runner): ansible bootstrap for the dedicated ci runner

### DIFF
--- a/test-infra/runner/.gitignore
+++ b/test-infra/runner/.gitignore
@@ -1,0 +1,5 @@
+# Host-specific and secret material stays local. The example file is
+# the only inventory that ships.
+inventory.yml
+*.key
+*.pem

--- a/test-infra/runner/README.md
+++ b/test-infra/runner/README.md
@@ -49,6 +49,22 @@ Rerunning the playbook is how drift gets fixed. Registration tasks
 are skipped when the runner services already exist, so reruns do not
 need tokens.
 
+## Concurrency
+
+A GitHub runner service executes one job at a time. Parallelism on
+this box comes from running several runner instances, set per repo
+via `count` in the inventory: a suite matrix fans out across the
+osvbng instances, while osvbng-vpp keeps a single instance because
+the artifact build uses fixed docker volume and container names and
+must never run concurrently with itself.
+
+Different suites deploy differently named containerlab labs, so they
+coexist on one host. Two runs of the SAME suite collide on lab and
+container names; workflows must serialize per suite with a
+concurrency group (for example `group: suite-${{ matrix.suite }}`).
+Perf jobs want a quiet machine and should take a box-wide
+concurrency group instead.
+
 ## Not covered here
 
 Workflow definitions live in each repo's `.github/workflows/`. This

--- a/test-infra/runner/README.md
+++ b/test-infra/runner/README.md
@@ -1,0 +1,55 @@
+# CI runner provisioning
+
+Ansible provisioning for the dedicated bare-metal machine that runs
+the osvbng and osvbng-vpp GitHub Actions runners. Everything here is
+public and host-agnostic; everything host-specific (addresses, ports,
+keys) lives in `inventory.yml`, which is gitignored. Copy
+`inventory.example.yml` to `inventory.yml` and fill it in.
+
+## Security model
+
+The runner makes outbound HTTPS connections to GitHub only, so the
+box needs no inbound ports at all. After bootstrap completes:
+
+- The public interface default-denies all inbound except the
+  WireGuard UDP port, which does not answer unauthenticated probes.
+- sshd accepts keys only, no passwords, no root login, and after
+  cutover listens on the WireGuard address only.
+- fail2ban covers sshd for the bootstrap window while it is still
+  publicly reachable.
+- The runner executes jobs as an unprivileged `runner` user with
+  passwordless sudo, because the suites need root (containerlab,
+  docker). The box is single-purpose and burnable by design: keep
+  nothing on it but the runner, and reprovision rather than repair.
+
+Workflow runs from pull requests must stay approval-gated (GitHub
+environment with a required reviewer) because approving a run
+executes that PR's code on this machine.
+
+## Bootstrap
+
+The provider hands over an IP with an initial SSH key on port 22.
+
+1. `cp inventory.example.yml inventory.yml` and fill it in. Leave
+   `ssh_wg_only: false` for the first run.
+2. Generate a WireGuard keypair for your workstation
+   (`wg genkey | tee wg.key | wg pubkey`) and put the public key in
+   the inventory. Keep `wg.key` out of the repo.
+3. Fetch runner registration tokens (they expire after an hour):
+   `gh api -X POST repos/veesix-networks/osvbng/actions/runners/registration-token -q .token`
+   and the same for osvbng-vpp.
+4. `ansible-playbook bootstrap.yml -e osvbng_runner_token=... -e osvbng_vpp_runner_token=...`
+5. Add the server peer printed by the play to your workstation's
+   WireGuard config, bring the tunnel up, and confirm
+   `ssh runner@<wg address>` works.
+6. Set `ssh_wg_only: true` in the inventory and rerun the playbook.
+   sshd now binds to the tunnel and the public SSH port closes.
+
+Rerunning the playbook is how drift gets fixed. Registration tasks
+are skipped when the runner services already exist, so reruns do not
+need tokens.
+
+## Not covered here
+
+Workflow definitions live in each repo's `.github/workflows/`. This
+directory only builds the machine they run on.

--- a/test-infra/runner/ansible.cfg
+++ b/test-infra/runner/ansible.cfg
@@ -1,0 +1,7 @@
+[defaults]
+inventory = inventory.yml
+host_key_checking = True
+interpreter_python = auto_silent
+
+[ssh_connection]
+pipelining = True

--- a/test-infra/runner/bootstrap.yml
+++ b/test-infra/runner/bootstrap.yml
@@ -1,0 +1,11 @@
+# Provision the dedicated CI runner box. Idempotent: rerunning is how
+# drift gets fixed. See README.md for the bootstrap and cutover flow.
+- name: Provision CI runner
+  hosts: runner
+  become: true
+  roles:
+    - hardening
+    - wireguard
+    - firewall
+    - ci-deps
+    - runner

--- a/test-infra/runner/inventory.example.yml
+++ b/test-infra/runner/inventory.example.yml
@@ -1,0 +1,48 @@
+# Copy to inventory.yml (gitignored) and fill in. Everything
+# host-specific or secret belongs there, never in this file.
+all:
+  hosts:
+    runner:
+      # Provider-assigned public address. First run connects here on
+      # ansible_port with the provider's initial key; after cutover
+      # (ssh_wg_only: true) connect via wg_server_address instead.
+      ansible_host: 203.0.113.10
+      ansible_port: 22
+      ansible_user: root
+
+  vars:
+    # SSH public keys allowed to log in as the runner user, one per
+    # line entry. Password and root logins are disabled outright.
+    authorized_keys:
+      - ssh-ed25519 AAAA... you@workstation
+
+    # WireGuard tunnel. The server keypair is generated on the box on
+    # first run; the play prints the server public key so you can add
+    # the peer on your workstation.
+    wg_listen_port: 51820
+    wg_server_address: 10.99.0.1/24
+    wg_peers:
+      - name: workstation
+        public_key: REPLACE_WITH_WORKSTATION_WG_PUBLIC_KEY
+        allowed_ips: 10.99.0.2/32
+
+    # false for the first run (sshd still reachable on the public
+    # address); flip to true and rerun once the tunnel is verified.
+    ssh_wg_only: false
+
+    # Tool versions. containerlab matches the dev machine so CI and
+    # local runs exercise the same deployer.
+    containerlab_version: "0.73.0"
+
+    # GitHub repos this box serves. One runner service is installed
+    # per repo; registration tokens are passed as extra-vars at run
+    # time (see README) and never stored.
+    runner_version: "2.328.0"
+    runner_labels: osvbng-metal
+    runner_repos:
+      - name: osvbng
+        url: https://github.com/veesix-networks/osvbng
+        token_var: osvbng_runner_token
+      - name: osvbng-vpp
+        url: https://github.com/veesix-networks/osvbng-vpp
+        token_var: osvbng_vpp_runner_token

--- a/test-infra/runner/inventory.example.yml
+++ b/test-infra/runner/inventory.example.yml
@@ -34,15 +34,22 @@ all:
     # local runs exercise the same deployer.
     containerlab_version: "0.73.0"
 
-    # GitHub repos this box serves. One runner service is installed
-    # per repo; registration tokens are passed as extra-vars at run
-    # time (see README) and never stored.
+    # GitHub repos this box serves. Each runner service executes one
+    # job at a time, so count is that repo's job parallelism here:
+    # osvbng gets several for concurrent integration suites,
+    # osvbng-vpp stays at 1 because the artifact build uses fixed
+    # volume and container names and must not run concurrently with
+    # itself. Registration tokens are passed as extra-vars at run
+    # time (see README) and never stored; one token per repo covers
+    # all its instances.
     runner_version: "2.328.0"
     runner_labels: osvbng-metal
     runner_repos:
       - name: osvbng
         url: https://github.com/veesix-networks/osvbng
         token_var: osvbng_runner_token
+        count: 3
       - name: osvbng-vpp
         url: https://github.com/veesix-networks/osvbng-vpp
         token_var: osvbng_vpp_runner_token
+        count: 1

--- a/test-infra/runner/roles/ci-deps/tasks/main.yml
+++ b/test-infra/runner/roles/ci-deps/tasks/main.yml
@@ -41,6 +41,16 @@
     groups: docker
     append: true
 
+# Preallocate the hugepage pool at the host level. Every BNG
+# container draws 2M pages from this one global pool, so parallel
+# labs need it sized for all of them, and preallocation at boot
+# avoids late-allocation failures from memory fragmentation.
+- name: Preallocate hugepages
+  ansible.posix.sysctl:
+    name: vm.nr_hugepages
+    value: "{{ hugepages_2m | default(4096) }}"
+    sysctl_file: /etc/sysctl.d/90-hugepages.conf
+
 # Pinned release deb from GitHub, not the fury apt repo: the repo is
 # unsigned (upstream's instructions use trusted=yes) and unpinned,
 # and CI wants the same containerlab version as the dev machine.

--- a/test-infra/runner/roles/ci-deps/tasks/main.yml
+++ b/test-infra/runner/roles/ci-deps/tasks/main.yml
@@ -1,0 +1,49 @@
+- name: Base packages
+  ansible.builtin.apt:
+    name:
+      - git
+      - make
+      - curl
+      - jq
+      - rsync
+      - python3-venv
+      - ca-certificates
+      - gnupg
+    state: present
+    update_cache: true
+
+- name: Docker apt key
+  ansible.builtin.get_url:
+    url: https://download.docker.com/linux/debian/gpg
+    dest: /etc/apt/keyrings/docker.asc
+    mode: "0644"
+
+- name: Docker apt repo
+  ansible.builtin.apt_repository:
+    repo: >-
+      deb [signed-by=/etc/apt/keyrings/docker.asc]
+      https://download.docker.com/linux/debian {{ ansible_distribution_release }} stable
+    filename: docker
+
+- name: Install docker
+  ansible.builtin.apt:
+    name:
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+      - docker-buildx-plugin
+    state: present
+    update_cache: true
+
+- name: Runner user in docker group
+  ansible.builtin.user:
+    name: runner
+    groups: docker
+    append: true
+
+# Pinned release deb from GitHub, not the fury apt repo: the repo is
+# unsigned (upstream's instructions use trusted=yes) and unpinned,
+# and CI wants the same containerlab version as the dev machine.
+- name: Install containerlab
+  ansible.builtin.apt:
+    deb: "https://github.com/srl-labs/containerlab/releases/download/v{{ containerlab_version }}/containerlab_{{ containerlab_version }}_linux_amd64.deb"

--- a/test-infra/runner/roles/firewall/tasks/main.yml
+++ b/test-infra/runner/roles/firewall/tasks/main.yml
@@ -1,0 +1,42 @@
+- name: Install ufw
+  ansible.builtin.apt:
+    name: ufw
+    state: present
+    update_cache: true
+
+# Docker and containerlab manage their own bridge traffic in
+# DOCKER-USER and per-lab chains; ufw here governs only what the
+# outside world can reach on the host itself.
+- name: Default deny inbound
+  community.general.ufw:
+    direction: incoming
+    policy: deny
+
+- name: Default allow outbound
+  community.general.ufw:
+    direction: outgoing
+    policy: allow
+
+- name: Allow WireGuard
+  community.general.ufw:
+    rule: allow
+    port: "{{ wg_listen_port }}"
+    proto: udp
+
+- name: Allow public SSH during bootstrap only
+  community.general.ufw:
+    rule: "{{ 'deny' if ssh_wg_only else 'allow' }}"
+    port: "{{ ansible_port | default(22) }}"
+    proto: tcp
+
+- name: Allow SSH over the tunnel
+  community.general.ufw:
+    rule: allow
+    interface: wg0
+    direction: in
+    port: "22"
+    proto: tcp
+
+- name: Enable ufw
+  community.general.ufw:
+    state: enabled

--- a/test-infra/runner/roles/hardening/handlers/main.yml
+++ b/test-infra/runner/roles/hardening/handlers/main.yml
@@ -1,0 +1,9 @@
+- name: Restart sshd
+  ansible.builtin.service:
+    name: ssh
+    state: restarted
+
+- name: Restart fail2ban
+  ansible.builtin.service:
+    name: fail2ban
+    state: restarted

--- a/test-infra/runner/roles/hardening/tasks/main.yml
+++ b/test-infra/runner/roles/hardening/tasks/main.yml
@@ -1,0 +1,53 @@
+- name: Create runner user
+  ansible.builtin.user:
+    name: runner
+    shell: /bin/bash
+    groups: []
+
+- name: Authorize SSH keys for runner user
+  ansible.posix.authorized_key:
+    user: runner
+    key: "{{ item }}"
+  loop: "{{ authorized_keys }}"
+
+# The suites need root (containerlab, docker) and the box is
+# single-purpose, so the runner user gets full passwordless sudo
+# rather than a curated command list that would drift with every
+# suite change. The security boundary is the approval gate on
+# workflow runs, not this sudoers file.
+- name: Passwordless sudo for runner user
+  ansible.builtin.copy:
+    dest: /etc/sudoers.d/runner
+    content: "runner ALL=(ALL) NOPASSWD:ALL\n"
+    mode: "0440"
+    validate: visudo -cf %s
+
+- name: Harden sshd
+  ansible.builtin.copy:
+    dest: /etc/ssh/sshd_config.d/90-runner.conf
+    mode: "0644"
+    content: |
+      PermitRootLogin no
+      PasswordAuthentication no
+      KbdInteractiveAuthentication no
+      X11Forwarding no
+      AllowUsers runner
+      {% if ssh_wg_only %}
+      ListenAddress {{ wg_server_address | ansible.utils.ipaddr('address') }}
+      {% endif %}
+  notify: Restart sshd
+
+- name: Install fail2ban
+  ansible.builtin.apt:
+    name: fail2ban
+    state: present
+    update_cache: true
+
+- name: Enable fail2ban sshd jail
+  ansible.builtin.copy:
+    dest: /etc/fail2ban/jail.d/sshd.local
+    mode: "0644"
+    content: |
+      [sshd]
+      enabled = true
+  notify: Restart fail2ban

--- a/test-infra/runner/roles/runner/tasks/main.yml
+++ b/test-infra/runner/roles/runner/tasks/main.yml
@@ -13,8 +13,23 @@
     creates: /usr/lib/x86_64-linux-gnu/libicu*
   failed_when: false
 
-- name: Per-repo runner instances
+# A runner service executes one job at a time, so a repo's count is
+# its job parallelism on this box. Expand repos into one entry per
+# instance (osvbng-1, osvbng-2, ...) before stamping out services.
+- name: Expand runner instances
+  ansible.builtin.set_fact:
+    runner_instances: >-
+      {%- set out = [] -%}
+      {%- for r in runner_repos -%}
+      {%- for i in range(r.count | default(1)) -%}
+      {%- set _ = out.append(r | combine({'instance': r.name ~ '-' ~ (i + 1)})) -%}
+      {%- endfor -%}
+      {%- endfor -%}
+      {{ out }}
+
+- name: Per-instance runner services
   ansible.builtin.include_tasks: register.yml
-  loop: "{{ runner_repos }}"
+  loop: "{{ runner_instances }}"
   loop_control:
     loop_var: repo
+    label: "{{ repo.instance }}"

--- a/test-infra/runner/roles/runner/tasks/main.yml
+++ b/test-infra/runner/roles/runner/tasks/main.yml
@@ -1,0 +1,20 @@
+- name: Download actions runner
+  ansible.builtin.unarchive:
+    src: "https://github.com/actions/runner/releases/download/v{{ runner_version }}/actions-runner-linux-x64-{{ runner_version }}.tar.gz"
+    dest: /opt
+    remote_src: true
+    creates: /opt/bin/Runner.Listener
+    extra_opts: [--one-top-level=runner-dist]
+    owner: runner
+
+- name: Install runner OS dependencies
+  ansible.builtin.command: /opt/runner-dist/bin/installdependencies.sh
+  args:
+    creates: /usr/lib/x86_64-linux-gnu/libicu*
+  failed_when: false
+
+- name: Per-repo runner instances
+  ansible.builtin.include_tasks: register.yml
+  loop: "{{ runner_repos }}"
+  loop_control:
+    loop_var: repo

--- a/test-infra/runner/roles/runner/tasks/register.yml
+++ b/test-infra/runner/roles/runner/tasks/register.yml
@@ -1,0 +1,54 @@
+# One runner instance per repo, from the shared dist. Registration is
+# one-shot: once .runner exists the token tasks are skipped, so
+# reruns of the playbook never need tokens.
+- name: "Create instance directory for {{ repo.name }}"
+  ansible.builtin.copy:
+    src: /opt/runner-dist/
+    dest: "/opt/runner-{{ repo.name }}/"
+    remote_src: true
+    owner: runner
+    group: runner
+    mode: preserve
+
+- name: "Check registration of {{ repo.name }}"
+  ansible.builtin.stat:
+    path: "/opt/runner-{{ repo.name }}/.runner"
+  register: runner_registered
+
+- name: "Require registration token for {{ repo.name }}"
+  ansible.builtin.assert:
+    that: lookup('vars', repo.token_var, default='') | length > 0
+    fail_msg: >-
+      {{ repo.name }} is unregistered and no {{ repo.token_var }} was
+      passed; fetch one with gh (see README) and rerun with
+      -e {{ repo.token_var }}=...
+  when: not runner_registered.stat.exists
+
+- name: "Register {{ repo.name }}"
+  become: true
+  become_user: runner
+  ansible.builtin.command:
+    chdir: "/opt/runner-{{ repo.name }}"
+    cmd: >-
+      ./config.sh --unattended
+      --url {{ repo.url }}
+      --token {{ lookup('vars', repo.token_var) }}
+      --name {{ ansible_hostname }}-{{ repo.name }}
+      --labels {{ runner_labels }}
+      --replace
+  when: not runner_registered.stat.exists
+  changed_when: true
+  no_log: true
+
+- name: "Install runner service for {{ repo.name }}"
+  ansible.builtin.command:
+    chdir: "/opt/runner-{{ repo.name }}"
+    cmd: ./svc.sh install runner
+    creates: "/etc/systemd/system/actions.runner.*{{ repo.name }}*.service"
+
+- name: "Start runner service for {{ repo.name }}"
+  ansible.builtin.command:
+    chdir: "/opt/runner-{{ repo.name }}"
+    cmd: ./svc.sh start
+  changed_when: false
+  failed_when: false

--- a/test-infra/runner/roles/runner/tasks/register.yml
+++ b/test-infra/runner/roles/runner/tasks/register.yml
@@ -1,54 +1,54 @@
-# One runner instance per repo, from the shared dist. Registration is
-# one-shot: once .runner exists the token tasks are skipped, so
+# One runner service per instance, from the shared dist. Registration
+# is one-shot: once .runner exists the token tasks are skipped, so
 # reruns of the playbook never need tokens.
-- name: "Create instance directory for {{ repo.name }}"
+- name: "Create instance directory for {{ repo.instance }}"
   ansible.builtin.copy:
     src: /opt/runner-dist/
-    dest: "/opt/runner-{{ repo.name }}/"
+    dest: "/opt/runner-{{ repo.instance }}/"
     remote_src: true
     owner: runner
     group: runner
     mode: preserve
 
-- name: "Check registration of {{ repo.name }}"
+- name: "Check registration of {{ repo.instance }}"
   ansible.builtin.stat:
-    path: "/opt/runner-{{ repo.name }}/.runner"
+    path: "/opt/runner-{{ repo.instance }}/.runner"
   register: runner_registered
 
-- name: "Require registration token for {{ repo.name }}"
+- name: "Require registration token for {{ repo.instance }}"
   ansible.builtin.assert:
     that: lookup('vars', repo.token_var, default='') | length > 0
     fail_msg: >-
-      {{ repo.name }} is unregistered and no {{ repo.token_var }} was
-      passed; fetch one with gh (see README) and rerun with
+      {{ repo.instance }} is unregistered and no {{ repo.token_var }}
+      was passed; fetch one with gh (see README) and rerun with
       -e {{ repo.token_var }}=...
   when: not runner_registered.stat.exists
 
-- name: "Register {{ repo.name }}"
+- name: "Register {{ repo.instance }}"
   become: true
   become_user: runner
   ansible.builtin.command:
-    chdir: "/opt/runner-{{ repo.name }}"
+    chdir: "/opt/runner-{{ repo.instance }}"
     cmd: >-
       ./config.sh --unattended
       --url {{ repo.url }}
       --token {{ lookup('vars', repo.token_var) }}
-      --name {{ ansible_hostname }}-{{ repo.name }}
+      --name {{ ansible_hostname }}-{{ repo.instance }}
       --labels {{ runner_labels }}
       --replace
   when: not runner_registered.stat.exists
   changed_when: true
   no_log: true
 
-- name: "Install runner service for {{ repo.name }}"
+- name: "Install runner service for {{ repo.instance }}"
   ansible.builtin.command:
-    chdir: "/opt/runner-{{ repo.name }}"
+    chdir: "/opt/runner-{{ repo.instance }}"
     cmd: ./svc.sh install runner
-    creates: "/etc/systemd/system/actions.runner.*{{ repo.name }}*.service"
+    creates: "/etc/systemd/system/actions.runner.*{{ repo.instance }}*.service"
 
-- name: "Start runner service for {{ repo.name }}"
+- name: "Start runner service for {{ repo.instance }}"
   ansible.builtin.command:
-    chdir: "/opt/runner-{{ repo.name }}"
+    chdir: "/opt/runner-{{ repo.instance }}"
     cmd: ./svc.sh start
   changed_when: false
   failed_when: false

--- a/test-infra/runner/roles/wireguard/handlers/main.yml
+++ b/test-infra/runner/roles/wireguard/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: Restart wg0
+  ansible.builtin.service:
+    name: wg-quick@wg0
+    state: restarted

--- a/test-infra/runner/roles/wireguard/tasks/main.yml
+++ b/test-infra/runner/roles/wireguard/tasks/main.yml
@@ -1,0 +1,51 @@
+- name: Install wireguard
+  ansible.builtin.apt:
+    name: wireguard
+    state: present
+    update_cache: true
+
+- name: Generate server private key
+  ansible.builtin.shell: umask 077 && wg genkey > /etc/wireguard/server.key
+  args:
+    creates: /etc/wireguard/server.key
+
+- name: Derive server public key
+  ansible.builtin.shell: wg pubkey < /etc/wireguard/server.key > /etc/wireguard/server.pub
+  args:
+    creates: /etc/wireguard/server.pub
+
+- name: Read server keys
+  ansible.builtin.slurp:
+    src: "{{ item }}"
+  loop:
+    - /etc/wireguard/server.key
+    - /etc/wireguard/server.pub
+  register: wireguard_keys
+
+- name: Write wg0 config
+  ansible.builtin.copy:
+    dest: /etc/wireguard/wg0.conf
+    mode: "0600"
+    content: |
+      [Interface]
+      Address = {{ wg_server_address }}
+      ListenPort = {{ wg_listen_port }}
+      PrivateKey = {{ wireguard_keys.results[0].content | b64decode | trim }}
+      {% for peer in wg_peers %}
+
+      # {{ peer.name }}
+      [Peer]
+      PublicKey = {{ peer.public_key }}
+      AllowedIPs = {{ peer.allowed_ips }}
+      {% endfor %}
+  notify: Restart wg0
+
+- name: Enable wg0
+  ansible.builtin.service:
+    name: wg-quick@wg0
+    state: started
+    enabled: true
+
+- name: Show server public key for the workstation peer config
+  ansible.builtin.debug:
+    msg: "WireGuard server public key: {{ wireguard_keys.results[1].content | b64decode | trim }}"


### PR DESCRIPTION
A dedicated bare-metal runner is planned for the integration suites and osvbng-vpp artifact builds, and there is no provisioning for it: setup would be by-hand and unreproducible, and host details would have nowhere safe to live.

This adds test-infra/runner/, an Ansible bootstrap with a strict public/private split. Committed: the playbook and roles (hardening with key-only SSH and fail2ban, WireGuard, default-deny firewall, CI dependencies, per-repo GitHub Actions runner instances), an inventory.example.yml with placeholder values, and a README with the bootstrap and SSH cutover flow. Gitignored: inventory.yml with the real address, keys and WireGuard peers, plus any key material. The security model is zero inbound: the runner only makes outbound HTTPS connections, so after cutover sshd binds to the WireGuard address and the public interface exposes only the silent WireGuard UDP port. Registration tokens are passed as extra-vars at run time, used once, and never stored; reruns skip registration so the playbook stays the drift-fixer. containerlab installs as a pinned release deb (0.73.0, matching the dev machine) rather than the unsigned fury apt repo.

Verified: ansible-playbook syntax check and ansible-lint pass clean at the production profile against the example inventory. The ci-deps role was executed for real against a fresh debian:12 container and installed docker-ce 29.7.2 and containerlab 0.73.0; that run caught and fixed a broken fury GPG key URL, which is why the pinned deb approach replaced the apt repo. Not verified: hardening, wireguard, firewall and runner roles were syntax and lint checked only, since they need a real host with systemd and a kernel; first run against the actual server is part of the bring-up, with the SSH cutover deliberately split into a second run so a mistake cannot lock the box before the tunnel is proven.