### PR TITLE
test: stream suite output to the log instead of buffering

### DIFF
--- a/scripts/run-qa-tests.sh
+++ b/scripts/run-qa-tests.sh
@@ -183,19 +183,21 @@ for test in "${TESTS[@]}"; do
         log_file="$RESULTS_DIR/${test}-run${i}.log"
         echo -n "  Run $i/$RUNS: "
 
-        if output=$(make robot-test suite="$test" 2>&1); then
-            result=$(echo "$output" | grep "tests," | tail -1)
+        # Stream to the log as the suite runs instead of buffering:
+        # a killed run (job timeout, cancellation) used to lose its
+        # entire output, which is exactly the evidence a post-mortem
+        # needs.
+        if make robot-test suite="$test" > "$log_file" 2>&1; then
+            result=$(grep "tests," "$log_file" | tail -1)
             echo "PASS ($result)" | tee -a "$SUMMARY"
             pass=$((pass + 1))
             total_pass=$((total_pass + 1))
         else
-            result=$(echo "$output" | grep "tests," | tail -1)
+            result=$(grep "tests," "$log_file" | tail -1)
             echo "FAIL ($result)" | tee -a "$SUMMARY"
             fail=$((fail + 1))
             total_fail=$((total_fail + 1))
         fi
-
-        echo "$output" > "$log_file"
     done
 
     echo "  Result: $pass/$RUNS passed" | tee -a "$SUMMARY"


### PR DESCRIPTION
run-qa-tests.sh captured each suite's entire output in a shell variable and wrote it after completion, so any killed run, job timeout or cancellation, lost every line: the 02-smoke-ha timeout in the sweep left a 162-line job log containing only the cancellation marker, exactly when the output mattered most. The suite now writes its log as it runs and the summary greps the file instead of the variable.

Verified: a full 01-smoke run through the changed script passes with exit 0 and the log written incrementally. Not verified: the kill mid-run case was not staged; its behavior follows from redirection semantics.