### PR TITLE
fix(docker): decide the plugin drop from a marker the tmp purge cannot delete

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,8 +52,13 @@ ARG DATAPLANE_VERSION=26.06-release
 # plugins from one build. Otherwise fall back to upstream packagecloud
 # debs; the osvbng plugins then come from the prebuilt drop below.
 COPY docker/dataplane-debs/ /tmp/dataplane-debs/
+# The marker must live outside /tmp: the image-slimming purge below
+# runs rm -rf /tmp/* between this RUN and the plugin-drop decision,
+# and testing /tmp/dataplane-debs there silently reverted every image
+# to the stale prebuilt plugin drop, CI images included.
 RUN if ls /tmp/dataplane-debs/*.deb >/dev/null 2>&1; then \
-        apt-get update && apt-get install -y --no-install-recommends \
+        touch /usr/lib/osvbng-dataplane-from-debs \
+        && apt-get update && apt-get install -y --no-install-recommends \
         numactl \
         /tmp/dataplane-debs/vpp_*.deb \
         /tmp/dataplane-debs/vpp-plugin-core_*.deb \
@@ -98,12 +103,12 @@ RUN mkdir -p /etc/osvbng /var/log/osvbng /var/lib/osvbng /run/osvbng
 # dataplane-debs path already ships the plugins from the same build as
 # the core, and overlaying stale binaries would defeat it.
 COPY test-infra/vpp-plugins/ /tmp/stock-plugins/
-RUN if ls /tmp/dataplane-debs/*.deb >/dev/null 2>&1; then \
-        echo "dataplane debs present, skipping prebuilt plugin drop"; \
+RUN if [ -f /usr/lib/osvbng-dataplane-from-debs ]; then \
+        echo "dataplane debs installed, skipping prebuilt plugin drop"; \
     else \
         cp /tmp/stock-plugins/*.so /usr/lib/x86_64-linux-gnu/vpp_plugins/; \
     fi \
-    && rm -rf /tmp/stock-plugins /tmp/dataplane-debs
+    && rm -rf /tmp/stock-plugins /tmp/dataplane-debs /usr/lib/osvbng-dataplane-from-debs
 
 COPY --from=builder /build/bin/osvbngd /usr/local/bin/osvbngd
 COPY --from=builder /build/bin/osvbngcli /usr/local/bin/osvbngcli


### PR DESCRIPTION
## Problem

The two-source dataplane install decided the prebuilt plugin drop by testing /tmp/dataplane-debs, but the image-slimming layer between the deb install and that decision runs rm -rf /tmp/*, so the test was always false and the stale committed plugin drop overwrote the deb-installed osvbng plugins in every image built since the two-source design landed, CI images included. Every integration run since then has tested the hand-committed plugin binaries from 2026-08-14 regardless of which dataplane debs the workflow staged: the NS punt registration, the qos scheduler fixes and the punt policer burst fix were never actually in a test image. Found because sweep 32056764011 failed suite 52 with the exact policed-counter signature of the un-fixed policer on an image whose provenance claimed the fixed build, and the plugin md5 in the image matched test-infra/vpp-plugins, not the staged deb.

## Change

The deb-install branch writes a marker outside /tmp and the plugin-drop decision tests the marker, which the purge cannot delete. The marker is removed in the same layer that ends the decision.

## Verification

Rebuilt locally with debs staged: the build logs "dataplane debs installed, skipping prebuilt plugin drop" and the image's osvbng_punt_plugin.so md5 now matches the deb's. Suite 52 verification against the genuinely fixed dataplane is running and will be reported on this PR before the next sweep.