### PR TITLE
build(runner): install the github cli for workflow release publishing

### DIFF
--- a/test-infra/runner/roles/ci-deps/tasks/main.yml
+++ b/test-infra/runner/roles/ci-deps/tasks/main.yml
@@ -42,6 +42,26 @@
     groups: docker
     append: true
 
+# Workflows publish and fetch release assets with the GitHub CLI.
+- name: GitHub CLI apt key
+  ansible.builtin.get_url:
+    url: https://cli.github.com/packages/githubcli-archive-keyring.gpg
+    dest: /etc/apt/keyrings/githubcli.gpg
+    mode: "0644"
+
+- name: GitHub CLI apt repo
+  ansible.builtin.apt_repository:
+    repo: >-
+      deb [signed-by=/etc/apt/keyrings/githubcli.gpg]
+      https://cli.github.com/packages stable main
+    filename: github-cli
+
+- name: Install GitHub CLI
+  ansible.builtin.apt:
+    name: gh
+    state: present
+    update_cache: true
+
 # Preallocate the hugepage pool at the host level. Every BNG
 # container draws 2M pages from this one global pool, so parallel
 # labs need it sized for all of them, and preallocation at boot

--- a/test-infra/runner/roles/runner/tasks/register.yml
+++ b/test-infra/runner/roles/runner/tasks/register.yml
@@ -1,6 +1,14 @@
 # One runner service per instance, from the shared dist. Registration
 # is one-shot: once .runner exists the token tasks are skipped, so
-# reruns of the playbook never need a token.
+# reruns of the playbook never need a token. The dist copy is also
+# one-shot: resyncing an existing instance fails with ETXTBSY when
+# its Runner.Listener is mid-job, and a live instance must not be
+# overwritten anyway.
+- name: "Check instance directory for shared-{{ instance_no }}"
+  ansible.builtin.stat:
+    path: "/opt/runner-shared-{{ instance_no }}/bin/Runner.Listener"
+  register: runner_instance
+
 - name: "Create instance directory for shared-{{ instance_no }}"
   ansible.builtin.copy:
     src: /opt/runner-dist/
@@ -9,6 +17,7 @@
     owner: runner
     group: runner
     mode: preserve
+  when: not runner_instance.stat.exists
 
 - name: "Check registration of shared-{{ instance_no }}"
   ansible.builtin.stat:


### PR DESCRIPTION
The first live dataplane-artifacts run built the deb set successfully and then failed at the publish step with gh: command not found: the workflows publish and fetch release assets with the GitHub CLI, and the ci-deps role never installed it.

The role adds gh from GitHub's apt repo.

Verified: applied to the rehearsal VM and the failed workflow job rerun completed the publish (see run log). Not verified beyond that run.