### PR TITLE
ci: cancel a pr's parked integration runs when it closes

### DIFF
--- a/.github/workflows/integration-janitor.yml
+++ b/.github/workflows/integration-janitor.yml
@@ -1,0 +1,35 @@
+# Copyright 2026 The osvbng Authors
+# Licensed under the GNU General Public License v3.0 or later.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# A PR-triggered integration run that is never approved sits at the
+# environment gate holding the shared concurrency group, and every
+# later run (other PRs, the nightly sweep) queues behind it forever.
+# Cancel a PR's parked runs as soon as the PR closes; an unapproved
+# run for a closed PR can never be worth executing.
+
+name: integration-janitor
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  actions: write
+
+jobs:
+  cancel-stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel parked integration runs for this PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for st in waiting pending queued; do
+            for id in $(gh run list -R "$GITHUB_REPOSITORY" \
+                --workflow integration --branch "${{ github.head_ref }}" \
+                --status "$st" --json databaseId -q '.[].databaseId'); do
+              echo "cancelling $st run $id"
+              gh run cancel "$id" -R "$GITHUB_REPOSITORY" || true
+            done
+          done


### PR DESCRIPTION
An integration run waiting at the approval gate holds the shared integration concurrency group, and every later run queues behind it indefinitely. This has now blocked the pipeline twice: the dispatched sweep queued behind PR 438's unapproved run, and tonight's nightly dispatch queued behind PR 441's, both PRs already merged with their parked runs stale by definition.

A janitor workflow triggers when a PR closes and cancels that PR's integration runs in waiting, pending or queued state. An unapproved run for a closed PR can never be worth executing: merged PRs are covered by the nightly sweep on main, and abandoned PRs need no run at all. Runs for still-open PRs are untouched, so the approve-or-ignore decision stays the maintainer's while the PR lives.

Verified: yaml parses; the cancellation command is the same one used manually both times this bit. Not verified: the trigger itself has not fired yet, the next PR close exercises it, and this PR's own close is that first exercise since it will have a parked integration run of its own.