### PR TITLE
test: per-uid deploy lock path

### DIFF
--- a/tests/common.robot
+++ b/tests/common.robot
@@ -28,9 +28,12 @@ Deploy Topology
     # concurrent containerlab deploys race each other's network and
     # container setup and have deadlocked half-created labs. Deploys
     # take seconds, so serializing them costs little; the suites
-    # themselves still run in parallel.
+    # themselves still run in parallel. The lock path carries the uid
+    # because flock cannot open another user's lock file (exit 66):
+    # CI's runner instances share one uid so they still serialize,
+    # and a developer's local runs are single anyway.
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    flock /tmp/osvbng-clab-deploy.lock ${CLAB_BIN} deploy -t ${topology_file} --reconfigure
+    ...    flock /tmp/osvbng-clab-deploy.$(id -u).lock ${CLAB_BIN} deploy -t ${topology_file} --reconfigure
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     RETURN    ${output}


### PR DESCRIPTION
Every suite failed instantly on the runner after the deploy lock landed: flock exits 66 when it cannot open the lock file, and /tmp/osvbng-clab-deploy.lock existed owned by a different user, created by the manual lock test during verification of the previous change. A fixed path in a shared /tmp cannot be opened for locking across users.

The lock path now carries the uid. CI's runner instances share one uid, so parallel suite deploys still serialize against each other, which is the property the lock exists for; a developer's local runs are single and get their own lock file.

Verified: a full 01-smoke run through the changed keyword passes 10 of 10 with exit 0 locally, and the stale cross-user lock file was removed from the runner host. Not verified: the multi-instance serialization path runs first on the next sweep.