### PR TITLE
build(runner): pin docker to the pre-29 line matching dev stability

### DIFF
--- a/test-infra/runner/inventory.example.yml
+++ b/test-infra/runner/inventory.example.yml
@@ -20,6 +20,7 @@ all:
     # Tool versions. containerlab matches the dev machine so CI and
     # local runs exercise the same deployer.
     containerlab_version: "0.73.0"
+    docker_version: "5:28.5.2-1~ubuntu.24.04~noble"
 
     # One shared org-level runner pool; runner_count is the box's job
     # parallelism. The registration token is passed as an extra-var at

--- a/test-infra/runner/roles/ci-deps/tasks/main.yml
+++ b/test-infra/runner/roles/ci-deps/tasks/main.yml
@@ -26,15 +26,30 @@
       {{ ansible_distribution_release }} stable
     filename: docker
 
+# Pinned: unpinned docker-ce put 29.x on the runner while the dev
+# machine ran a proven 27.x, and 29.x's buildkit session handling
+# storms dockerd healthchecks under our cache-mounted builds
+# ("only one connection allowed"), leaving deploys that run during
+# a storm half-wired. Same-version-as-dev is the principle; 28.5.2
+# is the newest pre-29 packaged for noble.
 - name: Install docker
   ansible.builtin.apt:
     name:
-      - docker-ce
-      - docker-ce-cli
+      - "docker-ce={{ docker_version }}"
+      - "docker-ce-cli={{ docker_version }}"
       - containerd.io
       - docker-buildx-plugin
     state: present
     update_cache: true
+    allow_downgrade: true
+
+- name: Hold docker at the pinned version
+  ansible.builtin.dpkg_selections:
+    name: "{{ item }}"
+    selection: hold
+  loop:
+    - docker-ce
+    - docker-ce-cli
 
 - name: Runner user in docker group
   ansible.builtin.user:


### PR DESCRIPTION
Every unexplained one-shot failure on the runner correlated with dockerd healthcheck storms ('only one connection allowed') that fire during BuildKit cache-mounted image builds on docker 29.7.2, which the unpinned ci-deps role installed; the dev machine ran 27.5.1 all along without a single storm, and suites deploying during a storm window came up half-wired (02-smoke-ha with no data veths) or never started their daemon (28-northbound-api-tls). The role now pins docker-ce and docker-ce-cli via a docker_version inventory variable, holds the packages, and documents why; 28.5.2 is the newest pre-29 build packaged for noble.

Verified live: the playbook downgraded the runner cleanly to 28.5.2, and the exact BuildKit workload that stormed 29.x completed with zero healthcheck failures in the daemon journal. The full-width sweep dispatched after this is the system-level validation.

Applied to the runner already; this PR records it in provisioning so a reprovision keeps the pin.