### PR TITLE
fix(aaa): make the accounting bucket sleep interruptible

### DIFF
--- a/internal/aaa/component.go
+++ b/internal/aaa/component.go
@@ -208,7 +208,15 @@ func (c *Component) BuildAccountingBuckets() {
 			}
 
 			c.logger.Debug("Bucket sleeping", "id", bucketId, "until", next, "duration", time.Until(next))
-			time.Sleep(time.Until(next))
+			// Interruptible: StopContext cancels Ctx then waits on the
+			// goroutine WaitGroup, so a plain Sleep here holds shutdown
+			// open until the bucket's second-of-minute arrives, up to a
+			// full minute of dead daemon on every restart.
+			select {
+			case <-time.After(time.Until(next)):
+			case <-c.Ctx.Done():
+				return
+			}
 
 			ticker := time.NewTicker(1 * time.Minute)
 			defer ticker.Stop()


### PR DESCRIPTION
A graceful osvbngd shutdown with live sessions took up to a full minute, dataplane orphaned the whole time, on every planned restart. BuildAccountingBuckets spawns sixty goroutines through Base.Go, one per second-of-minute, and each sleeps with time.Sleep until its scheduled second before entering its ctx-aware ticker loop. StopContext cancels the context and then waits on the goroutine WaitGroup, so any bucket still in that initial uninterruptible sleep holds shutdown open until its second arrives.

The initial wait becomes a select on the timer and Ctx.Done.

Verified on the live rig by instrumenting the three shutdown phases: orch.Stop measured 51,985 ms with one established session while telemetry.Shutdown and vpp.Close were 0 ms, and the same lab after this change shuts down in 1 second. Unit tests pass. Reported honestly: this does not fix suites 32, 42 and 47, which still fail probabilistically after restart (32 passed one of three runs on this build); their remaining cause is still under investigation and is not this stall. The value here is the production restart window, not a test result.