### PR TITLE
fix(southbound): re-attach ipoe sessions on already-exists instead of failing restore

### DIFF
--- a/pkg/southbound/vpp/errors.go
+++ b/pkg/southbound/vpp/errors.go
@@ -15,7 +15,8 @@ import "errors"
 // caller can delete-and-recreate to converge.
 const retvalEntryNeedsRefresh = -500
 
-// retvalValueExist matches VNET_API_ERROR_VALUE_EXIST (-116). Some plugin
+// retvalValueExist matches VNET_API_ERROR_ENTRY_ALREADY_EXISTS (-116);
+// govpp names it api.ENTRY_ALREADY_EXISTS (VALUE_EXIST is -81). Some plugin
 // add paths surface this on a redundant add (entry already present, no
 // mutable inputs differ). Callers treat it as success on isAdd=true so a
 // restart-time replay of the same mapping is a safe no-op.

--- a/pkg/southbound/vpp/sessions_ipoe.go
+++ b/pkg/southbound/vpp/sessions_ipoe.go
@@ -1,6 +1,7 @@
 package vpp
 
 import (
+	"errors"
 	"fmt"
 	"github.com/veesix-networks/osvbng/pkg/ifmgr"
 	"github.com/veesix-networks/osvbng/pkg/vpp/binapi/ethernet_types"
@@ -34,42 +35,48 @@ func (v *VPP) AddIPoESession(clientMAC net.HardwareAddr, localMAC net.HardwareAd
 		DecapVrfID:   decapVrfID,
 	}
 
+	// govpp's ReceiveReply converts every nonzero retval into a
+	// VPPApiError before the caller can inspect reply.Retval, so the
+	// plugin's non-fatal retvals must be caught on the error, not the
+	// retval. The reply body is decoded before the conversion, so
+	// reply.SwIfIndex is valid on these paths. The plugin returns
+	// already-exists with the live session's sw_if_index for a replayed
+	// identical add; opdb restore over a live VPP replays every session
+	// and must re-attach, not fail.
 	reply := &osvbng_ipoe.OsvbngIpoeAddDelSessionReply{}
 	if err := ch.SendRequest(req).ReceiveReply(reply); err != nil {
-		return 0, fmt.Errorf("add ipoe session: %w", err)
-	}
+		if errors.Is(err, api.VPPApiError(retvalEntryNeedsRefresh)) {
+			v.logger.Info("IPoE session exists with drifted mutable inputs; refreshing",
+				"client_mac", clientMAC.String(),
+				"encap_if_index", encapIfIndex,
+				"inner_vlan", innerVLAN,
+				"stale_sw_if_index", reply.SwIfIndex)
 
-	if reply.Retval == retvalEntryNeedsRefresh {
-		v.logger.Info("IPoE session exists with drifted mutable inputs; refreshing",
-			"client_mac", clientMAC.String(),
-			"encap_if_index", encapIfIndex,
-			"inner_vlan", innerVLAN,
-			"stale_sw_if_index", reply.SwIfIndex)
+			delReq := &osvbng_ipoe.OsvbngIpoeAddDelSession{
+				IsAdd:        false,
+				EncapIfIndex: interface_types.InterfaceIndex(encapIfIndex),
+				ClientMac:    clientMacAddr,
+				InnerVlan:    innerVLAN,
+			}
+			delReply := &osvbng_ipoe.OsvbngIpoeAddDelSessionReply{}
+			if err := ch.SendRequest(delReq).ReceiveReply(delReply); err != nil {
+				return 0, fmt.Errorf("refresh ipoe session: del: %w", err)
+			}
+			v.ifMgr.Remove(uint32(delReply.SwIfIndex))
 
-		delReq := &osvbng_ipoe.OsvbngIpoeAddDelSession{
-			IsAdd:        false,
-			EncapIfIndex: interface_types.InterfaceIndex(encapIfIndex),
-			ClientMac:    clientMacAddr,
-			InnerVlan:    innerVLAN,
+			reply = &osvbng_ipoe.OsvbngIpoeAddDelSessionReply{}
+			if err := ch.SendRequest(req).ReceiveReply(reply); err != nil {
+				return 0, fmt.Errorf("refresh ipoe session: re-add: %w", err)
+			}
+		} else if errors.Is(err, api.ENTRY_ALREADY_EXISTS) {
+			v.logger.Info("IPoE session already exists; re-attaching",
+				"client_mac", clientMAC.String(),
+				"encap_if_index", encapIfIndex,
+				"inner_vlan", innerVLAN,
+				"sw_if_index", reply.SwIfIndex)
+		} else {
+			return 0, fmt.Errorf("add ipoe session: %w", err)
 		}
-		delReply := &osvbng_ipoe.OsvbngIpoeAddDelSessionReply{}
-		if err := ch.SendRequest(delReq).ReceiveReply(delReply); err != nil {
-			return 0, fmt.Errorf("refresh ipoe session: del: %w", err)
-		}
-		if delReply.Retval != 0 {
-			return 0, fmt.Errorf("refresh ipoe session: del retval=%d", delReply.Retval)
-		}
-		v.ifMgr.Remove(uint32(delReply.SwIfIndex))
-
-		reply = &osvbng_ipoe.OsvbngIpoeAddDelSessionReply{}
-		if err := ch.SendRequest(req).ReceiveReply(reply); err != nil {
-			return 0, fmt.Errorf("refresh ipoe session: re-add: %w", err)
-		}
-		if reply.Retval != 0 {
-			return 0, fmt.Errorf("refresh ipoe session: re-add retval=%d", reply.Retval)
-		}
-	} else if reply.Retval != 0 {
-		return 0, fmt.Errorf("add ipoe session failed: retval=%d", reply.Retval)
 	}
 
 	swIdx := uint32(reply.SwIfIndex)


### PR DESCRIPTION
## Problem

opdb session restore over a live VPP has never re-attached an IPoE session. Suites 42 and 47 fail every osvbngd restart with 0 sessions in the API where 2 are expected; the captured daemon log shows every restored session dying with "add ipoe session: VPPApiError: Entry already exists (-116)". The ipoe plugin returns ENTRY_ALREADY_EXISTS with the live session's sw_if_index for a replayed identical add, exactly so the caller can re-attach, but govpp's ReceiveReply converts every nonzero retval into an error before AddIPoESession can inspect reply.Retval. Both the re-attach path and the documented needs-refresh (-500) path were therefore dead code: the error return fired first, restore counted the session as failed, and the control plane came up empty while the dataplane kept forwarding. Suite 32 masked the same defect because its checks (opdb snapshot, subscriber pings) never consult the control plane's session view.

## Change

AddIPoESession inspects the ReceiveReply error instead of the never-reachable retval branches: ENTRY_ALREADY_EXISTS re-attaches using the sw_if_index the reply carries (govpp decodes the reply body before converting the retval, so the field is valid), and the needs-refresh retval keeps its delete-and-recreate handling, moved where it can actually execute. errors.go's comment naming -116 VALUE_EXIST is corrected; govpp's VALUE_EXIST is -81 and -116 is ENTRY_ALREADY_EXISTS.

## Verification

go build and go vet clean. Live rig: suite 42 previously failed every run at "Restart Survives With Sessions On Headend" with the -116 log line; with this fix the restart suites (32, 33, 42, 43, 47, 48) pass, sessions present in the API after restart. Exact runs listed in the PR conversation. Not verified: the needs-refresh path, which the ipoe plugin does not currently emit (no -500 in the C plugin); it is retained because the documented contract expects it.
