### PR TITLE
ci: cache dataplane debs per commit on the runner

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,22 +41,34 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The runner keeps a per-commit cache of the four debs the
+      # image actually installs (the release also carries vpp-dbg,
+      # 92MB of symbols the image never uses), so a run downloads
+      # nothing unless the dataplane changed since the last run on
+      # this box.
       - name: Fetch dataplane artifacts
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          rm -rf /tmp/dataplane-debs && mkdir -p /tmp/dataplane-debs
-          gh release download dataplane-latest -R veesix-networks/osvbng-vpp \
-            -p '*.deb' -D /tmp/dataplane-debs
-          echo "dataplane provenance:"
-          gh release view dataplane-latest -R veesix-networks/osvbng-vpp \
-            --json body -q .body
+          body=$(gh release view dataplane-latest -R veesix-networks/osvbng-vpp \
+            --json body -q .body)
+          echo "dataplane provenance: $body"
+          sha=$(echo "$body" | grep -oE 'from [0-9a-f]{40}' | awk '{print $2}')
+          test -n "$sha"
+          cache="$HOME/.cache/osvbng-dataplane/$sha"
+          if [ ! -d "$cache" ]; then
+            tmp=$(mktemp -d)
+            for p in 'vpp_*.deb' 'vpp-plugin-core_*.deb' \
+                     'vpp-plugin-dpdk_*.deb' 'libvppinfra_*.deb'; do
+              gh release download dataplane-latest -R veesix-networks/osvbng-vpp \
+                -p "$p" -D "$tmp"
+            done
+            mkdir -p "$HOME/.cache/osvbng-dataplane"
+            mv "$tmp" "$cache"
+            ls -dt "$HOME"/.cache/osvbng-dataplane/*/ | tail -n +4 | xargs -r rm -rf
+          fi
           mkdir -p docker/dataplane-debs
-          cp /tmp/dataplane-debs/vpp_*.deb \
-             /tmp/dataplane-debs/vpp-plugin-core_*.deb \
-             /tmp/dataplane-debs/vpp-plugin-dpdk_*.deb \
-             /tmp/dataplane-debs/libvppinfra_*.deb \
-             docker/dataplane-debs/
+          cp "$cache"/*.deb docker/dataplane-debs/
 
       - name: Build osvbng image from dataplane debs
         run: make docker-local


### PR DESCRIPTION
The integration image job downloads the full dataplane-latest asset set on every run, about 110MB of which 92MB is vpp-dbg symbols the image never installs, and it re-downloads even when the dataplane has not changed. Constant round-tripping between the runner and GitHub for identical bytes is waste.

The fetch step now parses the source commit from the release provenance, keeps a per-commit cache under the runner user's home of only the four debs the image installs (about 12MB), and downloads nothing when the cache already holds that commit, pruning to the three most recent. Steady-state per-run transfer drops to zero until an osvbng-vpp merge actually changes the dataplane. The release keeps publishing the full set including vpp-dbg, which stays valuable for crash analysis; only the consumer side narrows.

Verified: yaml parses; the grep that extracts the commit matches the note format dataplane-artifacts writes. Not verified: not yet executed by a live run, the next approved integration run exercises it; if the provenance format ever changes the step fails loudly on the empty-sha test rather than proceeding uncached.