### PR TITLE
feat(logger): per-key storm sampler, sampled auth-failure logging

### DIFF
--- a/internal/aaa/component.go
+++ b/internal/aaa/component.go
@@ -81,7 +81,13 @@ type AccountingSession struct {
 type Component struct {
 	*component.Base
 
-	logger       *logger.Logger
+	logger *logger.Logger
+	// authFailures samples auth-failure logging: a RADIUS outage during a
+	// reconnect wave fails every request in flight, and one line per event
+	// would melt the sink and bury the signal. One line per interval plus a
+	// suppressed count; per-request detail stays visible at debug level in
+	// the provider.
+	authFailures *logger.Sampler
 	authProvider auth.AuthProvider
 	eventBus     events.Bus
 	cache        cache.Cache
@@ -106,6 +112,7 @@ func New(deps component.Dependencies, authProvider auth.AuthProvider) (*Componen
 	c := &Component{
 		Base:         component.NewBase("aaa"),
 		logger:       log,
+		authFailures: logger.NewSampler(log, 10*time.Second),
 		authProvider: authProvider,
 		eventBus:     deps.EventBus,
 		cache:        deps.Cache,
@@ -378,7 +385,7 @@ func (c *Component) handleAAARequest(event events.Event) {
 
 	authResp, err := c.authProvider.Authenticate(c.Ctx, authReq)
 	if err != nil {
-		c.logger.Error("Authentication failed",
+		c.authFailures.Error("authenticate", "Authentication failed",
 			"mac", req.MAC,
 			"acct_session_id", req.AcctSessionID,
 			"error", err)

--- a/pkg/logger/sampler.go
+++ b/pkg/logger/sampler.go
@@ -1,0 +1,82 @@
+// Copyright 2026 The osvbng Authors
+// Licensed under the GNU General Public License v3.0 or later.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package logger
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Sampler rate-limits storm-shaped logging per key. The first event for a
+// key logs immediately and opens a window; events inside the window are
+// counted, not logged; the first event after the window closes logs again,
+// carrying the count as a "suppressed" field. There is no background timer:
+// a count with no follow-up event stays pending until the next event for
+// that key, which keeps the sampler off the scheduler entirely.
+//
+// The hot path is one sync.Map load and one or two atomics, no allocation
+// when suppressing. Keys follow the same bounded-cardinality discipline as
+// metric labels: key by server, pool or operation, never by subscriber,
+// session or MAC. Entries are never removed, so an unbounded key set is a
+// leak as well as a signal problem.
+type Sampler struct {
+	log      *Logger
+	interval time.Duration
+	entries  sync.Map // key string -> *sampleEntry
+}
+
+type sampleEntry struct {
+	windowStart atomic.Int64 // unix nanos; zero means never logged
+	suppressed  atomic.Uint64
+}
+
+// NewSampler returns a Sampler emitting through log at most one line per
+// key per interval.
+func NewSampler(log *Logger, interval time.Duration) *Sampler {
+	return &Sampler{log: log, interval: interval}
+}
+
+// allow reports whether this event should log, and if so how many events
+// for the key were suppressed since the last logged one. Exactly one
+// concurrent caller wins an expired window (CAS); losers are counted.
+func (s *Sampler) allow(key string) (uint64, bool) {
+	v, ok := s.entries.Load(key)
+	if !ok {
+		v, _ = s.entries.LoadOrStore(key, &sampleEntry{})
+	}
+	e := v.(*sampleEntry)
+
+	now := time.Now().UnixNano()
+	start := e.windowStart.Load()
+	if now-start >= int64(s.interval) {
+		if e.windowStart.CompareAndSwap(start, now) {
+			return e.suppressed.Swap(0), true
+		}
+	}
+	e.suppressed.Add(1)
+	return 0, false
+}
+
+func (s *Sampler) Warn(key, msg string, args ...any) {
+	if n, ok := s.allow(key); ok {
+		s.log.Warn(msg, withSuppressed(args, n)...)
+	}
+}
+
+func (s *Sampler) Error(key, msg string, args ...any) {
+	if n, ok := s.allow(key); ok {
+		s.log.Error(msg, withSuppressed(args, n)...)
+	}
+}
+
+// withSuppressed appends the count without aliasing the caller's backing
+// array (the full slice expression forces a copy on append).
+func withSuppressed(args []any, n uint64) []any {
+	if n == 0 {
+		return args
+	}
+	return append(args[:len(args):len(args)], "suppressed", n)
+}

--- a/pkg/logger/sampler_test.go
+++ b/pkg/logger/sampler_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 The osvbng Authors
+// Licensed under the GNU General Public License v3.0 or later.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package logger
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+func testLogger(buf *bytes.Buffer) *Logger {
+	return &Logger{zl: zerolog.New(buf)}
+}
+
+func logLines(buf *bytes.Buffer) []map[string]any {
+	var out []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+func TestSamplerFirstEventLogsThenSuppresses(t *testing.T) {
+	var buf bytes.Buffer
+	s := NewSampler(testLogger(&buf), time.Hour)
+
+	for i := 0; i < 100; i++ {
+		s.Error("radius", "auth failed", "server", "10.0.0.1")
+	}
+
+	lines := logLines(&buf)
+	if len(lines) != 1 {
+		t.Fatalf("got %d lines, want 1", len(lines))
+	}
+	if _, ok := lines[0]["suppressed"]; ok {
+		t.Errorf("first line must not carry suppressed: %v", lines[0])
+	}
+}
+
+func TestSamplerSummaryCarriesSuppressedCount(t *testing.T) {
+	var buf bytes.Buffer
+	s := NewSampler(testLogger(&buf), 30*time.Millisecond)
+
+	for i := 0; i < 100; i++ {
+		s.Warn("pool", "exhausted")
+	}
+	time.Sleep(40 * time.Millisecond)
+	s.Warn("pool", "exhausted")
+
+	lines := logLines(&buf)
+	if len(lines) != 2 {
+		t.Fatalf("got %d lines, want 2", len(lines))
+	}
+	if got := lines[1]["suppressed"]; got != float64(99) {
+		t.Errorf("suppressed = %v, want 99", got)
+	}
+}
+
+func TestSamplerKeysAreIndependent(t *testing.T) {
+	var buf bytes.Buffer
+	s := NewSampler(testLogger(&buf), time.Hour)
+
+	s.Error("a", "m")
+	s.Error("b", "m")
+	s.Error("a", "m")
+
+	if lines := logLines(&buf); len(lines) != 2 {
+		t.Fatalf("got %d lines, want 2 (one per key)", len(lines))
+	}
+}
+
+// Conservation under concurrency: every event is either logged or counted
+// into a suppressed field, exactly once.
+func TestSamplerConservesEvents(t *testing.T) {
+	var buf bytes.Buffer
+	var mu sync.Mutex
+	s := NewSampler(&Logger{zl: zerolog.New(lockedWriter{&mu, &buf})}, 5*time.Millisecond)
+
+	const goroutines, events = 8, 500
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < events; i++ {
+				s.Error("k", "m")
+				if i%100 == 0 {
+					time.Sleep(time.Millisecond)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	time.Sleep(10 * time.Millisecond)
+	s.Error("k", "m") // flush any pending count
+
+	mu.Lock()
+	lines := logLines(&buf)
+	mu.Unlock()
+
+	total := 0
+	for _, l := range lines {
+		total++
+		if v, ok := l["suppressed"]; ok {
+			total += int(v.(float64))
+		}
+	}
+	// Residual: events suppressed after the flush line's window opened.
+	pending := goroutines*events + 1 - total
+	if pending != 0 {
+		t.Errorf("conservation: %d events unaccounted (logged+suppressed=%d of %d)",
+			pending, total, goroutines*events+1)
+	}
+	if len(lines) >= goroutines*events {
+		t.Errorf("sampling ineffective: %d lines for %d events", len(lines), goroutines*events)
+	}
+}
+
+type lockedWriter struct {
+	mu  *sync.Mutex
+	buf *bytes.Buffer
+}
+
+func (w lockedWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}


### PR DESCRIPTION
## Problem

Storm-shaped errors log per event. A RADIUS outage during a reconnect wave fails every authentication in flight, and the AAA component logged one error line per request: thousands of identical lines that burn the log sink's ring budget (the diode writer starts dropping, taking unrelated lines with them) and bury the one fact that matters, that auth is failing and at what rate. Session-setup profiling already measured logging as the single largest contention source before the non-blocking sink; per-event storm logging is the remaining way logging load scales with subscriber count.

## Change

- pkg/logger gains a Sampler: first event per key logs immediately and opens a window, events inside the window are counted, and the first event after the window closes logs with the count as a suppressed field. No background timer, so it costs nothing on the scheduler; a pending count rides the next event for the key. The hot path is one sync.Map load plus one or two atomics, no allocation when suppressing. Keys carry the same bounded-cardinality discipline as metric labels (server, pool, operation, never subscriber or MAC), documented on the type.
- The AAA component's per-request "Authentication failed" error becomes the reference caller, sampled at one line per 10s under the "authenticate" key. Per-request detail remains available at debug level in the RADIUS provider, which already logs attempts there.

## Verified

- pkg/logger tests: first-event emission, suppressed-count summary after window expiry, per-key independence, and a concurrent conservation test (every event either logs or is counted exactly once, checked across 8 goroutines) run green with -race, twice.
- go build ./... clean; internal/aaa and pkg/logger suites green with -race.
- Full unit suite: pkg/component's TestStateFileWriter cases flaked under full-suite parallel load on a busy box (2s file-watch deadlines); they pass in isolation both with and without this change and are untouched by it.
- Not verified: no containerlab run; the sampled path needs a RADIUS outage under a bngblaster reconnect wave to observe end to end, which is worth doing when the rig is free.