### PR TITLE
fix(southbound): disable kernel ipv6 on interfaces claimed for the dataplane

### DIFF
--- a/pkg/southbound/vpp/interfaces.go
+++ b/pkg/southbound/vpp/interfaces.go
@@ -3,6 +3,7 @@ package vpp
 import (
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"time"
 
@@ -1463,12 +1464,32 @@ func (v *VPP) afPacketRxQueues() uint16 {
 	return 1
 }
 
+// silenceKernelIPv6 disables the kernel IPv6 stack on a netdev VPP is
+// about to claim via af-packet. af-packet leaves the kernel bound to
+// the same wire with the same MAC and link-local: the kernel answers
+// ND probes for that address, VPP hears those frames as inbound,
+// learns its own link-local as a dynamic neighbour, and that entry
+// shadows the interface's local-receive route in the ip6-ll FIB, after
+// which every ND reply to the interface hairpins back out the wire and
+// IPv6 forwarding through the box is dead. VPP must be the only IPv6
+// speaker on a claimed interface; the kernel-side routing stack talks
+// through the linux-cp taps, never through the claimed netdev.
+func silenceKernelIPv6(linuxIface string) error {
+	path := "/proc/sys/net/ipv6/conf/" + linuxIface + "/disable_ipv6"
+	return os.WriteFile(path, []byte("1"), 0o644)
+}
+
 func (v *VPP) createVPPHostInterface(linuxIface string) (string, error) {
 	ch, err := v.conn.NewAPIChannel()
 	if err != nil {
 		return "", fmt.Errorf("create API channel: %w", err)
 	}
 	defer ch.Close()
+
+	if err := silenceKernelIPv6(linuxIface); err != nil {
+		v.logger.Warn("Failed to disable kernel IPv6 on claimed interface; kernel ND can poison the ip6-ll FIB",
+			"interface", linuxIface, "error", err)
+	}
 
 	afReq := &af_packet.AfPacketCreateV2{
 		HostIfName:      linuxIface,


### PR DESCRIPTION
## Problem

IPv6 forwarding through the BNG dies nondeterministically: suite 32 failed 2 of 3 runs pinging the core router over v6 after an osvbngd restart, and one lab deploy came up with v6-to-core dead from the start, while v6 to the BNG itself and all of v4 kept working. Live diagnosis on the frozen lab: the core answers every neighbor solicitation on the wire, but VPP forwards the NA back out eth2 to its own MAC instead of receiving it. VPP's neighbor table held a dynamic entry for its own eth2 link-local, and that entry had replaced the interface's local-receive /128 in the ip6-ll FIB, so every ND reply to the interface hairpinned onto the wire and the core's global address could never resolve past a glean adjacency.

The poisoning source is the container kernel. af-packet leaves the kernel bound to the claimed netdev with the same MAC and the same link-local, and the kernel's IPv6 stack answers ND probes for that address. VPP hears the kernel's transmitted NA as an inbound frame and learns its own link-local as a neighbor. Every NUD probe cycle from the core re-arms the poison, which is why restart suites whose late re-verification lands in a probe window failed probabilistically while by-hand checks passed.

## Change

createVPPHostInterface writes disable_ipv6=1 for the netdev before claiming it via af-packet. The kernel-side routing stack talks through the linux-cp taps in the dataplane namespace, never through the claimed netdev, so the kernel has no legitimate IPv6 role there. v4 has no equivalent exposure because the kernel holds no v4 address on claimed interfaces.

## Verification

Local rig, suite 32 lab. Before: baseline v6-to-core ping dead on deploy; mechanism traced packet-by-packet (NS out, NA on the wire, NA hairpinned by the ip6-ll FIB, missing dpo-receive route confirmed against a healthy interface). After: both claimed interfaces report disable_ipv6=1 with no kernel link-local, the ip6-ll FIB keeps its receive route, baseline v6 up immediately, and 20 consecutive osvbngd restart cycles hold all four subscriber ping targets (v4/v6 gateway, v4/v6 core). Not verified here: the full suite sweep; the nightly dispatch after merge covers it.
