### PR TITLE
revert: worker pin, identical cores across labs concentrate contention

### DIFF
--- a/tests/01-smoke/01-smoke.clab.yml
+++ b/tests/01-smoke/01-smoke.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/02-smoke-ha/02-smoke-ha.clab.yml
+++ b/tests/02-smoke-ha/02-smoke-ha.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 
@@ -41,8 +39,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng2/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/03-ipoe-local/03-ipoe-local.clab.yml
+++ b/tests/03-ipoe-local/03-ipoe-local.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/04-pppoe-local/04-pppoe-local.clab.yml
+++ b/tests/04-pppoe-local/04-pppoe-local.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/05-ipoe-radius/05-ipoe-radius.clab.yml
+++ b/tests/05-ipoe-radius/05-ipoe-radius.clab.yml
@@ -23,8 +23,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/06-pppoe-radius/06-pppoe-radius.clab.yml
+++ b/tests/06-pppoe-radius/06-pppoe-radius.clab.yml
@@ -23,8 +23,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/07-dhcp-relay-proxy/07-dhcp-relay-proxy.clab.yml
+++ b/tests/07-dhcp-relay-proxy/07-dhcp-relay-proxy.clab.yml
@@ -23,8 +23,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/09-cgnat-ipoe-det/09-cgnat-ipoe-det.clab.yml
+++ b/tests/09-cgnat-ipoe-det/09-cgnat-ipoe-det.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/11-cgnat-pppoe-det/11-cgnat-pppoe-det.clab.yml
+++ b/tests/11-cgnat-pppoe-det/11-cgnat-pppoe-det.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/12-cgnat-ha-ipoe-pba/12-cgnat-ha-ipoe-pba.clab.yml
+++ b/tests/12-cgnat-ha-ipoe-pba/12-cgnat-ha-ipoe-pba.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 
@@ -41,8 +39,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng2/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/13-cgnat-ha-pppoe-pba/13-cgnat-ha-pppoe-pba.clab.yml
+++ b/tests/13-cgnat-ha-pppoe-pba/13-cgnat-ha-pppoe-pba.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 
@@ -41,8 +39,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng2/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/14-ha-failover-ipoe/14-ha-failover-ipoe.clab.yml
+++ b/tests/14-ha-failover-ipoe/14-ha-failover-ipoe.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 
@@ -41,8 +39,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng2/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/15-ha-failover-pppoe/15-ha-failover-pppoe.clab.yml
+++ b/tests/15-ha-failover-pppoe/15-ha-failover-pppoe.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 
@@ -41,8 +39,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng2/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/16-ha-failover-radius-ipoe/16-ha-failover-radius-ipoe.clab.yml
+++ b/tests/16-ha-failover-radius-ipoe/16-ha-failover-radius-ipoe.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 
@@ -41,8 +39,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng2/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/17-ha-tracker-promotion-ipoe/17-ha-tracker-promotion-ipoe.clab.yml
+++ b/tests/17-ha-tracker-promotion-ipoe/17-ha-tracker-promotion-ipoe.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 
@@ -41,8 +39,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng2/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/18-ipoe-linux-client/18-ipoe-linux-client.clab.yml
+++ b/tests/18-ipoe-linux-client/18-ipoe-linux-client.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/19-ipoe-linux-client-cake/19-ipoe-linux-client-cake.clab.yml
+++ b/tests/19-ipoe-linux-client-cake/19-ipoe-linux-client-cake.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/20-routing-policy/20-routing-policy.clab.yml
+++ b/tests/20-routing-policy/20-routing-policy.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/21-cli-openapi/21-cli-openapi.clab.yml
+++ b/tests/21-cli-openapi/21-cli-openapi.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/22-mss-clamp/22-mss-clamp.clab.yml
+++ b/tests/22-mss-clamp/22-mss-clamp.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/23-radius-coa/23-radius-coa.clab.yml
+++ b/tests/23-radius-coa/23-radius-coa.clab.yml
@@ -23,8 +23,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/24-vrf-lite/24-vrf-lite.clab.yml
+++ b/tests/24-vrf-lite/24-vrf-lite.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/25-l3vpn/25-l3vpn.clab.yml
+++ b/tests/25-l3vpn/25-l3vpn.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/26-dhcpv6-ldra/26-dhcpv6-ldra.clab.yml
+++ b/tests/26-dhcpv6-ldra/26-dhcpv6-ldra.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/27-api-pagination/27-api-pagination.clab.yml
+++ b/tests/27-api-pagination/27-api-pagination.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/28-northbound-api-tls/28-northbound-api-tls.clab.yml
+++ b/tests/28-northbound-api-tls/28-northbound-api-tls.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
         - config/certs:/etc/osvbng/certs:ro

--- a/tests/29-radius-vrf/29-radius-vrf.clab.yml
+++ b/tests/29-radius-vrf/29-radius-vrf.clab.yml
@@ -23,8 +23,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/30-l2tp-lns/30-l2tp-lns.clab.yml
+++ b/tests/30-l2tp-lns/30-l2tp-lns.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "1"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/31-l2tp-lac/31-l2tp-lac.clab.yml
+++ b/tests/31-l2tp-lac/31-l2tp-lac.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/32-ipoe-opdb-restore/32-ipoe-opdb-restore.clab.yml
+++ b/tests/32-ipoe-opdb-restore/32-ipoe-opdb-restore.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/33-pppoe-opdb-restore/33-pppoe-opdb-restore.clab.yml
+++ b/tests/33-pppoe-opdb-restore/33-pppoe-opdb-restore.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/34-cgnat-restart-idempotent/34-cgnat-restart-idempotent.clab.yml
+++ b/tests/34-cgnat-restart-idempotent/34-cgnat-restart-idempotent.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/35-ipoe-family-disabled/35-ipoe-family-disabled.clab.yml
+++ b/tests/35-ipoe-family-disabled/35-ipoe-family-disabled.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/36-aaa-empty-username/36-aaa-empty-username.clab.yml
+++ b/tests/36-aaa-empty-username/36-aaa-empty-username.clab.yml
@@ -23,8 +23,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/37-ha-graceful-switchover-ipoe/37-ha-graceful-switchover-ipoe.clab.yml
+++ b/tests/37-ha-graceful-switchover-ipoe/37-ha-graceful-switchover-ipoe.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 
@@ -41,8 +39,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng2/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/38-l2gw-static/38-l2gw-static.clab.yml
+++ b/tests/38-l2gw-static/38-l2gw-static.clab.yml
@@ -23,8 +23,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/39-l2gw-dynamic/39-l2gw-dynamic.clab.yml
+++ b/tests/39-l2gw-dynamic/39-l2gw-dynamic.clab.yml
@@ -23,8 +23,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/40-l2gw-packet-trigger/40-l2gw-packet-trigger.clab.yml
+++ b/tests/40-l2gw-packet-trigger/40-l2gw-packet-trigger.clab.yml
@@ -23,8 +23,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/40-l2gw-vxlan/40-l2gw-vxlan.clab.yml
+++ b/tests/40-l2gw-vxlan/40-l2gw-vxlan.clab.yml
@@ -28,8 +28,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/42-ipoe-vxlan-pwhe/42-ipoe-vxlan-pwhe.clab.yml
+++ b/tests/42-ipoe-vxlan-pwhe/42-ipoe-vxlan-pwhe.clab.yml
@@ -29,8 +29,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "2"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/43-pppoe-vxlan-pwhe/43-pppoe-vxlan-pwhe.clab.yml
+++ b/tests/43-pppoe-vxlan-pwhe/43-pppoe-vxlan-pwhe.clab.yml
@@ -29,8 +29,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "2"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/44-lac-vxlan-pwhe/44-lac-vxlan-pwhe.clab.yml
+++ b/tests/44-lac-vxlan-pwhe/44-lac-vxlan-pwhe.clab.yml
@@ -29,8 +29,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/45-ha-pwhe-ipoe/45-ha-pwhe-ipoe.clab.yml
+++ b/tests/45-ha-pwhe-ipoe/45-ha-pwhe-ipoe.clab.yml
@@ -32,8 +32,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "2"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
@@ -51,8 +49,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "2"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng2/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/46-l2gw-evpn/46-l2gw-evpn.clab.yml
+++ b/tests/46-l2gw-evpn/46-l2gw-evpn.clab.yml
@@ -31,8 +31,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "2"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/47-ipoe-evpn-pwhe/47-ipoe-evpn-pwhe.clab.yml
+++ b/tests/47-ipoe-evpn-pwhe/47-ipoe-evpn-pwhe.clab.yml
@@ -30,8 +30,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "2"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/48-pppoe-evpn-pwhe/48-pppoe-evpn-pwhe.clab.yml
+++ b/tests/48-pppoe-evpn-pwhe/48-pppoe-evpn-pwhe.clab.yml
@@ -30,8 +30,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "2"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/49-lac-evpn-pwhe/49-lac-evpn-pwhe.clab.yml
+++ b/tests/49-lac-evpn-pwhe/49-lac-evpn-pwhe.clab.yml
@@ -30,8 +30,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/50-ha-evpn-pwhe/50-ha-evpn-pwhe.clab.yml
+++ b/tests/50-ha-evpn-pwhe/50-ha-evpn-pwhe.clab.yml
@@ -32,8 +32,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "2"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
@@ -51,8 +49,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "2"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng2/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/51-ipoe-hqos-svlan/51-ipoe-hqos-svlan.clab.yml
+++ b/tests/51-ipoe-hqos-svlan/51-ipoe-hqos-svlan.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/52-pppoe-hqos-svlan/52-pppoe-hqos-svlan.clab.yml
+++ b/tests/52-pppoe-hqos-svlan/52-pppoe-hqos-svlan.clab.yml
@@ -24,8 +24,6 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 


### PR DESCRIPTION
## Problem

Pinning every lab's dataplane to cores 1-2 (#466) moved the oversubscription instead of removing it: with five concurrent labs, up to seven VPP instances busy-poll the same two host cores while the rest of the box idles. Sweep 32062082757 failed four session-establishment-sensitive suites (14, 16, 43, 48) that pass under the auto layout, whose whole-box spread at least distributes the polling. VPP always pins its worker threads, so a capped-but-kernel-balanced layout is not expressible with the current knobs; per-lab core staggering needs the rig to know its concurrency, which topologies cannot.

## Change

Revert of #466. The auto layout returns; the cgnat PBA suites keep their pre-existing pins as before.

## Verification

The previous sweep (32056764011) ran 46 of 47 suites green under the auto layout; the reverted-to state is that one. The right-sizing problem moves to the queue with the constraint recorded: it needs either per-run core assignment from the CI layer or an unpinned worker mode in the dataplane config.