### PR TITLE
ci: survive root-owned workspace leftovers and drop upload-artifact

### DIFF
--- a/.github/workflows/suite-run.yml
+++ b/.github/workflows/suite-run.yml
@@ -50,6 +50,11 @@ jobs:
       - name: Checkout
         run: |
           git init -q .
+          # Suites run robot and containerlab under sudo, which leaves
+          # root-owned files (test-results, generated certs) in the
+          # workspace. checkout -f and clean run unprivileged and fail
+          # on them, killing the job before any step output exists.
+          sudo chown -R "$(id -u):$(id -g)" .
           git remote remove origin 2>/dev/null || true
           git remote add origin "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}"
           git fetch -q --depth 1 origin "$GITHUB_SHA"
@@ -160,6 +165,11 @@ jobs:
       - name: Checkout
         run: |
           git init -q .
+          # Suites run robot and containerlab under sudo, which leaves
+          # root-owned files (test-results, generated certs) in the
+          # workspace. checkout -f and clean run unprivileged and fail
+          # on them, killing the job before any step output exists.
+          sudo chown -R "$(id -u):$(id -g)" .
           git remote remove origin 2>/dev/null || true
           git remote add origin "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}"
           git fetch -q --depth 1 origin "$GITHUB_SHA"
@@ -184,9 +194,11 @@ jobs:
             -t tests/${{ matrix.suite }}/${{ matrix.suite }}.clab.yml \
             --cleanup 2>/dev/null || true
 
-      # The host copy is the guaranteed evidence store; the artifact
-      # upload is best-effort because its action download shares
-      # codeload's rate-limit exposure.
+      # The host copy is the evidence store. No upload-artifact: its
+      # action tarball downloads during job setup, before any step
+      # runs, so continue-on-error cannot save the job when codeload
+      # rate-limits this box, and one cold action cache then fails
+      # every suite in the sweep at setup.
       - name: Keep robot output on the host
         if: always()
         run: |
@@ -194,12 +206,3 @@ jobs:
           sudo mkdir -p "$d"
           sudo cp -r tests/out/. "$d"/ 2>/dev/null || true
           sudo find /var/log/osvbng-ci -maxdepth 1 -mtime +7 -exec rm -rf {} + 2>/dev/null || true
-
-      - name: Upload robot output
-        if: always()
-        continue-on-error: true
-        uses: actions/upload-artifact@v4
-        with:
-          name: robot-${{ github.run_id }}-${{ matrix.suite }}
-          path: tests/out/
-          retention-days: 14


### PR DESCRIPTION
## Problem

Two independent ways a suite job dies before robot runs. First, run 32044685963 failed 9 suites at the checkout step: sudo'd robot and containerlab leave root-owned files (test-results, generated certs) in the runner workspace, and the unprivileged git clean -qfdx exits 1 on them, so the job fails with an empty evidence directory. Second, sweep 32042366488 failed 45 of 47 jobs at job setup because the upload-artifact action tarball downloads from codeload.github.com before any step runs; codeload rate-limits this box under sweep load and continue-on-error cannot save a job that dies before its first step.

Note: #459 was intended to remove upload-artifact but merged as an empty commit (its branch was the already-merged #457), so the step is still on main until this lands.

## Change

Both Checkout steps chown the workspace to the runner user before checkout -f and clean. The upload-artifact step is removed; the host evidence store at /var/log/osvbng-ci/<run_id>/<suite>/ is the record and was the only diagnostics that survived both failures.

## Verification

yaml parses. The chown path and the artifact removal are exercised by the next dispatch against main; not verified on a branch run because the failing condition (dirty workspace, cold action cache) is host state, not branch state.