### PR TITLE
fix(docker): grow the hugepage pool instead of resetting it

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -65,7 +65,15 @@ mkdir -p /var/log/osvbng
 echo "Configuring hugepages..."
 mkdir -p /dev/hugepages
 mount -t hugetlbfs -o pagesize=2M none /dev/hugepages || true
-echo 512 > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages || true
+# nr_hugepages is the HOST-wide pool shared by every container on the
+# box. Grow it if it is too small, never shrink it: a plain write of
+# 512 here would pull the pool out from under labs already running.
+HP_PATH=/sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
+HP_WANT=512
+HP_HAVE=$(cat $HP_PATH 2>/dev/null || echo 0)
+if [ "$HP_HAVE" -lt "$HP_WANT" ]; then
+    echo $HP_WANT > $HP_PATH || true
+fi
 
 sysctl -w net.unix.max_dgram_qlen=10000 2>/dev/null || echo "Warning: Could not set max_dgram_qlen (need privileged mode)"
 sysctl -w net.core.rmem_max=67108864 2>/dev/null || true


### PR DESCRIPTION
The container entrypoint writes 512 to nr_hugepages unconditionally. That sysctl is the host-wide 2M hugepage pool shared by every container on the box, so a BNG container starting while other labs are running resets the shared pool to 512 pages and can pull memory out from under them. Harmless while suites run one at a time; a real hazard for the parallel CI runs the dedicated runner is being provisioned for, and the companion runner provisioning preallocates a larger pool (vm.nr_hugepages) that this write would silently shrink on every container start.

The entrypoint now grows the pool only when it is below 512 pages and otherwise leaves it alone, so a preallocated or already-grown pool is never reduced.

Verified by rebuilding the image and running the 01-smoke suite against it, 10/10 pass, with the host pool intact at its prior size afterwards. Not verified: no concurrent multi-lab run was exercised.