### PR TITLE
ci: self-healing host reset before each run

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,13 +14,21 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# Whole runs serialize across all tiers: the suites share one image
-# tag on the box, and two runs building it concurrently would race.
-concurrency:
-  group: integration
-  cancel-in-progress: false
+# No workflow-level concurrency: a run parked at the approval gate
+# must hold nothing, or every unapproved PR run blocks the nightly
+# and other PRs (a group allows one pending run, so a newer arrival
+# cancels an older pending one; only running runs are protected).
+# The gate is a no-op job on a hosted runner; the box's mutual
+# exclusion is job-level on the run job, claimed only after
+# approval, when execution actually starts.
 
 jobs:
+  gate:
+    environment: integration-rig
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "approved"
+
   suites-list:
     runs-on: ubuntu-latest
     outputs:
@@ -31,8 +39,10 @@ jobs:
         run: echo "suites=$(./scripts/list-qa-suites.sh)" >> "$GITHUB_OUTPUT"
 
   run:
-    needs: suites-list
+    needs: [gate, suites-list]
+    concurrency:
+      group: rig
+      cancel-in-progress: false
     uses: ./.github/workflows/suite-run.yml
     with:
       suites: ${{ needs.suites-list.outputs.suites }}
-      environment: integration-rig

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,10 +19,6 @@ on:
     - cron: "0 2 * * *"
   workflow_dispatch:
 
-concurrency:
-  group: integration
-  cancel-in-progress: false
-
 permissions:
   contents: read
   actions: write
@@ -58,6 +54,11 @@ jobs:
   run:
     needs: changes
     if: needs.changes.outputs.changed == 'true'
+    # Box-level mutual exclusion, shared with the other tiers'
+    # run jobs; claimed only when execution starts.
+    concurrency:
+      group: rig
+      cancel-in-progress: false
     uses: ./.github/workflows/suite-run.yml
     with:
       suites: ${{ needs.changes.outputs.suites }}

--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -17,10 +17,6 @@ on:
         required: false
         default: "3"
 
-concurrency:
-  group: integration
-  cancel-in-progress: false
-
 jobs:
   suites-list:
     runs-on: ubuntu-latest
@@ -33,6 +29,9 @@ jobs:
 
   run:
     needs: suites-list
+    concurrency:
+      group: rig
+      cancel-in-progress: false
     uses: ./.github/workflows/suite-run.yml
     with:
       suites: ${{ needs.suites-list.outputs.suites }}

--- a/.github/workflows/suite-run.yml
+++ b/.github/workflows/suite-run.yml
@@ -43,6 +43,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The run heals the box instead of assuming it is clean. This
+      # job runs once per run before any suite, and runs serialize,
+      # so nothing legitimate is executing on the host here: stray
+      # deploy processes and leftover lab containers are residue by
+      # definition, and a docker daemon that cannot answer a bounded
+      # probe is wedged and gets restarted. Every one of these was a
+      # by-hand SSH intervention once; none may ever be again.
+      - name: Reset host state
+        run: |
+          sudo pkill -9 -f 'containerlab deploy' 2>/dev/null || true
+          if ! timeout 20 docker info >/dev/null 2>&1; then
+            echo "docker unresponsive, restarting"
+            sudo systemctl restart docker
+            sleep 5
+            timeout 20 docker info >/dev/null
+          fi
+          stray=$(sudo docker ps -aq --filter name=clab-)
+          [ -n "$stray" ] && echo "$stray" | xargs -r sudo docker rm -f || true
+          timeout 20 sudo docker network inspect clab >/dev/null 2>&1 || \
+            timeout 30 sudo docker network create \
+              --subnet 172.20.20.0/24 --ipv6 --subnet 3fff:172:20:20::/64 clab
+          rm -f "/tmp/osvbng-clab-deploy.$(id -u).lock"
+
       # The runner keeps a per-commit cache of the four debs the
       # image actually installs (the release also carries vpp-dbg,
       # 92MB of symbols the image never uses), so a run downloads


### PR DESCRIPTION
Tonight's bring-up needed repeated by-hand SSH interventions on the runner, and separately the concurrency layout let parked runs strangle the pipeline. Two changes, one per commit.

First: the image job resets host state before building. It runs once per run before any suite, and execution serializes, so nothing legitimate runs on the host at that moment: stray containerlab deploy processes and leftover clab containers are removed, docker is probed with a bounded timeout so a wedged daemon (tonight: network-create path hung while listings still answered) is detected and restarted through the runner's own sudo, the clab management network is ensured to exist, and the deploy lock file is cleared. Every one of these was a manual SSH action tonight; steady-state CI must involve no humans beyond gate approval and merging.

Second: a run waiting at the approval gate must hold nothing. The workflow-level concurrency group let every unapproved PR run block the pipeline, and because a group keeps only one pending run, a newly opened PR cancelled the pending nightly outright (observed live, run 31981609433). The gate becomes a no-op job on a hosted runner, which parks harmlessly; the box's mutual exclusion moves to job-level concurrency (group rig) on each tier's run job, claimed only after approval when execution actually starts. Unapproved runs now block nothing and cancel nothing.

Verified: all four yamls parse; every reset command is one that was executed by hand on the runner tonight with the intended effect, including the daemon restart and network pre-create. Not verified: the reset step and the job-level concurrency-on-reusable-call semantics have not executed live; the first runs after merge exercise both, and I will dispatch and watch them.