### PR TITLE
ci: nightly full sweep and release qualification tiers

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,15 +2,10 @@
 # Licensed under the GNU General Public License v3.0 or later.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-# Integration suites on the shared self-hosted pool, gated on
-# maintainer approval: the image job references the integration-rig
-# environment, whose required reviewer must approve before anything
-# executes PR code on the runner. The image is built once per run
-# from the osvbng-vpp dataplane-latest release debs (patched VPP core
-# plus all osvbng plugins from one build), so every suite in a run
-# tests the same image and the same dataplane. The suite matrix is
-# generated from tests/ at run time; adding a suite directory adds it
-# to CI without touching this file.
+# Per-PR tier: the core suite set from tests/ci-suites.txt, gated on
+# maintainer approval because it executes PR code on the shared
+# runner pool. The full matrix runs nightly (nightly.yml) and before
+# releases (release-qualification.yml).
 
 name: integration
 
@@ -19,8 +14,8 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# Whole runs serialize: the suites share one image tag on the box,
-# and two runs building it concurrently would race.
+# Whole runs serialize across all tiers: the suites share one image
+# tag on the box, and two runs building it concurrently would race.
 concurrency:
   group: integration
   cancel-in-progress: false
@@ -35,81 +30,9 @@ jobs:
       - id: list
         run: echo "suites=$(./scripts/list-qa-suites.sh)" >> "$GITHUB_OUTPUT"
 
-  image:
-    environment: integration-rig
-    runs-on: [self-hosted, osvbng-metal]
-    steps:
-      - uses: actions/checkout@v4
-
-      # The runner keeps a per-commit cache of the four debs the
-      # image actually installs (the release also carries vpp-dbg,
-      # 92MB of symbols the image never uses), so a run downloads
-      # nothing unless the dataplane changed since the last run on
-      # this box.
-      - name: Fetch dataplane artifacts
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          body=$(gh release view dataplane-latest -R veesix-networks/osvbng-vpp \
-            --json body -q .body)
-          echo "dataplane provenance: $body"
-          sha=$(echo "$body" | grep -oE 'from [0-9a-f]{40}' | awk '{print $2}')
-          test -n "$sha"
-          cache="$HOME/.cache/osvbng-dataplane/$sha"
-          if [ ! -d "$cache" ]; then
-            tmp=$(mktemp -d)
-            for p in 'vpp_*.deb' 'vpp-plugin-core_*.deb' \
-                     'vpp-plugin-dpdk_*.deb' 'libvppinfra_*.deb'; do
-              gh release download dataplane-latest -R veesix-networks/osvbng-vpp \
-                -p "$p" -D "$tmp"
-            done
-            mkdir -p "$HOME/.cache/osvbng-dataplane"
-            mv "$tmp" "$cache"
-            ls -dt "$HOME"/.cache/osvbng-dataplane/*/ | tail -n +4 | xargs -r rm -rf
-          fi
-          mkdir -p docker/dataplane-debs
-          cp "$cache"/*.deb docker/dataplane-debs/
-
-      - name: Build osvbng image from dataplane debs
-        run: make docker-local
-
-      - name: Build Kea image
-        run: make docker-kea-local
-
-      - name: Pre-pull suite dependency images
-        run: |
-          docker pull veesixnetworks/bngblaster:0.9.30
-          docker pull frrouting/frr:v8.4.1
-
-  suites:
-    needs: [suites-list, image]
-    runs-on: [self-hosted, osvbng-metal]
-    strategy:
-      fail-fast: false
-      max-parallel: 3
-      matrix:
-        suite: ${{ fromJSON(needs.suites-list.outputs.suites) }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Run ${{ matrix.suite }}
-        run: ./scripts/run-qa-tests.sh -r 1 -t ${{ matrix.suite }}
-
-      # A cancelled job kills robot before its suite teardown, which
-      # would leave the lab's containers up with VPP polling a core
-      # forever. Scoped to this suite's topology only: parallel jobs
-      # own other labs on the same box, so never destroy --all here.
-      - name: Destroy suite lab
-        if: always()
-        run: |
-          sudo containerlab destroy \
-            -t tests/${{ matrix.suite }}/${{ matrix.suite }}.clab.yml \
-            --cleanup 2>/dev/null || true
-
-      - name: Upload robot output
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: robot-${{ matrix.suite }}
-          path: tests/out/
-          retention-days: 14
+  run:
+    needs: suites-list
+    uses: ./.github/workflows/suite-run.yml
+    with:
+      suites: ${{ needs.suites-list.outputs.suites }}
+      environment: integration-rig

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,75 @@
+# Copyright 2026 The osvbng Authors
+# Licensed under the GNU General Public License v3.0 or later.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Nightly tier: the full suite matrix against main, ungated because
+# it runs only already-merged code. A red nightly means main is red:
+# fix forward or revert before merging anything else, while the
+# failure still implicates at most a day of merges. The sweep is
+# skipped when nothing changed: the pair (osvbng HEAD, dataplane
+# provenance commit) is compared against the NIGHTLY_LAST repo
+# variable recorded by the previous successful sweep, so an
+# osvbng-vpp merge alone still triggers a run, since it changes what
+# is under test.
+
+name: nightly
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: integration
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      current: ${{ steps.check.outputs.current }}
+      changed: ${{ steps.check.outputs.changed }}
+      suites: ${{ steps.list.outputs.suites }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: list
+        run: echo "suites=$(./scripts/list-qa-suites.sh --all)" >> "$GITHUB_OUTPUT"
+      - id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          dp=$(gh release view dataplane-latest -R veesix-networks/osvbng-vpp \
+            --json body -q .body | grep -oE 'from [0-9a-f]{40}' | awk '{print $2}')
+          test -n "$dp"
+          current="${GITHUB_SHA}:${dp}"
+          last=$(gh variable get NIGHTLY_LAST --repo "$GITHUB_REPOSITORY" 2>/dev/null || echo none)
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+          if [ "$current" = "$last" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "no changes since last successful sweep ($last), skipping"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  run:
+    needs: changes
+    if: needs.changes.outputs.changed == 'true'
+    uses: ./.github/workflows/suite-run.yml
+    with:
+      suites: ${{ needs.changes.outputs.suites }}
+
+  record:
+    needs: [changes, run]
+    if: needs.run.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Record swept state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh variable set NIGHTLY_LAST --repo "$GITHUB_REPOSITORY" \
+            --body "${{ needs.changes.outputs.current }}"

--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -1,0 +1,39 @@
+# Copyright 2026 The osvbng Authors
+# Licensed under the GNU General Public License v3.0 or later.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Release tier: the full matrix with repeated runs so flakes cannot
+# hide, dispatched deliberately by the maintainer against main before
+# merging a release-please PR. Merge the release only on a green
+# qualification. Ungated: it runs already-merged code.
+
+name: release-qualification
+
+on:
+  workflow_dispatch:
+    inputs:
+      runs:
+        description: Runs per suite
+        required: false
+        default: "3"
+
+concurrency:
+  group: integration
+  cancel-in-progress: false
+
+jobs:
+  suites-list:
+    runs-on: ubuntu-latest
+    outputs:
+      suites: ${{ steps.list.outputs.suites }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: list
+        run: echo "suites=$(./scripts/list-qa-suites.sh --all)" >> "$GITHUB_OUTPUT"
+
+  run:
+    needs: suites-list
+    uses: ./.github/workflows/suite-run.yml
+    with:
+      suites: ${{ needs.suites-list.outputs.suites }}
+      runs: ${{ fromJSON(inputs.runs) }}

--- a/.github/workflows/suite-run.yml
+++ b/.github/workflows/suite-run.yml
@@ -1,0 +1,112 @@
+# Copyright 2026 The osvbng Authors
+# Licensed under the GNU General Public License v3.0 or later.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Reusable suite runner shared by every tier: integration (per-PR,
+# approval-gated core suites), nightly (full matrix on main) and
+# release qualification (full matrix, repeated runs). The image is
+# built once per run from the osvbng-vpp dataplane-latest release
+# debs, so every suite in a run tests the same image and the same
+# dataplane. Callers pass the suite list, the runs count, and the
+# environment name; an empty environment means no approval gate,
+# which is only correct for already-merged code.
+
+name: suite-run
+
+on:
+  workflow_call:
+    inputs:
+      suites:
+        description: JSON array of suite names
+        required: true
+        type: string
+      runs:
+        description: Runs per suite
+        required: false
+        type: number
+        default: 1
+      environment:
+        description: Environment gating the image job; empty for none
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  image:
+    environment: ${{ inputs.environment }}
+    runs-on: [self-hosted, osvbng-metal]
+    steps:
+      - uses: actions/checkout@v4
+
+      # The runner keeps a per-commit cache of the four debs the
+      # image actually installs (the release also carries vpp-dbg,
+      # 92MB of symbols the image never uses), so a run downloads
+      # nothing unless the dataplane changed since the last run on
+      # this box.
+      - name: Fetch dataplane artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          body=$(gh release view dataplane-latest -R veesix-networks/osvbng-vpp \
+            --json body -q .body)
+          echo "dataplane provenance: $body"
+          sha=$(echo "$body" | grep -oE 'from [0-9a-f]{40}' | awk '{print $2}')
+          test -n "$sha"
+          cache="$HOME/.cache/osvbng-dataplane/$sha"
+          if [ ! -d "$cache" ]; then
+            tmp=$(mktemp -d)
+            for p in 'vpp_*.deb' 'vpp-plugin-core_*.deb' \
+                     'vpp-plugin-dpdk_*.deb' 'libvppinfra_*.deb'; do
+              gh release download dataplane-latest -R veesix-networks/osvbng-vpp \
+                -p "$p" -D "$tmp"
+            done
+            mkdir -p "$HOME/.cache/osvbng-dataplane"
+            mv "$tmp" "$cache"
+            ls -dt "$HOME"/.cache/osvbng-dataplane/*/ | tail -n +4 | xargs -r rm -rf
+          fi
+          mkdir -p docker/dataplane-debs
+          cp "$cache"/*.deb docker/dataplane-debs/
+
+      - name: Build osvbng image from dataplane debs
+        run: make docker-local
+
+      - name: Build Kea image
+        run: make docker-kea-local
+
+      - name: Pre-pull suite dependency images
+        run: |
+          docker pull veesixnetworks/bngblaster:0.9.30
+          docker pull frrouting/frr:v8.4.1
+
+  suites:
+    needs: image
+    runs-on: [self-hosted, osvbng-metal]
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        suite: ${{ fromJSON(inputs.suites) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run ${{ matrix.suite }}
+        run: ./scripts/run-qa-tests.sh -r ${{ inputs.runs }} -t ${{ matrix.suite }}
+
+      # A cancelled job kills robot before its suite teardown, which
+      # would leave the lab's containers up with VPP polling a core
+      # forever. Scoped to this suite's topology only: parallel jobs
+      # own other labs on the same box, so never destroy --all here.
+      - name: Destroy suite lab
+        if: always()
+        run: |
+          sudo containerlab destroy \
+            -t tests/${{ matrix.suite }}/${{ matrix.suite }}.clab.yml \
+            --cleanup 2>/dev/null || true
+
+      - name: Upload robot output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: robot-${{ github.run_id }}-${{ matrix.suite }}
+          path: tests/out/
+          retention-days: 14

--- a/scripts/list-qa-suites.sh
+++ b/scripts/list-qa-suites.sh
@@ -8,13 +8,14 @@
 # integration workflow builds its matrix from this, so a new suite
 # directory joins CI without touching any workflow yaml.
 #
-# Staging override: while tests/ci-suites.txt exists, CI runs exactly
-# the suites it lists. Delete the file to return to the full
-# generated matrix.
+# Core-set override: while tests/ci-suites.txt exists, the default
+# output is exactly the suites it lists (the per-PR tier). --all
+# ignores the override and emits the full matrix minus skips: the
+# nightly and release-qualification tiers use it.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-if [ -f tests/ci-suites.txt ]; then
+if [ "${1:-}" != "--all" ] && [ -f tests/ci-suites.txt ]; then
     sed 's/#.*//; s/[[:space:]]*$//' tests/ci-suites.txt | grep -v '^$' \
         | jq -R . | jq -sc .
     exit 0


### PR DESCRIPTION
Per-PR CI runs the small core suite set, so the full matrix only ran when someone remembered to run it. A full-sweep failure discovered at release time bisects across everything merged since the last sweep, under release pressure, which is the worst moment to learn main is broken.

Three tiers now share one reusable suite runner (suite-run.yml: image built once per run from the dataplane-latest debs with the per-commit cache, matrix fan-out, scoped lab cleanup, robot artifacts). integration.yml stays the per-PR tier, core suites from tests/ci-suites.txt, gated on the integration-rig environment because it executes PR code. nightly.yml runs the full matrix against main at 02:00 UTC, ungated because merged code needs no approval; it skips entirely when the pair of osvbng HEAD and dataplane provenance commit matches the NIGHTLY_LAST repo variable recorded by the last successful sweep, so quiet days cost nothing while an osvbng-vpp merge alone still triggers a run. release-qualification.yml is dispatched by the maintainer before merging a release-please PR: the full matrix with three runs per suite so flakes cannot hide, merge only on green. All tiers share the integration concurrency group, so runs never race on the shared image tag. list-qa-suites.sh gains --all to bypass the core-set override for the full tiers.

Verified: all four yamls parse, the list script emits the three core suites by default and 47 suites with --all. Not verified: no tier has executed through the reusable workflow yet; the first dispatch after merge exercises the workflow_call plumbing, the dynamic environment input, and the nightly variable round-trip, and I will run and watch that dispatch.