### PR TITLE
fix(ipoe): send unsolicited na for restored sessions

### DIFF
--- a/internal/ipoe/nd_ra.go
+++ b/internal/ipoe/nd_ra.go
@@ -487,6 +487,53 @@ func (c *Component) sendNAResponse(pkt *dataplane.ParsedPacket, parentSwIfIndex 
 		naFlags |= 0x40
 	}
 
+	return c.emitNA(pkt.MAC.String(), dstIP, pkt.OuterVLAN, pkt.InnerVLAN,
+		pkt.SwIfIndex, parentSwIfIndex, localMAC, srcIP, naFlags, solicited)
+}
+
+// sendRestoreNA multicasts one unsolicited Neighbor Advertisement for
+// the session's gateway link-local after a restore. RFC 4861 7.2.6:
+// Solicited MUST be zero, a router MUST set the Router flag, Override
+// installs our link-layer address, destination is all-nodes. A
+// subscriber whose NUD probe went unanswered during the outage holds a
+// FAILED neighbour entry whose backoff outlives most retry windows;
+// the advertisement moves it to STALE so the next packet re-resolves
+// against the now-answering daemon.
+func (c *Component) sendRestoreNA(sess *SessionState) {
+	if sess.OuterVLAN == 0 {
+		return
+	}
+	match, ok := c.cfgMgr.LookupSubscriberGroup(sess.OuterVLAN, sess.InnerVLAN)
+	if !ok || !groupV6Enabled(match.Group) {
+		return
+	}
+	srgName := c.resolveSRGName(sess.OuterVLAN, sess.InnerVLAN)
+	if c.srgMgr != nil && !c.srgMgr.IsActive(srgName) {
+		return
+	}
+	var parentSwIfIndex uint32
+	if c.ifMgr != nil {
+		if iface := c.ifMgr.Get(sess.EncapIfIndex); iface != nil {
+			parentSwIfIndex = iface.SupSwIfIndex
+		}
+	}
+	localMAC := c.getLocalMAC(srgName, sess.EncapIfIndex)
+	if localMAC == nil {
+		return
+	}
+	srcIP := ra.LinkLocalFromMAC(localMAC)
+	if srcIP == nil {
+		return
+	}
+	if err := c.emitNA("33:33:00:00:00:01", net.ParseIP("ff02::1"),
+		sess.OuterVLAN, sess.InnerVLAN, sess.EncapIfIndex, parentSwIfIndex,
+		localMAC, srcIP, 0x80|0x20, false); err != nil {
+		c.logger.Warn("Failed to send restore NA",
+			"session_id", sess.SessionID, "error", err)
+	}
+}
+
+func (c *Component) emitNA(dstMAC string, dstIP net.IP, outerVLAN, innerVLAN uint16, tpidIfIndex, egressIfIndex uint32, localMAC net.HardwareAddr, srcIP net.IP, naFlags uint8, solicited bool) error {
 	naOptions := layers.ICMPv6Options{
 		{
 			Type: layers.ICMPv6OptTargetAddress,
@@ -523,20 +570,20 @@ func (c *Component) sendNAResponse(pkt *dataplane.ParsedPacket, parentSwIfIndex 
 	}
 
 	egressPayload := &models.EgressPacketPayload{
-		DstMAC:    pkt.MAC.String(),
+		DstMAC:    dstMAC,
 		SrcMAC:    localMAC.String(),
-		OuterVLAN: pkt.OuterVLAN,
-		InnerVLAN: pkt.InnerVLAN,
-		OuterTPID: c.ifMgr.OuterTPID(pkt.SwIfIndex),
-		SwIfIndex: parentSwIfIndex,
+		OuterVLAN: outerVLAN,
+		InnerVLAN: innerVLAN,
+		OuterTPID: c.ifMgr.OuterTPID(tpidIfIndex),
+		SwIfIndex: egressIfIndex,
 		RawData:   buf.Bytes(),
 	}
 
-	c.logger.Debug("Sending NA response",
-		"dst_mac", pkt.MAC.String(),
+	c.logger.Debug("Sending NA",
+		"dst_mac", dstMAC,
 		"src_mac", localMAC.String(),
-		"svlan", pkt.OuterVLAN,
-		"cvlan", pkt.InnerVLAN,
+		"svlan", outerVLAN,
+		"cvlan", innerVLAN,
 		"solicited", solicited,
 	)
 

--- a/internal/ipoe/restore.go
+++ b/internal/ipoe/restore.go
@@ -109,6 +109,8 @@ func (c *Component) restoreSessions(ctx context.Context) error {
 			return nil
 		}
 
+		c.sendRestoreNA(&sess)
+
 		if sess.State == "bound" && sess.MAC != nil {
 			counterKey := fmt.Sprintf("osvbng:session_count:%s:%d:%d",
 				sess.MAC.String(), sess.OuterVLAN, sess.InnerVLAN)

--- a/test-results/qa/20260817-023838/summary.txt
+++ b/test-results/qa/20260817-023838/summary.txt
@@ -1,0 +1,13 @@
+QA Test Run: 20260817-023838
+Runs per test: 1
+Tests: 32-ipoe-opdb-restore
+Results: /tmp/claude-1000/-home-brandon-osvbng-dev-osvbng-context/68545c9c-186f-4326-856f-554b5025900b/scratchpad/osvbng-nafix/test-results/qa/20260817-023838
+========================================
+
+--- 32-ipoe-opdb-restore ---
+FAIL (3 tests, 1 passed, 1 failed, 1 skipped)
+  Result: 0/1 passed
+
+========================================
+TOTAL: 0 passed, 1 failed out of 1
+Done: Mon Aug 17 02:41:06 UTC 2026

--- a/test-results/qa/20260817-024106/summary.txt
+++ b/test-results/qa/20260817-024106/summary.txt
@@ -1,0 +1,13 @@
+QA Test Run: 20260817-024106
+Runs per test: 1
+Tests: 32-ipoe-opdb-restore
+Results: /tmp/claude-1000/-home-brandon-osvbng-dev-osvbng-context/68545c9c-186f-4326-856f-554b5025900b/scratchpad/osvbng-nafix/test-results/qa/20260817-024106
+========================================
+
+--- 32-ipoe-opdb-restore ---
+FAIL (3 tests, 1 passed, 1 failed, 1 skipped)
+  Result: 0/1 passed
+
+========================================
+TOTAL: 0 passed, 1 failed out of 1
+Done: Mon Aug 17 02:43:18 UTC 2026

--- a/test-results/qa/20260817-024318/summary.txt
+++ b/test-results/qa/20260817-024318/summary.txt
@@ -1,0 +1,13 @@
+QA Test Run: 20260817-024318
+Runs per test: 1
+Tests: 32-ipoe-opdb-restore
+Results: /tmp/claude-1000/-home-brandon-osvbng-dev-osvbng-context/68545c9c-186f-4326-856f-554b5025900b/scratchpad/osvbng-nafix/test-results/qa/20260817-024318
+========================================
+
+--- 32-ipoe-opdb-restore ---
+PASS (3 tests, 2 passed, 0 failed, 1 skipped)
+  Result: 1/1 passed
+
+========================================
+TOTAL: 1 passed, 0 failed out of 1
+Done: Mon Aug 17 02:44:52 UTC 2026

--- a/test-results/qa/20260817-024452/summary.txt
+++ b/test-results/qa/20260817-024452/summary.txt
@@ -1,0 +1,13 @@
+QA Test Run: 20260817-024452
+Runs per test: 1
+Tests: 32-ipoe-opdb-restore
+Results: /tmp/claude-1000/-home-brandon-osvbng-dev-osvbng-context/68545c9c-186f-4326-856f-554b5025900b/scratchpad/osvbng-nafix/test-results/qa/20260817-024452
+========================================
+
+--- 32-ipoe-opdb-restore ---
+FAIL (3 tests, 1 passed, 1 failed, 1 skipped)
+  Result: 0/1 passed
+
+========================================
+TOTAL: 0 passed, 1 failed out of 1
+Done: Mon Aug 17 02:47:14 UTC 2026

--- a/test-results/qa/20260817-025938/summary.txt
+++ b/test-results/qa/20260817-025938/summary.txt
@@ -1,0 +1,13 @@
+QA Test Run: 20260817-025938
+Runs per test: 1
+Tests: 32-ipoe-opdb-restore
+Results: /tmp/claude-1000/-home-brandon-osvbng-dev-osvbng-context/68545c9c-186f-4326-856f-554b5025900b/scratchpad/osvbng-nafix/test-results/qa/20260817-025938
+========================================
+
+--- 32-ipoe-opdb-restore ---
+FAIL (3 tests, 1 passed, 1 failed, 1 skipped)
+  Result: 0/1 passed
+
+========================================
+TOTAL: 0 passed, 1 failed out of 1
+Done: Mon Aug 17 03:01:15 UTC 2026

--- a/test-results/qa/20260817-030115/summary.txt
+++ b/test-results/qa/20260817-030115/summary.txt
@@ -1,0 +1,13 @@
+QA Test Run: 20260817-030115
+Runs per test: 1
+Tests: 32-ipoe-opdb-restore
+Results: /tmp/claude-1000/-home-brandon-osvbng-dev-osvbng-context/68545c9c-186f-4326-856f-554b5025900b/scratchpad/osvbng-nafix/test-results/qa/20260817-030115
+========================================
+
+--- 32-ipoe-opdb-restore ---
+FAIL (3 tests, 1 passed, 1 failed, 1 skipped)
+  Result: 0/1 passed
+
+========================================
+TOTAL: 0 passed, 1 failed out of 1
+Done: Mon Aug 17 03:03:15 UTC 2026

--- a/test-results/qa/20260817-030315/summary.txt
+++ b/test-results/qa/20260817-030315/summary.txt
@@ -1,0 +1,13 @@
+QA Test Run: 20260817-030315
+Runs per test: 1
+Tests: 32-ipoe-opdb-restore
+Results: /tmp/claude-1000/-home-brandon-osvbng-dev-osvbng-context/68545c9c-186f-4326-856f-554b5025900b/scratchpad/osvbng-nafix/test-results/qa/20260817-030315
+========================================
+
+--- 32-ipoe-opdb-restore ---
+FAIL (3 tests, 1 passed, 1 failed, 1 skipped)
+  Result: 0/1 passed
+
+========================================
+TOTAL: 0 passed, 1 failed out of 1
+Done: Mon Aug 17 03:05:18 UTC 2026

--- a/test-results/qa/20260817-030518/summary.txt
+++ b/test-results/qa/20260817-030518/summary.txt
@@ -1,0 +1,13 @@
+QA Test Run: 20260817-030518
+Runs per test: 1
+Tests: 32-ipoe-opdb-restore
+Results: /tmp/claude-1000/-home-brandon-osvbng-dev-osvbng-context/68545c9c-186f-4326-856f-554b5025900b/scratchpad/osvbng-nafix/test-results/qa/20260817-030518
+========================================
+
+--- 32-ipoe-opdb-restore ---
+FAIL (3 tests, 1 passed, 1 failed, 1 skipped)
+  Result: 0/1 passed
+
+========================================
+TOTAL: 0 passed, 1 failed out of 1
+Done: Mon Aug 17 03:07:14 UTC 2026


### PR DESCRIPTION
Suite 32's 2b case documents the gap: after a restart, subscriber NUD probes that went unanswered during the outage leave FAILED neighbour entries whose backoff outlives the test's retry window, and the suite calls for the BNG to send Unsolicited Neighbor Advertisements on recovery per RFC 4861 section 7.2.6. This adds that: after each successful session restore, one unsolicited NA is multicast for the gateway link-local (Solicited zero, Router and Override set, all-nodes destination, target link-layer option carrying our MAC), reusing the existing NA builder via an extracted emitNA. Skipped for v4-only groups and standby SRGs.

Verified: builds, unit tests pass, and four full suite-32 runs exercised the path without harm. Reported honestly: this change did NOT fix suite 32's failures. The investigation that followed found the failing assertion is the through-path to the core, not gateway ND, and traced it to a deeper IPoE v6 dataplane issue: ipoe-input passes subscriber IPv6 through without session classification, and the ND punt shows not-enabled for the subscriber sub-interface, so the daemon's ND handlers are bypassed entirely in that state. Full evidence chain in the companion context-repo note; the enablement-granularity decision needs a maintainer. This PR stands on the RFC-documented recovery gap it does close, not on curing suite 32.