### PR TITLE
build(runner): weekly disk janitor for docker and runner log growth

### DIFF
--- a/test-infra/runner/roles/ci-deps/tasks/main.yml
+++ b/test-infra/runner/roles/ci-deps/tasks/main.yml
@@ -72,6 +72,23 @@
     value: "{{ hugepages_2m | default(4096) }}"
     sysctl_file: /etc/sysctl.d/90-hugepages.conf
 
+# Nothing on the box prunes itself: every image build strands the
+# previous build's unique layers as dangling, the BuildKit cache
+# only grows, and runner job diagnostics accumulate forever. Weekly
+# janitor keeps growth bounded. Dangling-only image prune: an
+# aggressive prune would evict the warm layers that make builds
+# fast, which is the box's whole value.
+- name: Install disk janitor
+  ansible.builtin.copy:
+    dest: /etc/cron.weekly/ci-disk-janitor
+    mode: "0755"
+    content: |
+      #!/bin/sh
+      docker image prune -f
+      docker builder prune -f --keep-storage {{ builder_cache_keep | default('20GB') }}
+      find /opt/runner-*/_diag -name '*.log' -mtime +14 -delete 2>/dev/null
+      exit 0
+
 # Pinned release deb from GitHub, not the fury apt repo: the repo is
 # unsigned (upstream's instructions use trusted=yes) and unpinned,
 # and CI wants the same containerlab version as the dev machine.


### PR DESCRIPTION
Nothing on the runner box prunes itself: every image build strands the previous build's unique layers as dangling, the BuildKit cache only grows, and runner job diagnostics accumulate indefinitely. The box sits at 72% disk after one day of use; growth is unbounded from here. Lab containers and workspaces are fine, suite teardown and checkout's clean handle those.

The ci-deps role installs a weekly cron janitor: dangling-only image prune (an aggressive prune would evict the warm layers that make builds fast, which is the box's whole value), builder-cache prune above a configurable keep threshold defaulting to 20GB, and runner diagnostic logs older than two weeks.

Verified: lint clean, applied to the rehearsal VM, the cron file is installed and executed once by hand without error. Not verified: reclaimed space was minimal on first execution because current layers are all live and the builder cache is under threshold, which is the expected steady state; the janitor's value shows over weeks.