### PR TITLE
test: v4-only mgmt network everywhere, by declaration

### DIFF
--- a/.github/workflows/suite-run.yml
+++ b/.github/workflows/suite-run.yml
@@ -61,9 +61,21 @@ jobs:
           fi
           stray=$(sudo docker ps -aq --filter name=clab-)
           [ -n "$stray" ] && echo "$stray" | xargs -r sudo docker rm -f || true
+          # The mgmt network must exist AND be IPv4-only, enforced by
+          # shape, not just presence: a dual-stack mgmt network hands
+          # every node an eth0 v6 default route that races the test
+          # RA route on the access interface, and which route wins
+          # flips with RA lifetime timing. That race was the root
+          # cause of the ipoe v6 suite flakes. Nothing in the rig
+          # needs mgmt IPv6.
+          if timeout 20 sudo docker network inspect clab >/dev/null 2>&1; then
+            if [ "$(sudo docker network inspect clab -f '{{.EnableIPv6}}')" != "false" ]; then
+              echo "mgmt network is dual-stack, recreating v4-only"
+              sudo docker network rm clab
+            fi
+          fi
           timeout 20 sudo docker network inspect clab >/dev/null 2>&1 || \
-            timeout 30 sudo docker network create \
-              --subnet 172.20.20.0/24 --ipv6 --subnet 3fff:172:20:20::/64 clab
+            timeout 30 sudo docker network create --subnet 172.20.20.0/24 clab
           rm -f "/tmp/osvbng-clab-deploy.$(id -u).lock"
 
       # The runner keeps a per-commit cache of the four debs the

--- a/test-results/qa/20260817-083555/summary.txt
+++ b/test-results/qa/20260817-083555/summary.txt
@@ -1,0 +1,13 @@
+QA Test Run: 20260817-083555
+Runs per test: 1
+Tests: 32-ipoe-opdb-restore
+Results: /tmp/claude-1000/-home-brandon-osvbng-dev-osvbng-context/68545c9c-186f-4326-856f-554b5025900b/scratchpad/osvbng-v4net/test-results/qa/20260817-083555
+========================================
+
+--- 32-ipoe-opdb-restore ---
+FAIL (3 tests, 1 passed, 1 failed, 1 skipped)
+  Result: 0/1 passed
+
+========================================
+TOTAL: 0 passed, 1 failed out of 1
+Done: Mon Aug 17 08:38:14 UTC 2026

--- a/tests/01-smoke/01-smoke.clab.yml
+++ b/tests/01-smoke/01-smoke.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-smoke
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/02-smoke-ha/02-smoke-ha.clab.yml
+++ b/tests/02-smoke-ha/02-smoke-ha.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-smoke-ha
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/03-ipoe-local/03-ipoe-local.clab.yml
+++ b/tests/03-ipoe-local/03-ipoe-local.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-ipoe-local
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/04-pppoe-local/04-pppoe-local.clab.yml
+++ b/tests/04-pppoe-local/04-pppoe-local.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-pppoe-local
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/08-cgnat-ipoe-pba/08-cgnat-ipoe-pba.clab.yml
+++ b/tests/08-cgnat-ipoe-pba/08-cgnat-ipoe-pba.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-cgnat-ipoe-pba
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/09-cgnat-ipoe-det/09-cgnat-ipoe-det.clab.yml
+++ b/tests/09-cgnat-ipoe-det/09-cgnat-ipoe-det.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-cgnat-ipoe-det
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/10-cgnat-pppoe-pba/10-cgnat-pppoe-pba.clab.yml
+++ b/tests/10-cgnat-pppoe-pba/10-cgnat-pppoe-pba.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-cgnat-pppoe-pba
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/11-cgnat-pppoe-det/11-cgnat-pppoe-det.clab.yml
+++ b/tests/11-cgnat-pppoe-det/11-cgnat-pppoe-det.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-cgnat-pppoe-det
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/12-cgnat-ha-ipoe-pba/12-cgnat-ha-ipoe-pba.clab.yml
+++ b/tests/12-cgnat-ha-ipoe-pba/12-cgnat-ha-ipoe-pba.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-cgnat-ha-ipoe-pba
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/13-cgnat-ha-pppoe-pba/13-cgnat-ha-pppoe-pba.clab.yml
+++ b/tests/13-cgnat-ha-pppoe-pba/13-cgnat-ha-pppoe-pba.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-cgnat-ha-pppoe-pba
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/14-ha-failover-ipoe/14-ha-failover-ipoe.clab.yml
+++ b/tests/14-ha-failover-ipoe/14-ha-failover-ipoe.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-ha-failover-ipoe
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/15-ha-failover-pppoe/15-ha-failover-pppoe.clab.yml
+++ b/tests/15-ha-failover-pppoe/15-ha-failover-pppoe.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-ha-failover-pppoe
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/16-ha-failover-radius-ipoe/16-ha-failover-radius-ipoe.clab.yml
+++ b/tests/16-ha-failover-radius-ipoe/16-ha-failover-radius-ipoe.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-ha-failover-radius-ipoe
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/17-ha-tracker-promotion-ipoe/17-ha-tracker-promotion-ipoe.clab.yml
+++ b/tests/17-ha-tracker-promotion-ipoe/17-ha-tracker-promotion-ipoe.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-ha-tracker-promotion-ipoe
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/18-ipoe-linux-client/18-ipoe-linux-client.clab.yml
+++ b/tests/18-ipoe-linux-client/18-ipoe-linux-client.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-ipoe-linux-client
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/19-ipoe-linux-client-cake/19-ipoe-linux-client-cake.clab.yml
+++ b/tests/19-ipoe-linux-client-cake/19-ipoe-linux-client-cake.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-ipoe-linux-client-cake
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/20-routing-policy/20-routing-policy.clab.yml
+++ b/tests/20-routing-policy/20-routing-policy.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-routing-policy
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/21-cli-openapi/21-cli-openapi.clab.yml
+++ b/tests/21-cli-openapi/21-cli-openapi.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-cli-openapi
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/22-mss-clamp/22-mss-clamp.clab.yml
+++ b/tests/22-mss-clamp/22-mss-clamp.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-mss-clamp
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/24-vrf-lite/24-vrf-lite.clab.yml
+++ b/tests/24-vrf-lite/24-vrf-lite.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-vrf-lite
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/25-l3vpn/25-l3vpn.clab.yml
+++ b/tests/25-l3vpn/25-l3vpn.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-l3vpn
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/26-dhcpv6-ldra/26-dhcpv6-ldra.clab.yml
+++ b/tests/26-dhcpv6-ldra/26-dhcpv6-ldra.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-dhcpv6-ldra
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/27-api-pagination/27-api-pagination.clab.yml
+++ b/tests/27-api-pagination/27-api-pagination.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-api-pagination
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/28-northbound-api-tls/28-northbound-api-tls.clab.yml
+++ b/tests/28-northbound-api-tls/28-northbound-api-tls.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-northbound-api-tls
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/30-l2tp-lns/30-l2tp-lns.clab.yml
+++ b/tests/30-l2tp-lns/30-l2tp-lns.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-l2tp-lns
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/31-l2tp-lac/31-l2tp-lac.clab.yml
+++ b/tests/31-l2tp-lac/31-l2tp-lac.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-l2tp-lac
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/32-ipoe-opdb-restore/32-ipoe-opdb-restore.clab.yml
+++ b/tests/32-ipoe-opdb-restore/32-ipoe-opdb-restore.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-ipoe-opdb-restore
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/33-pppoe-opdb-restore/33-pppoe-opdb-restore.clab.yml
+++ b/tests/33-pppoe-opdb-restore/33-pppoe-opdb-restore.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-pppoe-opdb-restore
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/34-cgnat-restart-idempotent/34-cgnat-restart-idempotent.clab.yml
+++ b/tests/34-cgnat-restart-idempotent/34-cgnat-restart-idempotent.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-cgnat-restart-idempotent
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/35-ipoe-family-disabled/35-ipoe-family-disabled.clab.yml
+++ b/tests/35-ipoe-family-disabled/35-ipoe-family-disabled.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-ipoe-family-disabled
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/37-ha-graceful-switchover-ipoe/37-ha-graceful-switchover-ipoe.clab.yml
+++ b/tests/37-ha-graceful-switchover-ipoe/37-ha-graceful-switchover-ipoe.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-ha-graceful-ipoe
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/51-ipoe-hqos-svlan/51-ipoe-hqos-svlan.clab.yml
+++ b/tests/51-ipoe-hqos-svlan/51-ipoe-hqos-svlan.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-ipoe-hqos-svlan
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:

--- a/tests/52-pppoe-hqos-svlan/52-pppoe-hqos-svlan.clab.yml
+++ b/tests/52-pppoe-hqos-svlan/52-pppoe-hqos-svlan.clab.yml
@@ -4,6 +4,12 @@
 
 name: osvbng-pppoe-hqos-svlan
 
+# v4-only mgmt: without an explicit subnet containerlab creates a
+# dual-stack network whose static v6 default route on eth0 competes
+# with the test RA route and breaks subscriber-originated IPv6.
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+
 topology:
   nodes:
     bng1:


### PR DESCRIPTION
The intermittent subscriber-IPv6 failures in suites 32, 42 and 47 were test infrastructure: containerlab creates its management network dual-stack by default and installs a static v6 default route via eth0 on every node, which competes at equal metric with the test RA route on the access interface. Which route wins flips with route-install order and RA lifetime timing, so subscriber-originated v6 intermittently left via the management network and died at its gateway. Proven by packet capture (v4 echoes reaching the BNG access interface while no v6 frames left the subscriber) and by the unsuppressed ping error naming the management gateway; a v4-only network cured the same lab immediately. Pre-creating the network cannot fix this because containerlab removes it on cleanup and recreates it dual-stack on the next deploy; the durable knob is the topology itself, which creates a v4-only network whenever it declares an explicit ipv4 management subnet, verified empirically.

Every topology without a mgmt section, 33 of them, gains one declaring the shared 172.20.20.0/24; the suites with per-suite networks already declare theirs. The host reset step also enforces shape rather than existence as a second line of defense, and no longer creates the network dual-stack itself, which the previous reset did, faithfully copied from the old CI and part of the problem.

Verified: with the declaration in place a deploy creates the network EnableIPv6 false; the previously failing baseline v6 path passes; and a manual osvbngd-restart cycle on the live rig shows identical session FIB before and after with post-restart pings green. One suite run under heavy unrelated host load still failed the post-restart case; runner-side sweeps on an idle machine are the validation for that, which I will dispatch and watch after merge. PR 452, which skipped these suites on the earlier product-side theory, should be closed as superseded, and the context repo note has already been corrected to record the real root cause and the cleared false trails.