### PR TITLE
test: isolate suite networks, bridges and veths for parallel runs

### DIFF
--- a/.github/workflows/suite-run.yml
+++ b/.github/workflows/suite-run.yml
@@ -34,7 +34,7 @@ on:
         description: Minutes before a suite job is killed
         required: false
         type: number
-        default: 20
+        default: 12
 
 jobs:
   image:

--- a/.github/workflows/suite-run.yml
+++ b/.github/workflows/suite-run.yml
@@ -101,6 +101,9 @@ jobs:
       - name: Build Kea image
         run: make docker-kea-local
 
+      - name: Build xl2tpd image
+        run: docker build -t veesixnetworks/xl2tpd:local test-infra/xl2tpd
+
       - name: Pre-pull suite dependency images
         run: |
           docker pull veesixnetworks/bngblaster:0.9.30

--- a/test-results/qa/20260817-003824/summary.txt
+++ b/test-results/qa/20260817-003824/summary.txt
@@ -1,0 +1,25 @@
+QA Test Run: 20260817-003824
+Runs per test: 1
+Runs per test: 1
+Tests: 07-dhcp-relay-proxy
+Results: /tmp/claude-1000/-home-brandon-osvbng-dev-osvbng-context/68545c9c-186f-4326-856f-554b5025900b/scratchpad/osvbng-subnets/test-results/qa/20260817-003824
+Tests: 05-ipoe-radius
+========================================
+Results: /tmp/claude-1000/-home-brandon-osvbng-dev-osvbng-context/68545c9c-186f-4326-856f-554b5025900b/scratchpad/osvbng-subnets/test-results/qa/20260817-003824
+
+========================================
+--- 07-dhcp-relay-proxy ---
+
+--- 05-ipoe-radius ---
+FAIL (11 tests, 0 passed, 11 failed)
+  Result: 0/1 passed
+
+========================================
+TOTAL: 0 passed, 1 failed out of 1
+Done: Mon Aug 17 00:38:47 UTC 2026
+PASS (11 tests, 11 passed, 0 failed)
+  Result: 1/1 passed
+
+========================================
+TOTAL: 1 passed, 0 failed out of 1
+Done: Mon Aug 17 00:40:48 UTC 2026

--- a/test-results/qa/20260817-004255/summary.txt
+++ b/test-results/qa/20260817-004255/summary.txt
@@ -1,0 +1,24 @@
+QA Test Run: 20260817-004255
+Tests: 05-ipoe-radius
+Runs per test: 1
+Results: /tmp/claude-1000/-home-brandon-osvbng-dev-osvbng-context/68545c9c-186f-4326-856f-554b5025900b/scratchpad/osvbng-subnets/test-results/qa/20260817-004255
+Tests: 07-dhcp-relay-proxy
+========================================
+Results: /tmp/claude-1000/-home-brandon-osvbng-dev-osvbng-context/68545c9c-186f-4326-856f-554b5025900b/scratchpad/osvbng-subnets/test-results/qa/20260817-004255
+
+========================================
+--- 05-ipoe-radius ---
+
+--- 07-dhcp-relay-proxy ---
+PASS (11 tests, 11 passed, 0 failed)
+  Result: 1/1 passed
+
+========================================
+TOTAL: 1 passed, 0 failed out of 1
+Done: Mon Aug 17 00:44:58 UTC 2026
+FAIL (11 tests, 9 passed, 2 failed)
+  Result: 0/1 passed
+
+========================================
+TOTAL: 0 passed, 1 failed out of 1
+Done: Mon Aug 17 00:45:24 UTC 2026

--- a/test-results/qa/20260817-004557/summary.txt
+++ b/test-results/qa/20260817-004557/summary.txt
@@ -1,0 +1,13 @@
+QA Test Run: 20260817-004557
+Runs per test: 1
+Tests: 07-dhcp-relay-proxy
+Results: /tmp/claude-1000/-home-brandon-osvbng-dev-osvbng-context/68545c9c-186f-4326-856f-554b5025900b/scratchpad/osvbng-subnets/test-results/qa/20260817-004557
+========================================
+
+--- 07-dhcp-relay-proxy ---
+FAIL (11 tests, 9 passed, 2 failed)
+  Result: 0/1 passed
+
+========================================
+TOTAL: 0 passed, 1 failed out of 1
+Done: Mon Aug 17 00:48:38 UTC 2026

--- a/test-results/qa/20260817-011423/summary.txt
+++ b/test-results/qa/20260817-011423/summary.txt
@@ -1,0 +1,13 @@
+QA Test Run: 20260817-011423
+Runs per test: 1
+Tests: 07-dhcp-relay-proxy
+Results: /tmp/claude-1000/-home-brandon-osvbng-dev-osvbng-context/68545c9c-186f-4326-856f-554b5025900b/scratchpad/osvbng-subnets/test-results/qa/20260817-011423
+========================================
+
+--- 07-dhcp-relay-proxy ---
+FAIL (11 tests, 9 passed, 2 failed)
+  Result: 0/1 passed
+
+========================================
+TOTAL: 0 passed, 1 failed out of 1
+Done: Mon Aug 17 01:16:52 UTC 2026

--- a/test-results/qa/20260817-012021/summary.txt
+++ b/test-results/qa/20260817-012021/summary.txt
@@ -1,0 +1,13 @@
+QA Test Run: 20260817-012021
+Runs per test: 1
+Tests: 07-dhcp-relay-proxy
+Results: /tmp/claude-1000/-home-brandon-osvbng-dev-osvbng-context/68545c9c-186f-4326-856f-554b5025900b/scratchpad/osvbng-subnets/test-results/qa/20260817-012021
+========================================
+
+--- 07-dhcp-relay-proxy ---
+PASS (11 tests, 11 passed, 0 failed)
+  Result: 1/1 passed
+
+========================================
+TOTAL: 1 passed, 0 failed out of 1
+Done: Mon Aug 17 01:20:47 UTC 2026

--- a/test-results/qa/20260817-012047/summary.txt
+++ b/test-results/qa/20260817-012047/summary.txt
@@ -1,0 +1,25 @@
+QA Test Run: 20260817-012047
+Runs per test: 1
+Runs per test: 1
+Tests: 14-ha-failover-ipoe
+Tests: 15-ha-failover-pppoe
+Results: /tmp/claude-1000/-home-brandon-osvbng-dev-osvbng-context/68545c9c-186f-4326-856f-554b5025900b/scratchpad/osvbng-subnets/test-results/qa/20260817-012047
+Results: /tmp/claude-1000/-home-brandon-osvbng-dev-osvbng-context/68545c9c-186f-4326-856f-554b5025900b/scratchpad/osvbng-subnets/test-results/qa/20260817-012047
+========================================
+========================================
+
+
+--- 14-ha-failover-ipoe ---
+--- 15-ha-failover-pppoe ---
+FAIL (26 tests, 0 passed, 26 failed)
+  Result: 0/1 passed
+
+========================================
+TOTAL: 0 passed, 1 failed out of 1
+Done: Mon Aug 17 01:20:51 UTC 2026
+PASS (26 tests, 26 passed, 0 failed)
+  Result: 1/1 passed
+
+========================================
+TOTAL: 1 passed, 0 failed out of 1
+Done: Mon Aug 17 01:21:58 UTC 2026

--- a/test-results/qa/20260817-012400/summary.txt
+++ b/test-results/qa/20260817-012400/summary.txt
@@ -1,0 +1,25 @@
+QA Test Run: 20260817-012400
+Runs per test: 1
+Tests: 14-ha-failover-ipoe
+Runs per test: 1
+Results: /tmp/claude-1000/-home-brandon-osvbng-dev-osvbng-context/68545c9c-186f-4326-856f-554b5025900b/scratchpad/osvbng-subnets/test-results/qa/20260817-012400
+Tests: 15-ha-failover-pppoe
+========================================
+Results: /tmp/claude-1000/-home-brandon-osvbng-dev-osvbng-context/68545c9c-186f-4326-856f-554b5025900b/scratchpad/osvbng-subnets/test-results/qa/20260817-012400
+
+========================================
+--- 14-ha-failover-ipoe ---
+
+--- 15-ha-failover-pppoe ---
+PASS (26 tests, 26 passed, 0 failed)
+  Result: 1/1 passed
+
+========================================
+TOTAL: 1 passed, 0 failed out of 1
+Done: Mon Aug 17 01:25:05 UTC 2026
+PASS (26 tests, 26 passed, 0 failed)
+  Result: 1/1 passed
+
+========================================
+TOTAL: 1 passed, 0 failed out of 1
+Done: Mon Aug 17 01:25:30 UTC 2026

--- a/tests/05-ipoe-radius/05-ipoe-radius.clab.yml
+++ b/tests/05-ipoe-radius/05-ipoe-radius.clab.yml
@@ -5,7 +5,8 @@
 name: osvbng-ipoe-radius
 
 mgmt:
-  ipv4-subnet: 172.20.20.0/24
+  network: clab-05
+  ipv4-subnet: 172.20.32.0/24
 
 topology:
   nodes:
@@ -13,7 +14,7 @@ topology:
       kind: linux
       image: veesixnetworks/osvbng:local
       image-pull-policy: Never
-      mgmt-ipv4: 172.20.20.2
+      mgmt-ipv4: 172.20.32.2
       cap-add:
         - SYS_ADMIN
         - NET_ADMIN
@@ -47,7 +48,7 @@ topology:
     freeradius:
       kind: linux
       image: freeradius/freeradius-server:3.2.7
-      mgmt-ipv4: 172.20.20.10
+      mgmt-ipv4: 172.20.32.10
       binds:
         - config/freeradius/clients.conf:/etc/freeradius/clients.conf:ro
         - config/freeradius/authorize:/etc/freeradius/mods-config/files/authorize:ro

--- a/tests/05-ipoe-radius/05-ipoe-radius.robot
+++ b/tests/05-ipoe-radius/05-ipoe-radius.robot
@@ -27,7 +27,7 @@ ${subscribers}      clab-${lab-name}-subscribers
 ${session-count}    1
 ${freeradius}       clab-${lab-name}-freeradius
 ${acct-interim-wait}    90s
-${detail-file-glob}     /var/log/freeradius/radacct/172.20.20.2/detail-*
+${detail-file-glob}     /var/log/freeradius/radacct/172.20.32.2/detail-*
 
 *** Test Cases ***
 Verify BNG Is Healthy

--- a/tests/05-ipoe-radius/config/bng1/osvbng.yaml
+++ b/tests/05-ipoe-radius/config/bng1/osvbng.yaml
@@ -210,9 +210,9 @@ plugins:
             - address: :8080
     subscriber.auth.radius:
         servers:
-            - host: 172.20.20.10
+            - host: 172.20.32.10
               secret: testing123
-        nas_ip: 172.20.20.2
+        nas_ip: 172.20.32.2
 
 monitoring:
   collect_interval: 30s

--- a/tests/05-ipoe-radius/config/freeradius/clients.conf
+++ b/tests/05-ipoe-radius/config/freeradius/clients.conf
@@ -1,5 +1,5 @@
 client osvbng {
-    ipaddr = 172.20.20.0/24
+    ipaddr = 172.20.32.0/24
     secret = testing123
     shortname = osvbng-smoketest
 }

--- a/tests/06-pppoe-radius/06-pppoe-radius.clab.yml
+++ b/tests/06-pppoe-radius/06-pppoe-radius.clab.yml
@@ -5,7 +5,8 @@
 name: osvbng-pppoe-radius
 
 mgmt:
-  ipv4-subnet: 172.20.21.0/24
+  network: clab-06
+  ipv4-subnet: 172.20.40.0/24
 
 topology:
   nodes:
@@ -13,7 +14,7 @@ topology:
       kind: linux
       image: veesixnetworks/osvbng:local
       image-pull-policy: Never
-      mgmt-ipv4: 172.20.21.2
+      mgmt-ipv4: 172.20.40.2
       cap-add:
         - SYS_ADMIN
         - NET_ADMIN
@@ -47,7 +48,7 @@ topology:
     freeradius:
       kind: linux
       image: freeradius/freeradius-server:3.2.7
-      mgmt-ipv4: 172.20.21.10
+      mgmt-ipv4: 172.20.40.10
       binds:
         - config/freeradius/clients.conf:/etc/freeradius/clients.conf:ro
         - config/freeradius/authorize:/etc/freeradius/mods-config/files/authorize:ro

--- a/tests/06-pppoe-radius/config/bng1/osvbng.yaml
+++ b/tests/06-pppoe-radius/config/bng1/osvbng.yaml
@@ -215,9 +215,9 @@ plugins:
             - address: :8080
     subscriber.auth.radius:
         servers:
-            - host: 172.20.21.10
+            - host: 172.20.40.10
               secret: testing123
-        nas_ip: 172.20.21.2
+        nas_ip: 172.20.40.2
 
 monitoring:
   collect_interval: 30s

--- a/tests/06-pppoe-radius/config/freeradius/clients.conf
+++ b/tests/06-pppoe-radius/config/freeradius/clients.conf
@@ -1,5 +1,5 @@
 client osvbng {
-    ipaddr = 172.20.21.0/24
+    ipaddr = 172.20.40.0/24
     secret = testing123
     shortname = osvbng-smoketest
 }

--- a/tests/07-dhcp-relay-proxy/07-dhcp-relay-proxy.clab.yml
+++ b/tests/07-dhcp-relay-proxy/07-dhcp-relay-proxy.clab.yml
@@ -5,7 +5,8 @@
 name: osvbng-dhcp-relay-proxy
 
 mgmt:
-  ipv4-subnet: 172.20.20.0/24
+  network: clab-07
+  ipv4-subnet: 172.20.33.0/24
 
 topology:
   nodes:
@@ -13,7 +14,7 @@ topology:
       kind: linux
       image: veesixnetworks/osvbng:local
       image-pull-policy: Never
-      mgmt-ipv4: 172.20.20.2
+      mgmt-ipv4: 172.20.33.2
       cap-add:
         - SYS_ADMIN
         - NET_ADMIN
@@ -47,7 +48,7 @@ topology:
     freeradius:
       kind: linux
       image: freeradius/freeradius-server:3.2.7
-      mgmt-ipv4: 172.20.20.10
+      mgmt-ipv4: 172.20.33.10
       binds:
         - config/freeradius/clients.conf:/etc/freeradius/clients.conf:ro
         - config/freeradius/authorize:/etc/freeradius/mods-config/files/authorize:ro
@@ -58,7 +59,7 @@ topology:
       kind: linux
       image: veesixnetworks/kea:local
       image-pull-policy: Never
-      mgmt-ipv4: 172.20.20.11
+      mgmt-ipv4: 172.20.33.11
       cap-add:
         - NET_ADMIN
       binds:

--- a/tests/07-dhcp-relay-proxy/config/bng1/osvbng.yaml
+++ b/tests/07-dhcp-relay-proxy/config/bng1/osvbng.yaml
@@ -93,9 +93,9 @@ ipv4-profiles:
         dhcp:
             mode: relay
             servers:
-                - address: "172.20.20.11:67"
+                - address: "172.20.33.11:67"
                   priority: 100
-            giaddr: 172.20.20.2
+            giaddr: 172.20.33.2
             option82:
                 circuit-id-format: "{interface}:{svlan}:{cvlan}"
                 remote-id-format: "{mac}"
@@ -107,9 +107,9 @@ ipv4-profiles:
         dhcp:
             mode: proxy
             servers:
-                - address: "172.20.20.11:67"
+                - address: "172.20.33.11:67"
                   priority: 100
-            giaddr: 172.20.20.2
+            giaddr: 172.20.33.2
             client-lease: 300
             option82:
                 circuit-id-format: "{interface}:{svlan}:{cvlan}"
@@ -252,9 +252,9 @@ plugins:
             - address: :8080
     subscriber.auth.radius:
         servers:
-            - host: 172.20.20.10
+            - host: 172.20.33.10
               secret: testing123
-        nas_ip: 172.20.20.2
+        nas_ip: 172.20.33.2
 
 monitoring:
   collect_interval: 30s

--- a/tests/07-dhcp-relay-proxy/config/freeradius/clients.conf
+++ b/tests/07-dhcp-relay-proxy/config/freeradius/clients.conf
@@ -1,5 +1,5 @@
 client osvbng {
-    ipaddr = 172.20.20.0/24
+    ipaddr = 172.20.33.0/24
     secret = testing123
     shortname = osvbng-smoketest
 }

--- a/tests/07-dhcp-relay-proxy/config/kea/kea-dhcp4.conf
+++ b/tests/07-dhcp-relay-proxy/config/kea/kea-dhcp4.conf
@@ -19,7 +19,7 @@
                     { "pool": "10.255.0.100 - 10.255.255.254" }
                 ],
                 "relay": {
-                    "ip-addresses": ["172.20.20.2"]
+                    "ip-addresses": ["172.20.33.2"]
                 },
                 "option-data": [
                     { "name": "routers", "data": "10.255.0.1" },

--- a/tests/07-dhcp-relay-proxy/config/subscribers/config.json
+++ b/tests/07-dhcp-relay-proxy/config/subscribers/config.json
@@ -6,14 +6,16 @@
         "type": "ipoe",
         "vlan-mode": "N:1",
         "outer-vlan-min": 300,
-        "outer-vlan-max": 300
+        "outer-vlan-max": 300,
+        "ipv6": false
       },
       {
         "interface": "eth1",
         "type": "ipoe",
         "vlan-mode": "N:1",
         "outer-vlan-min": 400,
-        "outer-vlan-max": 400
+        "outer-vlan-max": 400,
+        "ipv6": false
       }
     ]
   },

--- a/tests/14-ha-failover-ipoe/14-ha-failover-ipoe.clab.yml
+++ b/tests/14-ha-failover-ipoe/14-ha-failover-ipoe.clab.yml
@@ -49,7 +49,7 @@ topology:
       exec:
         - bash /entrypoint.sh
 
-    access-sw:
+    access-sw14:
       kind: bridge
 
     subscribers:
@@ -59,11 +59,11 @@ topology:
         - config/subscribers/subscribers.json:/config/subscribers.json:ro
 
   links:
-    - endpoints: [bng1:eth1, access-sw:bng1]
+    - endpoints: [bng1:eth1, access-sw14:bng1-14]
       mtu: 1500
-    - endpoints: [bng2:eth1, access-sw:bng2]
+    - endpoints: [bng2:eth1, access-sw14:bng2-14]
       mtu: 1500
-    - endpoints: [subscribers:eth1, access-sw:sub1]
+    - endpoints: [subscribers:eth1, access-sw14:sub1-14]
       mtu: 1500
     - endpoints: [bng1:eth2, corerouter1:eth1]
       mtu: 1500

--- a/tests/14-ha-failover-ipoe/14-ha-failover-ipoe.robot
+++ b/tests/14-ha-failover-ipoe/14-ha-failover-ipoe.robot
@@ -146,11 +146,11 @@ Destroy Failover Topology
     Destroy Access Bridge
 
 Create Access Bridge
-    ${rc} =    Run And Return Rc    sudo ip link add access-sw type bridge
-    ${rc} =    Run And Return Rc    sudo ip link set access-sw up
+    ${rc} =    Run And Return Rc    sudo ip link add access-sw14 type bridge
+    ${rc} =    Run And Return Rc    sudo ip link set access-sw14 up
 
 Destroy Access Bridge
-    Run And Return Rc    sudo ip link del access-sw
+    Run And Return Rc    sudo ip link del access-sw14
 
 Check HA Status
     [Arguments]    ${container}    ${expected_state}

--- a/tests/15-ha-failover-pppoe/15-ha-failover-pppoe.clab.yml
+++ b/tests/15-ha-failover-pppoe/15-ha-failover-pppoe.clab.yml
@@ -49,7 +49,7 @@ topology:
       exec:
         - bash /entrypoint.sh
 
-    access-sw:
+    access-sw15:
       kind: bridge
 
     subscribers:
@@ -59,11 +59,11 @@ topology:
         - config/subscribers/subscribers.json:/config/subscribers.json:ro
 
   links:
-    - endpoints: [bng1:eth1, access-sw:bng1]
+    - endpoints: [bng1:eth1, access-sw15:bng1-15]
       mtu: 1500
-    - endpoints: [bng2:eth1, access-sw:bng2]
+    - endpoints: [bng2:eth1, access-sw15:bng2-15]
       mtu: 1500
-    - endpoints: [subscribers:eth1, access-sw:sub1]
+    - endpoints: [subscribers:eth1, access-sw15:sub1-15]
       mtu: 1500
     - endpoints: [bng1:eth2, corerouter1:eth1]
       mtu: 1500

--- a/tests/15-ha-failover-pppoe/15-ha-failover-pppoe.robot
+++ b/tests/15-ha-failover-pppoe/15-ha-failover-pppoe.robot
@@ -147,11 +147,11 @@ Destroy Failover Topology
     Destroy Access Bridge
 
 Create Access Bridge
-    ${rc} =    Run And Return Rc    sudo ip link add access-sw type bridge
-    ${rc} =    Run And Return Rc    sudo ip link set access-sw up
+    ${rc} =    Run And Return Rc    sudo ip link add access-sw15 type bridge
+    ${rc} =    Run And Return Rc    sudo ip link set access-sw15 up
 
 Destroy Access Bridge
-    Run And Return Rc    sudo ip link del access-sw
+    Run And Return Rc    sudo ip link del access-sw15
 
 Check HA Status
     [Arguments]    ${container}    ${expected_state}

--- a/tests/16-ha-failover-radius-ipoe/16-ha-failover-radius-ipoe.clab.yml
+++ b/tests/16-ha-failover-radius-ipoe/16-ha-failover-radius-ipoe.clab.yml
@@ -58,7 +58,7 @@ topology:
       exec:
         - bash -c "freeradius -X &"
 
-    access-sw:
+    access-sw16:
       kind: bridge
 
     subscribers:
@@ -68,11 +68,11 @@ topology:
         - config/subscribers/subscribers.json:/config/subscribers.json:ro
 
   links:
-    - endpoints: [bng1:eth1, access-sw:bng1]
+    - endpoints: [bng1:eth1, access-sw16:bng1-16]
       mtu: 1500
-    - endpoints: [bng2:eth1, access-sw:bng2]
+    - endpoints: [bng2:eth1, access-sw16:bng2-16]
       mtu: 1500
-    - endpoints: [subscribers:eth1, access-sw:sub1]
+    - endpoints: [subscribers:eth1, access-sw16:sub1-16]
       mtu: 1500
     - endpoints: [bng1:eth2, corerouter1:eth1]
       mtu: 1500

--- a/tests/16-ha-failover-radius-ipoe/16-ha-failover-radius-ipoe.robot
+++ b/tests/16-ha-failover-radius-ipoe/16-ha-failover-radius-ipoe.robot
@@ -152,11 +152,11 @@ Destroy Failover Topology
     Destroy Access Bridge
 
 Create Access Bridge
-    ${rc} =    Run And Return Rc    sudo ip link add access-sw type bridge
-    ${rc} =    Run And Return Rc    sudo ip link set access-sw up
+    ${rc} =    Run And Return Rc    sudo ip link add access-sw16 type bridge
+    ${rc} =    Run And Return Rc    sudo ip link set access-sw16 up
 
 Destroy Access Bridge
-    Run And Return Rc    sudo ip link del access-sw
+    Run And Return Rc    sudo ip link del access-sw16
 
 Check HA Status
     [Arguments]    ${container}    ${expected_state}

--- a/tests/17-ha-tracker-promotion-ipoe/17-ha-tracker-promotion-ipoe.clab.yml
+++ b/tests/17-ha-tracker-promotion-ipoe/17-ha-tracker-promotion-ipoe.clab.yml
@@ -49,7 +49,7 @@ topology:
       exec:
         - bash /entrypoint.sh
 
-    access-sw:
+    access-sw17:
       kind: bridge
 
     subscribers:
@@ -59,11 +59,11 @@ topology:
         - config/subscribers/subscribers.json:/config/subscribers.json:ro
 
   links:
-    - endpoints: [bng1:eth1, access-sw:bng1]
+    - endpoints: [bng1:eth1, access-sw17:bng1-17]
       mtu: 1500
-    - endpoints: [bng2:eth1, access-sw:bng2]
+    - endpoints: [bng2:eth1, access-sw17:bng2-17]
       mtu: 1500
-    - endpoints: [subscribers:eth1, access-sw:sub1]
+    - endpoints: [subscribers:eth1, access-sw17:sub1-17]
       mtu: 1500
     - endpoints: [bng1:eth2, corerouter1:eth1]
       mtu: 1500

--- a/tests/17-ha-tracker-promotion-ipoe/17-ha-tracker-promotion-ipoe.robot
+++ b/tests/17-ha-tracker-promotion-ipoe/17-ha-tracker-promotion-ipoe.robot
@@ -154,11 +154,11 @@ Destroy Failover Topology
     Destroy Access Bridge
 
 Create Access Bridge
-    ${rc} =    Run And Return Rc    sudo ip link add access-sw type bridge
-    ${rc} =    Run And Return Rc    sudo ip link set access-sw up
+    ${rc} =    Run And Return Rc    sudo ip link add access-sw17 type bridge
+    ${rc} =    Run And Return Rc    sudo ip link set access-sw17 up
 
 Destroy Access Bridge
-    Run And Return Rc    sudo ip link del access-sw
+    Run And Return Rc    sudo ip link del access-sw17
 
 Check HA Status
     [Arguments]    ${container}    ${expected_state}

--- a/tests/23-radius-coa/23-radius-coa.clab.yml
+++ b/tests/23-radius-coa/23-radius-coa.clab.yml
@@ -5,7 +5,8 @@
 name: osvbng-radius-coa
 
 mgmt:
-  ipv4-subnet: 172.20.20.0/24
+  network: clab-23
+  ipv4-subnet: 172.20.34.0/24
 
 topology:
   nodes:
@@ -13,7 +14,7 @@ topology:
       kind: linux
       image: veesixnetworks/osvbng:local
       image-pull-policy: Never
-      mgmt-ipv4: 172.20.20.2
+      mgmt-ipv4: 172.20.34.2
       cap-add:
         - SYS_ADMIN
         - NET_ADMIN
@@ -47,7 +48,7 @@ topology:
     freeradius:
       kind: linux
       image: freeradius/freeradius-server:3.2.7
-      mgmt-ipv4: 172.20.20.10
+      mgmt-ipv4: 172.20.34.10
       binds:
         - config/freeradius/clients.conf:/etc/freeradius/clients.conf:ro
         - config/freeradius/authorize:/etc/freeradius/mods-config/files/authorize:ro

--- a/tests/23-radius-coa/23-radius-coa.robot
+++ b/tests/23-radius-coa/23-radius-coa.robot
@@ -28,7 +28,7 @@ ${bng1}             clab-${lab-name}-bng1
 ${subscribers}      clab-${lab-name}-subscribers
 ${freeradius}       clab-${lab-name}-freeradius
 ${session-count}    10
-${bng1-mgmt-ip}    172.20.20.2
+${bng1-mgmt-ip}    172.20.34.2
 ${coa-secret}       testing123
 
 *** Test Cases ***

--- a/tests/23-radius-coa/config/bng1/osvbng.yaml
+++ b/tests/23-radius-coa/config/bng1/osvbng.yaml
@@ -209,11 +209,11 @@ plugins:
             - address: :8080
     subscriber.auth.radius:
         servers:
-            - host: 172.20.20.10
+            - host: 172.20.34.10
               secret: testing123
-        nas_ip: 172.20.20.2
+        nas_ip: 172.20.34.2
         coa_clients:
-            - host: 172.20.20.0/24
+            - host: 172.20.34.0/24
               secret: testing123
             - host: 10.0.0.0/24
               secret: testing123

--- a/tests/23-radius-coa/config/freeradius/clients.conf
+++ b/tests/23-radius-coa/config/freeradius/clients.conf
@@ -1,5 +1,5 @@
 client osvbng {
-    ipaddr = 172.20.20.0/24
+    ipaddr = 172.20.34.0/24
     secret = testing123
     shortname = osvbng-smoketest
 }

--- a/tests/29-radius-vrf/29-radius-vrf.clab.yml
+++ b/tests/29-radius-vrf/29-radius-vrf.clab.yml
@@ -5,7 +5,8 @@
 name: osvbng-radius-vrf
 
 mgmt:
-  ipv4-subnet: 172.20.20.0/24
+  network: clab-29
+  ipv4-subnet: 172.20.35.0/24
 
 topology:
   nodes:
@@ -13,7 +14,7 @@ topology:
       kind: linux
       image: veesixnetworks/osvbng:local
       image-pull-policy: Never
-      mgmt-ipv4: 172.20.20.2
+      mgmt-ipv4: 172.20.35.2
       cap-add:
         - SYS_ADMIN
         - NET_ADMIN
@@ -47,7 +48,7 @@ topology:
     freeradius:
       kind: linux
       image: freeradius/freeradius-server:3.2.7
-      mgmt-ipv4: 172.20.20.10
+      mgmt-ipv4: 172.20.35.10
       binds:
         - config/freeradius/clients.conf:/etc/freeradius/clients.conf:ro
         - config/freeradius/authorize:/etc/freeradius/mods-config/files/authorize:ro

--- a/tests/36-aaa-empty-username/36-aaa-empty-username.clab.yml
+++ b/tests/36-aaa-empty-username/36-aaa-empty-username.clab.yml
@@ -5,7 +5,8 @@
 name: osvbng-aaa-empty-username
 
 mgmt:
-  ipv4-subnet: 172.20.20.0/24
+  network: clab-36
+  ipv4-subnet: 172.20.36.0/24
 
 topology:
   nodes:
@@ -13,7 +14,7 @@ topology:
       kind: linux
       image: veesixnetworks/osvbng:local
       image-pull-policy: Never
-      mgmt-ipv4: 172.20.20.2
+      mgmt-ipv4: 172.20.36.2
       cap-add:
         - SYS_ADMIN
         - NET_ADMIN
@@ -47,7 +48,7 @@ topology:
     freeradius:
       kind: linux
       image: freeradius/freeradius-server:3.2.7
-      mgmt-ipv4: 172.20.20.10
+      mgmt-ipv4: 172.20.36.10
       binds:
         - config/freeradius/clients.conf:/etc/freeradius/clients.conf:ro
         - config/freeradius/authorize:/etc/freeradius/mods-config/files/authorize:ro

--- a/tests/36-aaa-empty-username/config/bng1/osvbng.yaml
+++ b/tests/36-aaa-empty-username/config/bng1/osvbng.yaml
@@ -210,9 +210,9 @@ plugins:
             - address: :8080
     subscriber.auth.radius:
         servers:
-            - host: 172.20.20.10
+            - host: 172.20.36.10
               secret: testing123
-        nas_ip: 172.20.20.2
+        nas_ip: 172.20.36.2
 
 monitoring:
   collect_interval: 30s

--- a/tests/36-aaa-empty-username/config/freeradius/clients.conf
+++ b/tests/36-aaa-empty-username/config/freeradius/clients.conf
@@ -1,5 +1,5 @@
 client osvbng {
-    ipaddr = 172.20.20.0/24
+    ipaddr = 172.20.36.0/24
     secret = testing123
     shortname = osvbng-smoketest
 }

--- a/tests/37-ha-graceful-switchover-ipoe/37-ha-graceful-switchover-ipoe.clab.yml
+++ b/tests/37-ha-graceful-switchover-ipoe/37-ha-graceful-switchover-ipoe.clab.yml
@@ -59,11 +59,11 @@ topology:
         - config/subscribers/subscribers.json:/config/subscribers.json:ro
 
   links:
-    - endpoints: [bng1:eth1, access-sw-gr:bng1]
+    - endpoints: [bng1:eth1, access-sw-gr:bng1-37]
       mtu: 1500
-    - endpoints: [bng2:eth1, access-sw-gr:bng2]
+    - endpoints: [bng2:eth1, access-sw-gr:bng2-37]
       mtu: 1500
-    - endpoints: [subscribers:eth1, access-sw-gr:sub1]
+    - endpoints: [subscribers:eth1, access-sw-gr:sub1-37]
       mtu: 1500
     - endpoints: [bng1:eth2, corerouter1:eth1]
       mtu: 1500

--- a/tests/38-l2gw-static/38-l2gw-static.clab.yml
+++ b/tests/38-l2gw-static/38-l2gw-static.clab.yml
@@ -5,7 +5,8 @@
 name: osvbng-l2gw-static
 
 mgmt:
-  ipv4-subnet: 172.20.20.0/24
+  network: clab-38
+  ipv4-subnet: 172.20.37.0/24
 
 topology:
   nodes:
@@ -13,7 +14,7 @@ topology:
       kind: linux
       image: veesixnetworks/osvbng:local
       image-pull-policy: Never
-      mgmt-ipv4: 172.20.20.2
+      mgmt-ipv4: 172.20.37.2
       cap-add:
         - SYS_ADMIN
         - NET_ADMIN

--- a/tests/39-l2gw-dynamic/39-l2gw-dynamic.clab.yml
+++ b/tests/39-l2gw-dynamic/39-l2gw-dynamic.clab.yml
@@ -5,7 +5,8 @@
 name: osvbng-l2gw-dynamic
 
 mgmt:
-  ipv4-subnet: 172.20.20.0/24
+  network: clab-39
+  ipv4-subnet: 172.20.38.0/24
 
 topology:
   nodes:
@@ -13,7 +14,7 @@ topology:
       kind: linux
       image: veesixnetworks/osvbng:local
       image-pull-policy: Never
-      mgmt-ipv4: 172.20.20.2
+      mgmt-ipv4: 172.20.38.2
       cap-add:
         - SYS_ADMIN
         - NET_ADMIN
@@ -35,7 +36,7 @@ topology:
     freeradius:
       kind: linux
       image: freeradius/freeradius-server:3.2.7
-      mgmt-ipv4: 172.20.20.10
+      mgmt-ipv4: 172.20.38.10
       binds:
         - config/freeradius/clients.conf:/etc/freeradius/clients.conf:ro
         - config/freeradius/authorize:/etc/freeradius/mods-config/files/authorize:ro

--- a/tests/39-l2gw-dynamic/39-l2gw-dynamic.robot
+++ b/tests/39-l2gw-dynamic/39-l2gw-dynamic.robot
@@ -33,13 +33,13 @@ Suite Teardown      Teardown L2GW Dynamic Test
 ${lab-name}             osvbng-l2gw-dynamic
 ${lab-file}             ${CURDIR}/39-l2gw-dynamic.clab.yml
 ${bng1}                 clab-${lab-name}-bng1
-${bng1-mgmt-ip}         172.20.20.2
+${bng1-mgmt-ip}         172.20.38.2
 ${subscribers}          clab-${lab-name}-subscribers
 ${freeradius}           clab-${lab-name}-freeradius
 ${session-count}        2
 ${coa-secret}           testing123
 ${acct-interim-wait}    90s
-${detail-file-glob}     /var/log/freeradius/radacct/172.20.20.2/detail-*
+${detail-file-glob}     /var/log/freeradius/radacct/172.20.38.2/detail-*
 
 *** Test Cases ***
 Verify BNG Is Healthy
@@ -137,12 +137,12 @@ Verify Prometheus L2GW Circuit Metrics
     [Documentation]    Per-circuit counters must be exported through the
     ...    telemetry SDK with the access/handoff identity labels.
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    curl -sf http://172.20.20.2:9090/metrics | grep "^osvbng_dataplane_vpp_l2gw_upstream_packets"
+    ...    curl -sf http://172.20.38.2:9090/metrics | grep "^osvbng_dataplane_vpp_l2gw_upstream_packets"
     Should Be Equal As Integers    ${rc}    0    no l2gw upstream metrics exported
     Log    ${output}
     Should Contain    ${output}    handoff_group="isp-blue"
     ${rc}    ${nonzero} =    Run And Return Rc And Output
-    ...    curl -sf http://172.20.20.2:9090/metrics | awk '/^osvbng_dataplane_vpp_l2gw_upstream_packets/ {if ($NF+0 > 0) n++} END {print n+0}'
+    ...    curl -sf http://172.20.38.2:9090/metrics | awk '/^osvbng_dataplane_vpp_l2gw_upstream_packets/ {if ($NF+0 > 0) n++} END {print n+0}'
     Should Be Equal As Integers    ${rc}    0
     Should Be True    ${nonzero} >= ${session-count}    l2gw upstream packet metrics all zero
 

--- a/tests/39-l2gw-dynamic/config/bng1/osvbng.yaml
+++ b/tests/39-l2gw-dynamic/config/bng1/osvbng.yaml
@@ -52,11 +52,11 @@ plugins:
     # PEN 32473); no response/accounting mappings needed.
     subscriber.auth.radius:
         servers:
-            - host: 172.20.20.10
+            - host: 172.20.38.10
               secret: testing123
-        nas_ip: 172.20.20.2
+        nas_ip: 172.20.38.2
         coa_clients:
-            - host: 172.20.20.0/24
+            - host: 172.20.38.0/24
               secret: testing123
 
 monitoring:

--- a/tests/39-l2gw-dynamic/config/freeradius/clients.conf
+++ b/tests/39-l2gw-dynamic/config/freeradius/clients.conf
@@ -1,5 +1,5 @@
 client osvbng {
-    ipaddr = 172.20.20.0/24
+    ipaddr = 172.20.38.0/24
     secret = testing123
     shortname = osvbng-l2gw
 }

--- a/tests/40-l2gw-packet-trigger/40-l2gw-packet-trigger.clab.yml
+++ b/tests/40-l2gw-packet-trigger/40-l2gw-packet-trigger.clab.yml
@@ -5,7 +5,8 @@
 name: osvbng-l2gw-packet-trigger
 
 mgmt:
-  ipv4-subnet: 172.20.20.0/24
+  network: clab-40pt
+  ipv4-subnet: 172.20.39.0/24
 
 topology:
   nodes:
@@ -13,7 +14,7 @@ topology:
       kind: linux
       image: veesixnetworks/osvbng:local
       image-pull-policy: Never
-      mgmt-ipv4: 172.20.20.2
+      mgmt-ipv4: 172.20.39.2
       cap-add:
         - SYS_ADMIN
         - NET_ADMIN

--- a/tests/40-l2gw-vxlan/40-l2gw-vxlan.clab.yml
+++ b/tests/40-l2gw-vxlan/40-l2gw-vxlan.clab.yml
@@ -10,7 +10,8 @@
 name: osvbng-l2gw-vxlan
 
 mgmt:
-  ipv4-subnet: 172.20.21.0/24
+  network: clab-40vx
+  ipv4-subnet: 172.20.41.0/24
 
 topology:
   nodes:
@@ -18,7 +19,7 @@ topology:
       kind: linux
       image: veesixnetworks/osvbng:local
       image-pull-policy: Never
-      mgmt-ipv4: 172.20.21.2
+      mgmt-ipv4: 172.20.41.2
       cap-add:
         - SYS_ADMIN
         - NET_ADMIN
@@ -63,7 +64,7 @@ topology:
     freeradius:
       kind: linux
       image: freeradius/freeradius-server:3.2.7
-      mgmt-ipv4: 172.20.21.10
+      mgmt-ipv4: 172.20.41.10
       binds:
         - config/freeradius/clients.conf:/etc/freeradius/clients.conf:ro
         - config/freeradius/authorize:/etc/freeradius/mods-config/files/authorize:ro

--- a/tests/40-l2gw-vxlan/40-l2gw-vxlan.robot
+++ b/tests/40-l2gw-vxlan/40-l2gw-vxlan.robot
@@ -32,7 +32,7 @@ Suite Teardown      Teardown L2GW VXLAN Test
 ${lab-name}         osvbng-l2gw-vxlan
 ${lab-file}         ${CURDIR}/40-l2gw-vxlan.clab.yml
 ${bng1}             clab-${lab-name}-bng1
-${bng1-mgmt-ip}     172.20.21.2
+${bng1-mgmt-ip}     172.20.41.2
 ${subscribers}      clab-${lab-name}-subscribers
 ${session-count}    2
 

--- a/tests/40-l2gw-vxlan/config/bng1/osvbng.yaml
+++ b/tests/40-l2gw-vxlan/config/bng1/osvbng.yaml
@@ -70,11 +70,11 @@ plugins:
             - address: :8080
     subscriber.auth.radius:
         servers:
-            - host: 172.20.21.10
+            - host: 172.20.41.10
               secret: testing123
-        nas_ip: 172.20.21.2
+        nas_ip: 172.20.41.2
         coa_clients:
-            - host: 172.20.21.0/24
+            - host: 172.20.41.0/24
               secret: testing123
 
 monitoring:

--- a/tests/40-l2gw-vxlan/config/freeradius/clients.conf
+++ b/tests/40-l2gw-vxlan/config/freeradius/clients.conf
@@ -1,5 +1,5 @@
 client osvbng {
-    ipaddr = 172.20.21.0/24
+    ipaddr = 172.20.41.0/24
     secret = testing123
     shortname = osvbng-l2gw
 }

--- a/tests/42-ipoe-vxlan-pwhe/42-ipoe-vxlan-pwhe.clab.yml
+++ b/tests/42-ipoe-vxlan-pwhe/42-ipoe-vxlan-pwhe.clab.yml
@@ -11,6 +11,7 @@
 name: osvbng-ipoe-vxlan-pwhe
 
 mgmt:
+  network: clab-42
   ipv4-subnet: 172.20.22.0/24
 
 topology:

--- a/tests/43-pppoe-vxlan-pwhe/43-pppoe-vxlan-pwhe.clab.yml
+++ b/tests/43-pppoe-vxlan-pwhe/43-pppoe-vxlan-pwhe.clab.yml
@@ -11,6 +11,7 @@
 name: osvbng-pppoe-vxlan-pwhe
 
 mgmt:
+  network: clab-43
   ipv4-subnet: 172.20.23.0/24
 
 topology:

--- a/tests/44-lac-vxlan-pwhe/44-lac-vxlan-pwhe.clab.yml
+++ b/tests/44-lac-vxlan-pwhe/44-lac-vxlan-pwhe.clab.yml
@@ -11,6 +11,7 @@
 name: osvbng-lac-vxlan-pwhe
 
 mgmt:
+  network: clab-44
   ipv4-subnet: 172.20.24.0/24
 
 topology:

--- a/tests/45-ha-pwhe-ipoe/45-ha-pwhe-ipoe.clab.yml
+++ b/tests/45-ha-pwhe-ipoe/45-ha-pwhe-ipoe.clab.yml
@@ -14,6 +14,7 @@
 name: osvbng-ha-pwhe-ipoe
 
 mgmt:
+  network: clab-45
   ipv4-subnet: 172.20.25.0/24
 
 topology:
@@ -77,9 +78,9 @@ topology:
         - ip link set br-acc up
 
   links:
-    - endpoints: [bng1:eth1, access-sw-pwhe:bng1]
+    - endpoints: [bng1:eth1, access-sw-pwhe:bng1-45]
       mtu: 9000
-    - endpoints: [bng2:eth1, access-sw-pwhe:bng2]
+    - endpoints: [bng2:eth1, access-sw-pwhe:bng2-45]
       mtu: 9000
-    - endpoints: [subscribers:eth1, access-sw-pwhe:sub1]
+    - endpoints: [subscribers:eth1, access-sw-pwhe:sub1-45]
       mtu: 9000

--- a/tests/46-l2gw-evpn/46-l2gw-evpn.clab.yml
+++ b/tests/46-l2gw-evpn/46-l2gw-evpn.clab.yml
@@ -13,6 +13,7 @@
 name: osvbng-l2gw-evpn
 
 mgmt:
+  network: clab-46
   ipv4-subnet: 172.20.26.0/24
 
 topology:

--- a/tests/47-ipoe-evpn-pwhe/47-ipoe-evpn-pwhe.clab.yml
+++ b/tests/47-ipoe-evpn-pwhe/47-ipoe-evpn-pwhe.clab.yml
@@ -12,6 +12,7 @@
 name: osvbng-ipoe-evpn-pwhe
 
 mgmt:
+  network: clab-47
   ipv4-subnet: 172.20.27.0/24
 
 topology:

--- a/tests/48-pppoe-evpn-pwhe/48-pppoe-evpn-pwhe.clab.yml
+++ b/tests/48-pppoe-evpn-pwhe/48-pppoe-evpn-pwhe.clab.yml
@@ -12,6 +12,7 @@
 name: osvbng-pppoe-evpn-pwhe
 
 mgmt:
+  network: clab-48
   ipv4-subnet: 172.20.28.0/24
 
 topology:

--- a/tests/49-lac-evpn-pwhe/49-lac-evpn-pwhe.clab.yml
+++ b/tests/49-lac-evpn-pwhe/49-lac-evpn-pwhe.clab.yml
@@ -12,6 +12,7 @@
 name: osvbng-lac-evpn-pwhe
 
 mgmt:
+  network: clab-49
   ipv4-subnet: 172.20.29.0/24
 
 topology:

--- a/tests/50-ha-evpn-pwhe/50-ha-evpn-pwhe.clab.yml
+++ b/tests/50-ha-evpn-pwhe/50-ha-evpn-pwhe.clab.yml
@@ -14,6 +14,7 @@
 name: osvbng-ha-evpn-pwhe
 
 mgmt:
+  network: clab-50
   ipv4-subnet: 172.20.31.0/24
 
 topology:

--- a/tests/ci-suites.txt
+++ b/tests/ci-suites.txt
@@ -1,6 +1,19 @@
-# Staging allowlist: while this file exists, CI runs exactly these
-# suites. Grow it as suites prove green on the runner; delete the
-# file to return to the full generated matrix minus skip-suites.txt.
+# Staging allowlist: while this file exists, the per-PR tier runs
+# exactly these suites. Grow it as suites prove green on the runner;
+# delete the file to return to the full generated matrix minus
+# skip-suites.txt.
 01-smoke
+02-smoke-ha
 03-ipoe-local
 04-pppoe-local
+05-ipoe-radius
+06-pppoe-radius
+07-dhcp-relay-proxy
+08-cgnat-ipoe-pba
+10-cgnat-pppoe-pba
+12-cgnat-ha-ipoe-pba
+13-cgnat-ha-pppoe-pba
+14-ha-failover-ipoe
+15-ha-failover-pppoe
+16-ha-failover-radius-ipoe
+17-ha-tracker-promotion-ipoe

--- a/tests/common.robot
+++ b/tests/common.robot
@@ -33,7 +33,7 @@ Deploy Topology
     # CI's runner instances share one uid so they still serialize,
     # and a developer's local runs are single anyway.
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    flock /tmp/osvbng-clab-deploy.$(id -u).lock ${CLAB_BIN} deploy -t ${topology_file} --reconfigure
+    ...    flock -w 300 /tmp/osvbng-clab-deploy.$(id -u).lock ${CLAB_BIN} deploy -t ${topology_file} --reconfigure
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     RETURN    ${output}


### PR DESCRIPTION
Three chronic CI failure classes traced to suites sharing host resources that sequential local runs never contend for. Eight suites declare static management IPs on one shared 172.20.20.0/24 network and two more collide on .21, so any two in the same parallel window deadlock the second deploy, and a static suite also wedges when any other lab's dynamic allocation has taken its address. The four ha-failover suites create and delete one shared access-sw bridge, so parallel runs merge their access layer-2 domains and a finishing suite deletes the bridge under its neighbor; the bridge-side veth names (bng1, bng2, sub1) are host-global too, observed live when suite 15's deploy blocked suite 14's with interface-already-exists. Separately, 07's blaster config demands dual-stack establishment from service groups that are IPv4-only by design, so sessions bind DHCPv4 and sit in DHCPv6-pending forever.

Every static-IP suite gets its own named management network and unique subnet, with all config references moved (counted replacements, zero stale). The ha-failover suites (and 37 and 45, same pattern) get per-suite bridge names and per-suite veth names. 07's blaster access interfaces set ipv6 false. The suite job timeout drops to 12 minutes and the deploy lock waits at most 300 seconds so a held lock fails loudly. ci-suites.txt grows to the fifteen suites that are now individually validated or were already green on the runner. A scan found ten more suites with 07's latent dual-stack pattern; they are left untouched deliberately, to be fixed one by one when a run proves each bites, since local-server DHCP mode may behave differently from 07's relay mode and 35 tests v4-only gating on purpose.

Verified locally against the live rig: 07 passes 11 of 11 solo (previously 9 of 11 with blaster at 0 of 2 sessions, root-caused via bngblaster session-info showing DHCPv6 pending on a v4-only group); suites 14 and 15 pass in parallel, the exact pairing that deadlocked every CI sweep; 05 and 07 pass in parallel, the pairing that reproduced the subnet deadlock. Not verified: 16, 17, 37, 45 received the same mechanical fixes but were not individually re-run locally; the staged CI batch after merge exercises them, and all topologies parse.