### PR TITLE
ci: staged suite allowlist, honest exit codes, lab cleanup on cancel

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -83,6 +83,17 @@ jobs:
       - name: Run ${{ matrix.suite }}
         run: ./scripts/run-qa-tests.sh -r 1 -t ${{ matrix.suite }}
 
+      # A cancelled job kills robot before its suite teardown, which
+      # would leave the lab's containers up with VPP polling a core
+      # forever. Scoped to this suite's topology only: parallel jobs
+      # own other labs on the same box, so never destroy --all here.
+      - name: Destroy suite lab
+        if: always()
+        run: |
+          sudo containerlab destroy \
+            -t tests/${{ matrix.suite }}/${{ matrix.suite }}.clab.yml \
+            --cleanup 2>/dev/null || true
+
       - name: Upload robot output
         if: always()
         uses: actions/upload-artifact@v4

--- a/scripts/list-qa-suites.sh
+++ b/scripts/list-qa-suites.sh
@@ -7,8 +7,18 @@
 # directory with a robot file, minus tests/skip-suites.txt. The
 # integration workflow builds its matrix from this, so a new suite
 # directory joins CI without touching any workflow yaml.
+#
+# Staging override: while tests/ci-suites.txt exists, CI runs exactly
+# the suites it lists. Delete the file to return to the full
+# generated matrix.
 set -euo pipefail
 cd "$(dirname "$0")/.."
+
+if [ -f tests/ci-suites.txt ]; then
+    sed 's/#.*//; s/[[:space:]]*$//' tests/ci-suites.txt | grep -v '^$' \
+        | jq -R . | jq -sc .
+    exit 0
+fi
 
 skips=$(sed 's/#.*//; s/[[:space:]]*$//' tests/skip-suites.txt)
 for dir in tests/[0-9]*/; do

--- a/scripts/run-qa-tests.sh
+++ b/scripts/run-qa-tests.sh
@@ -130,9 +130,14 @@ total_pass=0
 total_fail=0
 
 REWRITTEN_TOPOS=()
+# Plain if, not a && chain: under set -e a failed test in the EXIT
+# trap becomes the script's exit code, which made every fully green
+# run exit 1.
 restore_topologies() {
     for f in "${REWRITTEN_TOPOS[@]:-}"; do
-        [ -n "$f" ] && [ -f "$f.qabak" ] && mv "$f.qabak" "$f"
+        if [ -n "$f" ] && [ -f "$f.qabak" ]; then
+            mv "$f.qabak" "$f"
+        fi
     done
 }
 trap restore_topologies EXIT
@@ -200,3 +205,8 @@ echo "" | tee -a "$SUMMARY"
 echo "========================================" | tee -a "$SUMMARY"
 echo "TOTAL: $total_pass passed, $total_fail failed out of $((total_pass + total_fail))" | tee -a "$SUMMARY"
 echo "Done: $(date)" | tee -a "$SUMMARY"
+
+# Exit red when any suite failed; the count was previously tallied
+# but never propagated, so CI could not tell a failed sweep from a
+# green one.
+[ "$total_fail" -eq 0 ]

--- a/test-results/qa/20260816-225923/summary.txt
+++ b/test-results/qa/20260816-225923/summary.txt
@@ -1,0 +1,13 @@
+QA Test Run: 20260816-225923
+Runs per test: 1
+Tests: 01-smoke
+Results: /tmp/claude-1000/-home-brandon-osvbng-dev-osvbng-context/68545c9c-186f-4326-856f-554b5025900b/scratchpad/osvbng-cifix/test-results/qa/20260816-225923
+========================================
+
+--- 01-smoke ---
+PASS (10 tests, 10 passed, 0 failed)
+  Result: 1/1 passed
+
+========================================
+TOTAL: 1 passed, 0 failed out of 1
+Done: Sun Aug 16 23:01:47 UTC 2026

--- a/tests/ci-suites.txt
+++ b/tests/ci-suites.txt
@@ -1,0 +1,6 @@
+# Staging allowlist: while this file exists, CI runs exactly these
+# suites. Grow it as suites prove green on the runner; delete the
+# file to return to the full generated matrix minus skip-suites.txt.
+01-smoke
+03-ipoe-local
+04-pppoe-local


### PR DESCRIPTION
Three defects surfaced by the first live integration run. run-qa-tests.sh exited 1 on fully green runs: the EXIT trap's test-and-move chain returns nonzero for its empty-array placeholder element and set -e promotes that to the script's exit code, a bug local use never saw because pipelines masked the status. The same script also never propagated real failures, total_fail was tallied but not returned, so CI could not distinguish a failed sweep from a green one. And a cancelled job kills robot before its suite teardown, leaving the lab's containers up with VPP polling a core indefinitely, confirmed live: the cancelled run left the 05-ipoe-radius lab running on the box.

The trap uses a plain if so it always returns clean; the script ends by asserting total_fail is zero, red when any suite failed. The suites job gains an always() step destroying this suite's topology only, never --all, since parallel jobs own other labs on the same host. And a staging mechanism for bringing CI up suite by suite: while tests/ci-suites.txt exists the matrix runs exactly its entries, starting with 01-smoke, 03-ipoe-local and 04-pppoe-local; grow the list as suites prove green on the runner, delete the file to return to the full generated matrix minus skip-suites.txt.

Verified: a real 01-smoke run through the fixed script exits 0 with 10/10 passing (previously exit 1); the list script emits the allowlist when the file exists and the full matrix when it does not; the workflow yaml parses; the leaked lab from the cancelled run was destroyed with the same scoped command the cleanup step uses. Not verified: the always() cleanup step has not been exercised by a live cancellation yet, and the failure exit path was verified by inspection of the final assertion, not by a deliberately failed suite.