### PR TITLE
ci: serialize lab deploys, bound suite runtime, kill orphaned deploys

### DIFF
--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -37,3 +37,4 @@ jobs:
     with:
       suites: ${{ needs.suites-list.outputs.suites }}
       runs: ${{ fromJSON(inputs.runs) }}
+      suite_timeout: 60

--- a/.github/workflows/suite-run.yml
+++ b/.github/workflows/suite-run.yml
@@ -30,6 +30,11 @@ on:
         required: false
         type: string
         default: ""
+      suite_timeout:
+        description: Minutes before a suite job is killed
+        required: false
+        type: number
+        default: 20
 
 jobs:
   image:
@@ -81,6 +86,11 @@ jobs:
   suites:
     needs: image
     runs-on: [self-hosted, osvbng-metal]
+    # A wedged suite must be a bounded failure, not a stalled lane:
+    # the slowest healthy suites finish in a few minutes, and one
+    # deadlocked deploy held two lanes for 20 minutes before this.
+    # Callers with repeated runs pass a larger budget.
+    timeout-minutes: ${{ inputs.suite_timeout }}
     strategy:
       fail-fast: false
       max-parallel: 3
@@ -92,13 +102,16 @@ jobs:
       - name: Run ${{ matrix.suite }}
         run: ./scripts/run-qa-tests.sh -r ${{ inputs.runs }} -t ${{ matrix.suite }}
 
-      # A cancelled job kills robot before its suite teardown, which
-      # would leave the lab's containers up with VPP polling a core
-      # forever. Scoped to this suite's topology only: parallel jobs
-      # own other labs on the same box, so never destroy --all here.
+      # A cancelled job kills robot before its suite teardown but not
+      # the root-owned sudo children, and an orphaned deploy holds
+      # containerlab's locks against every later deploy of that lab.
+      # Kill this suite's strays, then destroy its topology. Scoped
+      # to this suite only: parallel jobs own other labs on the same
+      # box, so never destroy --all here.
       - name: Destroy suite lab
         if: always()
         run: |
+          sudo pkill -f "containerlab deploy.*${{ matrix.suite }}" 2>/dev/null || true
           sudo containerlab destroy \
             -t tests/${{ matrix.suite }}/${{ matrix.suite }}.clab.yml \
             --cleanup 2>/dev/null || true

--- a/tests/common.robot
+++ b/tests/common.robot
@@ -24,8 +24,13 @@ ${TEST_LOG_DIR}         /tmp/test-logs
 *** Keywords ***
 Deploy Topology
     [Arguments]    ${topology_file}
+    # Deploys from parallel suites serialize under a host-wide lock:
+    # concurrent containerlab deploys race each other's network and
+    # container setup and have deadlocked half-created labs. Deploys
+    # take seconds, so serializing them costs little; the suites
+    # themselves still run in parallel.
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    ${CLAB_BIN} deploy -t ${topology_file} --reconfigure
+    ...    flock /tmp/osvbng-clab-deploy.lock ${CLAB_BIN} deploy -t ${topology_file} --reconfigure
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     RETURN    ${output}


### PR DESCRIPTION
The first nightly sweep wedged two of its three lanes for twenty minutes. Root cause chain, observed live: cancelling an earlier run killed the runner's process tree but not the root-owned sudo containerlab children, the orphaned deploys kept holding containerlab's setup locks, and the sweep's fresh deploys of the same labs blocked behind them indefinitely, one lab stuck with its BNG container created but never started. Separately, nothing bounded a suite job's runtime, so a wedge of any cause holds a lane until the six-hour default.

Three fixes. Deploy Topology serializes containerlab deploys under a host-wide flock: concurrent deploys race each other's network and container setup, deploys take seconds, and the suites themselves still run in parallel, so the lock costs little. Suite jobs get timeout-minutes from a new suite_timeout input, twenty by default and sixty for release qualification's repeated runs, so any wedge is a bounded failure instead of a stalled lane. The cleanup step kills this suite's stray deploy processes before destroying its topology, so a cancellation can no longer leave root orphans holding locks; it stays scoped to the suite, never touching parallel jobs' labs.

Verified: both yamls parse and the flock command line was exercised manually on the runner against a test lock. Not verified: the failure it prevents requires a cancellation mid-deploy to reproduce, which was not staged; tonight's live incident is the evidence for the mechanism, and the orphan kill command is the same one used to clear it by hand.