### PR TITLE
test: skip the ipoe v6 gap suites with the evidence note as reason

### DIFF
--- a/tests/skip-suites.txt
+++ b/tests/skip-suites.txt
@@ -5,3 +5,9 @@
 18-ipoe-linux-client
 19-ipoe-linux-client-cake
 25-l3vpn
+# IPoE IPv6 classification and ND punt gap, see the context repo
+# note design/ipoe-v6-dataplane-gap.md; unskip when the product fix
+# lands.
+32-ipoe-opdb-restore
+42-ipoe-vxlan-pwhe
+47-ipoe-evpn-pwhe


### PR DESCRIPTION
Suites 32, 42 and 47 fail on an open product issue, subscriber-initiated IPv6 dying on ipoe-input classification and ND punt enablement, with the full evidence chain in the context repo's design/ipoe-v6-dataplane-gap.md. Skipping them keeps the sweep green-by-construction so a red nightly stays a signal, while the skip file entry carries the reason and the unskip condition, per the skip list's contract.

Verified: 30 of the 33 remaining suites pass locally tonight, these three fail consistently on the documented issue, and suite 52 passed on rerun and stays in the matrix flagged mentally as a flake watch. Not verified: nothing beyond the list change.