### PR TITLE
test: gate restart verification on the daemon state file

### DIFF
--- a/tests/32-ipoe-opdb-restore/32-ipoe-opdb-restore.robot
+++ b/tests/32-ipoe-opdb-restore/32-ipoe-opdb-restore.robot
@@ -55,6 +55,7 @@ ${session-count}        1
     Restart osvbngd                                ${bng1}
     Wait For osvbngd Down                          ${bng1}
     Wait For osvbng Healthy                        bng1    ${lab-name}
+    Wait For osvbng State Ready                    ${bng1}
     Verify OpDB Sessions Match Snapshot            ${bng1}    ${OPDB_SNAPSHOT}
     Verify OpDB Session IP Addresses Match         ${bng1}    ${OPDB_SNAPSHOT}
     Verify Subscriber Has Stable Lease V4
@@ -79,6 +80,7 @@ ${session-count}        1
     ...    subscriber ND caches. Tracked separately.
     Restart VPP                                    ${bng1}
     Wait For VPP Recovery                          ${bng1}
+    Wait For osvbng State Ready                    ${bng1}
     Wait Until Keyword Succeeds    60s    2s
     ...    Verify OpDB Session Count               ${bng1}    ${session-count}
     Verify OpDB Sessions Match Snapshot            ${bng1}    ${OPDB_SNAPSHOT}

--- a/tests/33-pppoe-opdb-restore/33-pppoe-opdb-restore.robot
+++ b/tests/33-pppoe-opdb-restore/33-pppoe-opdb-restore.robot
@@ -53,6 +53,7 @@ ${session-count}        1
     Restart osvbngd                                ${bng1}
     Wait For osvbngd Down                          ${bng1}
     Wait For osvbng Healthy                        bng1    ${lab-name}
+    Wait For osvbng State Ready                    ${bng1}
     Verify OpDB Sessions Match Snapshot            ${bng1}    ${OPDB_SNAPSHOT}
     Verify PPPoE Session Has Not Re-Established
     Verify Subscriber Can Ping                     ${v4-gateway}
@@ -70,6 +71,7 @@ ${session-count}        1
     ...    v6 checks back once osvbng-context#89 lands.
     Restart VPP                                    ${bng1}
     Wait For VPP Recovery                          ${bng1}
+    Wait For osvbng State Ready                    ${bng1}
     Wait Until Keyword Succeeds    60s    2s
     ...    Verify OpDB Session Count               ${bng1}    ${session-count}
     Verify OpDB Sessions Match Snapshot            ${bng1}    ${OPDB_SNAPSHOT}

--- a/tests/34-cgnat-restart-idempotent/34-cgnat-restart-idempotent.robot
+++ b/tests/34-cgnat-restart-idempotent/34-cgnat-restart-idempotent.robot
@@ -34,6 +34,7 @@ Identical Config Across Restart
     Wait For osvbngd Down    ${bng1}
     Wait For osvbngd Up    ${bng1}
     Wait For osvbng Healthy    bng1    ${lab-name}
+    Wait For osvbng State Ready    ${bng1}
     ${log} =    Tail osvbngd Log    ${bng1}    400
     Should Not Contain    ${log}    cgnat reconcile: replace pool
     Should Not Contain    ${log}    cgnat reconcile: drop orphan
@@ -47,6 +48,7 @@ Soft Drift Preserves Mappings
     Wait For osvbngd Down    ${bng1}
     Wait For osvbngd Up    ${bng1}
     Wait For osvbng Healthy    bng1    ${lab-name}
+    Wait For osvbng State Ready    ${bng1}
     ${log} =    Tail osvbngd Log    ${bng1}    400
     Should Contain    ${log}    cgnat reconcile: soft-update pool
 

--- a/tests/39-l2gw-dynamic/39-l2gw-dynamic.robot
+++ b/tests/39-l2gw-dynamic/39-l2gw-dynamic.robot
@@ -155,6 +155,7 @@ Restart Survives With No Duplicate Accounting Start
     Restart osvbngd    ${bng1}
     Wait For osvbngd Down    ${bng1}
     Wait For osvbng Healthy    bng1    ${lab-name}
+    Wait For osvbng State Ready    ${bng1}
     Wait For L2GW Circuit Count    ${bng1}    ${session-count}
     ${restored} =    Snapshot L2GW Circuit IDs    ${bng1}
     Should Be Equal As Strings    ${restored}    ${snapshot}    circuit set changed across restart

--- a/tests/40-l2gw-packet-trigger/40-l2gw-packet-trigger.robot
+++ b/tests/40-l2gw-packet-trigger/40-l2gw-packet-trigger.robot
@@ -102,6 +102,7 @@ Restart Survives With Circuits Restored
     Restart osvbngd    ${bng1}
     Wait For osvbngd Down    ${bng1}
     Wait For osvbng Healthy    bng1    ${lab-name}
+    Wait For osvbng State Ready    ${bng1}
     Wait For L2GW Circuit Count    ${bng1}    ${session-count}
     ${restored} =    Snapshot L2GW Circuit IDs    ${bng1}
     Should Be Equal As Strings    ${restored}    ${snapshot}    circuit set changed across restart

--- a/tests/40-l2gw-vxlan/40-l2gw-vxlan.robot
+++ b/tests/40-l2gw-vxlan/40-l2gw-vxlan.robot
@@ -132,6 +132,7 @@ Restart Survives With Circuits On Tunnels
     Restart osvbngd    ${bng1}
     Wait For osvbngd Down    ${bng1}
     Wait For osvbng Healthy    bng1    ${lab-name}
+    Wait For osvbng State Ready    ${bng1}
     Wait For L2GW Circuit Count    ${bng1}    ${session-count}
     ${restored} =    Snapshot L2GW Circuit IDs    ${bng1}
     Should Be Equal As Strings    ${restored}    ${snapshot}    circuit set changed across restart

--- a/tests/42-ipoe-vxlan-pwhe/42-ipoe-vxlan-pwhe.robot
+++ b/tests/42-ipoe-vxlan-pwhe/42-ipoe-vxlan-pwhe.robot
@@ -105,6 +105,7 @@ Restart Survives With Sessions On Headend
     Restart osvbngd    ${bng1}
     Wait For osvbngd Down    ${bng1}
     Wait For osvbng Healthy    bng1    ${lab-name}
+    Wait For osvbng State Ready    ${bng1}
     Verify Sessions In API    ${bng1}    ${session-count}
     ${ips} =    Get Session IPv4 Addresses    ${bng1}
     FOR    ${ip}    IN    @{ips}

--- a/tests/43-pppoe-vxlan-pwhe/43-pppoe-vxlan-pwhe.robot
+++ b/tests/43-pppoe-vxlan-pwhe/43-pppoe-vxlan-pwhe.robot
@@ -97,6 +97,7 @@ Restart Survives With Sessions On Headend
     Restart osvbngd    ${bng1}
     Wait For osvbngd Down    ${bng1}
     Wait For osvbng Healthy    bng1    ${lab-name}
+    Wait For osvbng State Ready    ${bng1}
     Verify Sessions In API    ${bng1}    ${session-count}
     ${ips} =    Get Session IPv4 Addresses    ${bng1}
     FOR    ${ip}    IN    @{ips}

--- a/tests/46-l2gw-evpn/46-l2gw-evpn.robot
+++ b/tests/46-l2gw-evpn/46-l2gw-evpn.robot
@@ -138,6 +138,7 @@ Restart Survives With Circuits On Discovered Tunnels
     Restart osvbngd    ${bng1}
     Wait For osvbngd Down    ${bng1}
     Wait For osvbng Healthy    bng1    ${lab-name}
+    Wait For osvbng State Ready    ${bng1}
     Wait Until Keyword Succeeds    60s    5s
     ...    Verify VPP Tunnel Programmed    10101
     Wait Until Keyword Succeeds    60s    5s

--- a/tests/47-ipoe-evpn-pwhe/47-ipoe-evpn-pwhe.robot
+++ b/tests/47-ipoe-evpn-pwhe/47-ipoe-evpn-pwhe.robot
@@ -105,6 +105,7 @@ Restart Survives With Sessions On Headend
     Restart osvbngd    ${bng1}
     Wait For osvbngd Down    ${bng1}
     Wait For osvbng Healthy    bng1    ${lab-name}
+    Wait For osvbng State Ready    ${bng1}
     Wait Until Keyword Succeeds    60s    5s
     ...    Verify Tunnel And Binding Present
     Verify Sessions In API    ${bng1}    ${session-count}

--- a/tests/48-pppoe-evpn-pwhe/48-pppoe-evpn-pwhe.robot
+++ b/tests/48-pppoe-evpn-pwhe/48-pppoe-evpn-pwhe.robot
@@ -100,6 +100,7 @@ Restart Survives With Sessions On Headend
     Restart osvbngd    ${bng1}
     Wait For osvbngd Down    ${bng1}
     Wait For osvbng Healthy    bng1    ${lab-name}
+    Wait For osvbng State Ready    ${bng1}
     Wait Until Keyword Succeeds    60s    5s
     ...    Verify Tunnel And Binding Present
     Verify Sessions In API    ${bng1}    ${session-count}

--- a/tests/restart.robot
+++ b/tests/restart.robot
@@ -33,6 +33,25 @@ Check osvbngd Not Running
     ...    sudo docker exec ${container} pgrep -x osvbngd
     Should Not Be Equal As Integers    ${rc}    0    osvbngd still running
 
+# "osvbng started successfully" survives an osvbngd respawn in docker
+# logs, so log-grep health checks pass instantly after a restart while
+# opdb recovery is still running. /run/osvbng/state only reads ready
+# once every restoring component (ipoe, pppoe, cgnat, l2gw) finishes
+# recovery (cmd/osvbngd/main.go, TrackReadiness). Call this only after
+# Wait For osvbng Healthy confirms the new process is answering: the
+# killed process leaves a stale "ready" state file behind.
+Wait For osvbng State Ready
+    [Arguments]    ${container}    ${timeout}=${RESPAWN_TIMEOUT}    ${interval}=${RESPAWN_INTERVAL}
+    Wait Until Keyword Succeeds    ${timeout}    ${interval}
+    ...    Check osvbng State Ready    ${container}
+
+Check osvbng State Ready
+    [Arguments]    ${container}
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sudo docker exec ${container} cat /run/osvbng/state
+    Should Be Equal As Integers    ${rc}    0    cannot read /run/osvbng/state
+    Should Contain    ${output}    "state":"ready"    osvbng reports ${output}
+
 Restart VPP
     [Arguments]    ${container}
     ${rc}    ${output} =    Run And Return Rc And Output


### PR DESCRIPTION
## Problem

Every restart test waits on Check osvbng Started, which greps the container's docker log for "osvbng started successfully". That line survives an osvbngd respawn from the previous boot, so after a restart the health wait passes instantly, while opdb recovery is still running, and verification races restore. The daemon documents the truthful signal (cmd/osvbngd/main.go): /run/osvbng/state flips to ready only when every restoring component finishes recovery, and suite 41's upgrade harness already waits on it; the Robot suites never adopted it. Timeline from a failing suite 42 run: pkill to "healthy" in 3.2 seconds, state gate absent, sessions read mid-restore.

This is not claimed to be the cause of the current restart-suite failures. Verification with this gate alone still failed suites 32, 42 and 47, which exposed two real product defects (the kernel ND ip6-ll FIB poisoning and the dead session re-attach path, fixed separately). The gate is still required: without it, every restart suite starts verifying before restore has finished, and whether that passes depends on box load.

## Change

restart.robot gains Wait For osvbng State Ready, polling /run/osvbng/state for "state":"ready". Every restart flow (11 suites, 14 sites, including both VPP-restart flavors in 32 and 33) calls it after its existing Wait For osvbng Healthy. Ordering matters and is documented at the keyword: the killed process leaves a stale "ready" state file behind, so the gate is only trustworthy after the API check has confirmed the new process is answering.

## Verification

The gate executed in every run of the local verification loops (suite 32 three runs, 42 and 47 one each) and behaved correctly: it passed only after the daemon reported ready, and the remaining failures were the product defects above. robot --dryrun passes on all ten other modified suites. Combined with the two product fixes, the six restart suites (32, 33, 42, 43, 47, 48) pass locally; run list in the PR conversation. Not verified: the l2gw restart suites (39, 40, 46) live; they gain only an extra wait and the nightly sweep covers them.
