### PR TITLE
feat(config): implement auto cpu layout tiers and cp-cores intent knob

### DIFF
--- a/docs/configuration/dataplane.md
+++ b/docs/configuration/dataplane.md
@@ -5,9 +5,34 @@ Dataplane and DPDK configuration.
 | Field | Type | Description | Example |
 |-------|------|-------------|---------|
 | `rx_mode` | string | Interface RX mode: `polling`, `interrupt`, or `adaptive` | `polling` |
+| `main-core` | int | Core for VPP's main thread. Auto-resolved when unset | `0` |
+| `workers` | string | Core set for VPP workers. Auto-resolved when unset | `1-5` |
+| `cp-cores` | string | Core set for the Go control plane. Auto-resolved when unset | `6-7` |
 | `poll-sleep-usec` | int | Microseconds an idle worker sleeps between dispatch loops. Default `100` (low idle CPU); `0` polls continuously for lowest latency | `0` |
 | `dpdk` | [DPDK](#dpdk-configuration) | DPDK-specific configuration | |
 | `statseg` | [StatsSegment](#stats-segment) | Stats segment configuration | |
+
+## CPU Cores
+
+Each host resolves core placement locally at startup from the cores actually available to it (container cpusets are respected), so the same config works across hosts with different core counts. Unset fields follow the auto layout:
+
+| Cores | VPP main | VPP workers | Control plane |
+|-------|----------|-------------|---------------|
+| 1 | 0 | - | shared (0) |
+| 2 | 0 | 1 | shared (0) |
+| 3 | 0 | 1 | 2 |
+| 4 | 0 | 1-2 | 3 |
+| 5-7 | 0 | 1-(N-2) | N-1 |
+| 8+ | 0 | 1-(N-3) | (N-2)-(N-1) |
+
+Explicit sets override the auto layout per field and use the same syntax everywhere: ranges and commas, for example `2-3,34-35`. The control plane sizes `GOMAXPROCS` to its resolved set and is pinned to it, so giving it more cores is a config change, not a build change. Resolution is topology-blind: on a multi-socket host, expressing NUMA placement (workers beside their NICs, control-plane cores on a chosen socket) is done with explicit sets.
+
+```yaml
+dataplane:
+  main-core: 0
+  workers: 1-5
+  cp-cores: 6-7
+```
 
 ## RX Mode
 

--- a/pkg/config/cpu.go
+++ b/pkg/config/cpu.go
@@ -33,8 +33,9 @@ type ResolvedCPU struct {
 //	8+    | 0              | 1-(N-3)    | (N-2)-(N-1)
 //
 // Env var overrides (OSVBNG_DP_MAIN_CORE, OSVBNG_DP_WORKER_CORES, OSVBNG_CP_CORES)
-// and YAML config (dataplane.main-core, dataplane.workers) take priority over
-// auto-detection.
+// and YAML config (dataplane.main-core, dataplane.workers, dataplane.cp-cores)
+// take priority over auto-detection. The auto layout is topology-blind; on
+// multi-socket hosts NUMA placement is the operator's, via the explicit sets.
 func ResolveCPULayout(cfg *Config) *ResolvedCPU {
 	total := DetectAvailableCores()
 
@@ -61,8 +62,10 @@ func ResolveCPULayout(cfg *Config) *ResolvedCPU {
 		resolved.WorkerCores = autoWorkerCores(total)
 	}
 
-	// Priority for CP cores: env var > auto-layout
-	if v := os.Getenv("OSVBNG_CP_CORES"); v != "" {
+	// Priority for CP cores: YAML config > env var > auto-layout
+	if cfg.Dataplane.CPCores != "" {
+		resolved.CPCores = cfg.Dataplane.CPCores
+	} else if v := os.Getenv("OSVBNG_CP_CORES"); v != "" {
 		resolved.CPCores = v
 	} else {
 		resolved.CPCores = autoCPCores(total)
@@ -72,17 +75,33 @@ func ResolveCPULayout(cfg *Config) *ResolvedCPU {
 }
 
 func autoWorkerCores(total int) string {
-	if total > 1 {
+	switch {
+	case total <= 1:
+		return ""
+	case total <= 3:
 		return "1"
+	case total == 4:
+		return "1-2"
+	case total <= 7:
+		return fmt.Sprintf("1-%d", total-2)
+	default:
+		return fmt.Sprintf("1-%d", total-3)
 	}
-	return ""
 }
 
 func autoCPCores(total int) string {
-	if total >= 3 {
+	switch {
+	case total < 3:
+		return ""
+	case total == 3:
 		return "2"
+	case total == 4:
+		return "3"
+	case total <= 7:
+		return strconv.Itoa(total - 1)
+	default:
+		return fmt.Sprintf("%d-%d", total-2, total-1)
 	}
-	return ""
 }
 
 // WriteEnvFile writes the resolved layout as shell-evaluable variables.

--- a/pkg/config/cpu_test.go
+++ b/pkg/config/cpu_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 The osvbng Authors
+// Licensed under the GNU General Public License v3.0 or later.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package config
+
+import (
+	"testing"
+
+	"github.com/veesix-networks/osvbng/pkg/config/system"
+)
+
+func TestAutoLayoutTiers(t *testing.T) {
+	cases := []struct {
+		total   int
+		workers string
+		cp      string
+	}{
+		{1, "", ""},
+		{2, "1", ""},
+		{3, "1", "2"},
+		{4, "1-2", "3"},
+		{5, "1-3", "4"},
+		{7, "1-5", "6"},
+		{8, "1-5", "6-7"},
+		{16, "1-13", "14-15"},
+		{64, "1-61", "62-63"},
+	}
+	for _, c := range cases {
+		if got := autoWorkerCores(c.total); got != c.workers {
+			t.Errorf("autoWorkerCores(%d) = %q, want %q", c.total, got, c.workers)
+		}
+		if got := autoCPCores(c.total); got != c.cp {
+			t.Errorf("autoCPCores(%d) = %q, want %q", c.total, got, c.cp)
+		}
+	}
+}
+
+// Main core 0, workers and CP must partition the remaining cores with no
+// overlap at every host size.
+func TestAutoLayoutDisjoint(t *testing.T) {
+	for total := 3; total <= 96; total++ {
+		workers, err := parseCoreSet(autoWorkerCores(total))
+		if err != nil {
+			t.Fatalf("total=%d: bad worker set: %v", total, err)
+		}
+		cp, err := parseCoreSet(autoCPCores(total))
+		if err != nil {
+			t.Fatalf("total=%d: bad cp set: %v", total, err)
+		}
+		if len(cp) == 0 {
+			t.Fatalf("total=%d: no cp cores", total)
+		}
+		for core := range cp {
+			if workers[core] {
+				t.Fatalf("total=%d: core %d in both worker and cp sets", total, core)
+			}
+			if core == 0 || core >= total {
+				t.Fatalf("total=%d: cp core %d out of range", total, core)
+			}
+		}
+		for core := range workers {
+			if core == 0 || core >= total {
+				t.Fatalf("total=%d: worker core %d out of range", total, core)
+			}
+		}
+	}
+}
+
+func TestResolveCPCoresPriority(t *testing.T) {
+	cfg := &Config{}
+
+	t.Setenv("OSVBNG_CP_CORES", "4-5")
+	r := ResolveCPULayout(cfg)
+	if r.CPCores != "4-5" {
+		t.Errorf("env override: got %q, want 4-5", r.CPCores)
+	}
+
+	cfg.Dataplane = system.DataplaneConfig{CPCores: "2-3,34-35"}
+	r = ResolveCPULayout(cfg)
+	if r.CPCores != "2-3,34-35" {
+		t.Errorf("yaml over env: got %q, want 2-3,34-35", r.CPCores)
+	}
+	if n := r.CPCoreCount(); n != 4 {
+		t.Errorf("CPCoreCount() = %d, want 4", n)
+	}
+}

--- a/pkg/config/system/dataplane.go
+++ b/pkg/config/system/dataplane.go
@@ -12,25 +12,29 @@ import (
 )
 
 type DataplaneConfig struct {
-	DPAPISocket     string              `json:"dp_api_socket,omitempty" yaml:"dp_api_socket,omitempty"`
-	PuntSocketPath  string              `json:"punt_socket_path,omitempty" yaml:"punt_socket_path,omitempty"`
-	MemifSocketPath string              `json:"memif_socket_path,omitempty" yaml:"memif_socket_path,omitempty"`
-	RxMode          string              `json:"rx_mode,omitempty" yaml:"rx_mode,omitempty"`
-	MainCore        *int                `json:"main_core,omitempty" yaml:"main-core,omitempty"`
-	Workers         string              `json:"workers,omitempty" yaml:"workers,omitempty"`
-	SkipConfGen     bool                `json:"skip_conf_gen,omitempty" yaml:"skip-conf-gen,omitempty"`
-	LCPNetNs        string              `json:"lcp_netns,omitempty" yaml:"lcp-netns,omitempty"`
+	DPAPISocket     string `json:"dp_api_socket,omitempty" yaml:"dp_api_socket,omitempty"`
+	PuntSocketPath  string `json:"punt_socket_path,omitempty" yaml:"punt_socket_path,omitempty"`
+	MemifSocketPath string `json:"memif_socket_path,omitempty" yaml:"memif_socket_path,omitempty"`
+	RxMode          string `json:"rx_mode,omitempty" yaml:"rx_mode,omitempty"`
+	MainCore        *int   `json:"main_core,omitempty" yaml:"main-core,omitempty"`
+	Workers         string `json:"workers,omitempty" yaml:"workers,omitempty"`
+	// CPCores pins the Go control plane to an explicit core set ("2-3",
+	// "2,34"), same syntax as Workers. Empty lets the auto layout pick.
+	// Resolution is topology-blind; NUMA placement is expressed here.
+	CPCores     string `json:"cp_cores,omitempty" yaml:"cp-cores,omitempty"`
+	SkipConfGen bool   `json:"skip_conf_gen,omitempty" yaml:"skip-conf-gen,omitempty"`
+	LCPNetNs    string `json:"lcp_netns,omitempty" yaml:"lcp-netns,omitempty"`
 	// PollSleepUsec caps how long an idle worker sleeps between dispatch loops.
 	// Unset defaults to 100us, which keeps the dev/test environment off 100% CPU
 	// but bounds worker-handoff latency to that sleep. Set to 0 in production so
 	// workers poll continuously for lowest latency (DPDK workers spin regardless
 	// under load; this only affects idle workers). Pointer distinguishes unset
 	// from an explicit 0.
-	PollSleepUsec *uint32 `json:"poll_sleep_usec,omitempty" yaml:"poll-sleep-usec,omitempty"`
-	DPDK            *DPDKConfig         `json:"dpdk,omitempty" yaml:"dpdk,omitempty"`
-	StatsSegment    *StatsSegmentConfig `json:"statseg,omitempty" yaml:"statseg,omitempty"`
-	Memory          *MemoryConfig       `json:"memory,omitempty" yaml:"memory,omitempty"`
-	APITrace        *APITraceConfig     `json:"api-trace,omitempty" yaml:"api-trace,omitempty"`
+	PollSleepUsec *uint32             `json:"poll_sleep_usec,omitempty" yaml:"poll-sleep-usec,omitempty"`
+	DPDK          *DPDKConfig         `json:"dpdk,omitempty" yaml:"dpdk,omitempty"`
+	StatsSegment  *StatsSegmentConfig `json:"statseg,omitempty" yaml:"statseg,omitempty"`
+	Memory        *MemoryConfig       `json:"memory,omitempty" yaml:"memory,omitempty"`
+	APITrace      *APITraceConfig     `json:"api-trace,omitempty" yaml:"api-trace,omitempty"`
 }
 
 var validHeapPageSizes = map[string]bool{


### PR DESCRIPTION
## Problem

The auto CPU layout never implemented its own documented tiers. The layout table in pkg/config/cpu.go promises workers scaling with host size and a two-core control plane at 8+ cores, but autoWorkerCores always returned core 1 and autoCPCores always core 2, so a 64-core host auto-resolved to one VPP worker and a single control-plane core. The multi-core control plane path itself already works end to end (OSVBNG_CP_CORES is a core set, GOMAXPROCS is sized to CPCoreCount, both entrypoints taskset to the full set), but control-plane cores had no YAML intent knob, unlike main-core and workers.

## Change

- autoWorkerCores and autoCPCores implement the documented tiers: workers 1-(N-2) at 5-7 cores and 1-(N-3) at 8+, control plane N-1 at 5-7 and (N-2)-(N-1) at 8+. Small hosts (1-4 cores) resolve exactly as before.
- dataplane.cp-cores joins main-core and workers as the YAML intent knob, priority YAML over OSVBNG_CP_CORES over auto, same core-set syntax.
- Resolution stays topology-blind by design: on multi-socket hosts NUMA placement (workers beside NICs, control-plane cores per socket) is expressed through the explicit sets. Stated in the field comment and docs rather than guessed at by auto-detection.
- docs/configuration/dataplane.md gains a CPU Cores section with the tier table and the field rows, which were previously undocumented.

## Verified

- New pkg/config tests: tier table cases from 1 to 64 cores, a disjointness sweep from 3 to 96 cores (worker and control-plane sets never overlap, never include core 0, never exceed the host), and resolution priority including a multi-range NUMA-style set counted by CPCoreCount.
- go build ./... and go vet ./pkg/config clean; full pkg/config and cmd test suites pass.
- Not verified: no containerlab run, this changes core placement resolution only and the dev containers pin explicit cores; behaviour on a real 8+ core host with auto layout has not been observed beyond the unit tests.