### PR TITLE
ci: run suites across the full runner pool

### DIFF
--- a/.github/workflows/suite-run.yml
+++ b/.github/workflows/suite-run.yml
@@ -129,9 +129,11 @@ jobs:
     # deadlocked deploy held two lanes for 20 minutes before this.
     # Callers with repeated runs pass a larger budget.
     timeout-minutes: ${{ inputs.suite_timeout }}
+    # No max-parallel: suite concurrency is bounded by the runner
+    # pool itself, and an overloaded box shows up as bounded, logged
+    # suite timeouts rather than a silently undersized pipeline.
     strategy:
       fail-fast: false
-      max-parallel: 3
       matrix:
         suite: ${{ fromJSON(inputs.suites) }}
     steps:


### PR DESCRIPTION
The suite matrix carried max-parallel 3 as a conservative sizing guess for the rehearsal VM, leaving two of the five registered runners idle during sweeps. The cap goes: suite concurrency is bounded by the pool itself, and if the box is genuinely oversubscribed that surfaces as bounded, logged suite timeouts under the 12-minute cap and heals via the host reset, which is a better failure mode than a silently undersized pipeline. The maintainer called for full pool utilization.

Verified: yaml parses. Not verified: no sweep has run at five-wide on this VM yet; the next dispatched sweep is the sizing experiment, and if HA-heavy scheduling windows push past 32GB the evidence will be visible per-suite rather than inferred.