### PR TITLE
test: per-runner core slots so concurrent labs never share a polling core

### DIFF
--- a/pkg/config/cpu.go
+++ b/pkg/config/cpu.go
@@ -53,19 +53,24 @@ func ResolveCPULayout(cfg *Config) *ResolvedCPU {
 		}
 	}
 
-	// Priority for workers: YAML config > env var > auto-layout
+	// Priority for workers: YAML config > env var > auto-layout. The
+	// explicit value "auto" selects the auto layout: environments that
+	// template the env var (containerlab expands ${VAR:=auto} in test
+	// topologies) need a value that means "unset", because containerlab
+	// passes the unexpanded literal through when the variable is empty.
 	if cfg.Dataplane.Workers != "" {
 		resolved.WorkerCores = cfg.Dataplane.Workers
-	} else if v := os.Getenv("OSVBNG_DP_WORKER_CORES"); v != "" {
+	} else if v := os.Getenv("OSVBNG_DP_WORKER_CORES"); v != "" && v != "auto" {
 		resolved.WorkerCores = v
 	} else {
 		resolved.WorkerCores = autoWorkerCores(total)
 	}
 
-	// Priority for CP cores: YAML config > env var > auto-layout
+	// Priority for CP cores: YAML config > env var > auto-layout, with
+	// the same "auto" vocabulary as the workers.
 	if cfg.Dataplane.CPCores != "" {
 		resolved.CPCores = cfg.Dataplane.CPCores
-	} else if v := os.Getenv("OSVBNG_CP_CORES"); v != "" {
+	} else if v := os.Getenv("OSVBNG_CP_CORES"); v != "" && v != "auto" {
 		resolved.CPCores = v
 	} else {
 		resolved.CPCores = autoCPCores(total)

--- a/pkg/config/cpu_test.go
+++ b/pkg/config/cpu_test.go
@@ -85,3 +85,25 @@ func TestResolveCPCoresPriority(t *testing.T) {
 		t.Errorf("CPCoreCount() = %d, want 4", n)
 	}
 }
+
+func TestResolveAutoSentinel(t *testing.T) {
+	cfg := &Config{}
+
+	t.Setenv("OSVBNG_DP_WORKER_CORES", "auto")
+	t.Setenv("OSVBNG_CP_CORES", "auto")
+	r := ResolveCPULayout(cfg)
+	total := DetectAvailableCores()
+	if r.WorkerCores != autoWorkerCores(total) {
+		t.Errorf("worker auto sentinel: got %q, want auto layout %q", r.WorkerCores, autoWorkerCores(total))
+	}
+	if r.CPCores != autoCPCores(total) {
+		t.Errorf("cp auto sentinel: got %q, want auto layout %q", r.CPCores, autoCPCores(total))
+	}
+
+	t.Setenv("OSVBNG_DP_WORKER_CORES", "7-8")
+	t.Setenv("OSVBNG_CP_CORES", "9")
+	r = ResolveCPULayout(cfg)
+	if r.WorkerCores != "7-8" || r.CPCores != "9" {
+		t.Errorf("slot values: got %q/%q, want 7-8/9", r.WorkerCores, r.CPCores)
+	}
+}

--- a/test-infra/runner/roles/runner/tasks/register.yml
+++ b/test-infra/runner/roles/runner/tasks/register.yml
@@ -49,6 +49,22 @@
   changed_when: true
   no_log: true
 
+# Each instance owns a disjoint host core slot, exported to every job
+# so containerlab can expand it into the test topologies: concurrent
+# labs then never share a VPP polling core (todo item 16). Three cores
+# per slot, core 0 left for the VPP main threads; runner_count 5 on a
+# 16-core box fills cores 1-15 exactly.
+- name: "Write job environment for shared-{{ instance_no }}"
+  ansible.builtin.copy:
+    dest: "/opt/runner-shared-{{ instance_no }}/.env"
+    owner: runner
+    group: runner
+    mode: "0644"
+    content: |
+      LANG=en_GB.UTF-8
+      OSVBNG_LAB_WORKER_CORES={{ 3 * instance_no - 2 }}-{{ 3 * instance_no - 1 }}
+      OSVBNG_LAB_CP_CORES={{ 3 * instance_no }}
+
 - name: "Install runner service for shared-{{ instance_no }}"
   ansible.builtin.command:
     chdir: "/opt/runner-shared-{{ instance_no }}"

--- a/tests/01-smoke/01-smoke.clab.yml
+++ b/tests/01-smoke/01-smoke.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/02-smoke-ha/02-smoke-ha.clab.yml
+++ b/tests/02-smoke-ha/02-smoke-ha.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 
@@ -39,6 +41,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng2/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/03-ipoe-local/03-ipoe-local.clab.yml
+++ b/tests/03-ipoe-local/03-ipoe-local.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/04-pppoe-local/04-pppoe-local.clab.yml
+++ b/tests/04-pppoe-local/04-pppoe-local.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/05-ipoe-radius/05-ipoe-radius.clab.yml
+++ b/tests/05-ipoe-radius/05-ipoe-radius.clab.yml
@@ -23,6 +23,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/06-pppoe-radius/06-pppoe-radius.clab.yml
+++ b/tests/06-pppoe-radius/06-pppoe-radius.clab.yml
@@ -23,6 +23,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/07-dhcp-relay-proxy/07-dhcp-relay-proxy.clab.yml
+++ b/tests/07-dhcp-relay-proxy/07-dhcp-relay-proxy.clab.yml
@@ -23,6 +23,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/08-cgnat-ipoe-pba/08-cgnat-ipoe-pba.clab.yml
+++ b/tests/08-cgnat-ipoe-pba/08-cgnat-ipoe-pba.clab.yml
@@ -24,8 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/09-cgnat-ipoe-det/09-cgnat-ipoe-det.clab.yml
+++ b/tests/09-cgnat-ipoe-det/09-cgnat-ipoe-det.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/10-cgnat-pppoe-pba/10-cgnat-pppoe-pba.clab.yml
+++ b/tests/10-cgnat-pppoe-pba/10-cgnat-pppoe-pba.clab.yml
@@ -24,8 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
-        OSVBNG_DP_WORKER_CORES: "1-2"
-        OSVBNG_CP_CORES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/11-cgnat-pppoe-det/11-cgnat-pppoe-det.clab.yml
+++ b/tests/11-cgnat-pppoe-det/11-cgnat-pppoe-det.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/12-cgnat-ha-ipoe-pba/12-cgnat-ha-ipoe-pba.clab.yml
+++ b/tests/12-cgnat-ha-ipoe-pba/12-cgnat-ha-ipoe-pba.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 
@@ -39,6 +41,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng2/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/13-cgnat-ha-pppoe-pba/13-cgnat-ha-pppoe-pba.clab.yml
+++ b/tests/13-cgnat-ha-pppoe-pba/13-cgnat-ha-pppoe-pba.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 
@@ -39,6 +41,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng2/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/14-ha-failover-ipoe/14-ha-failover-ipoe.clab.yml
+++ b/tests/14-ha-failover-ipoe/14-ha-failover-ipoe.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 
@@ -39,6 +41,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng2/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/15-ha-failover-pppoe/15-ha-failover-pppoe.clab.yml
+++ b/tests/15-ha-failover-pppoe/15-ha-failover-pppoe.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 
@@ -39,6 +41,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng2/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/16-ha-failover-radius-ipoe/16-ha-failover-radius-ipoe.clab.yml
+++ b/tests/16-ha-failover-radius-ipoe/16-ha-failover-radius-ipoe.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 
@@ -39,6 +41,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng2/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/17-ha-tracker-promotion-ipoe/17-ha-tracker-promotion-ipoe.clab.yml
+++ b/tests/17-ha-tracker-promotion-ipoe/17-ha-tracker-promotion-ipoe.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 
@@ -39,6 +41,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng2/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/18-ipoe-linux-client/18-ipoe-linux-client.clab.yml
+++ b/tests/18-ipoe-linux-client/18-ipoe-linux-client.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/19-ipoe-linux-client-cake/19-ipoe-linux-client-cake.clab.yml
+++ b/tests/19-ipoe-linux-client-cake/19-ipoe-linux-client-cake.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/20-routing-policy/20-routing-policy.clab.yml
+++ b/tests/20-routing-policy/20-routing-policy.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/21-cli-openapi/21-cli-openapi.clab.yml
+++ b/tests/21-cli-openapi/21-cli-openapi.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/22-mss-clamp/22-mss-clamp.clab.yml
+++ b/tests/22-mss-clamp/22-mss-clamp.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/23-radius-coa/23-radius-coa.clab.yml
+++ b/tests/23-radius-coa/23-radius-coa.clab.yml
@@ -23,6 +23,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/24-vrf-lite/24-vrf-lite.clab.yml
+++ b/tests/24-vrf-lite/24-vrf-lite.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/25-l3vpn/25-l3vpn.clab.yml
+++ b/tests/25-l3vpn/25-l3vpn.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/26-dhcpv6-ldra/26-dhcpv6-ldra.clab.yml
+++ b/tests/26-dhcpv6-ldra/26-dhcpv6-ldra.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/27-api-pagination/27-api-pagination.clab.yml
+++ b/tests/27-api-pagination/27-api-pagination.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/28-northbound-api-tls/28-northbound-api-tls.clab.yml
+++ b/tests/28-northbound-api-tls/28-northbound-api-tls.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
         - config/certs:/etc/osvbng/certs:ro

--- a/tests/29-radius-vrf/29-radius-vrf.clab.yml
+++ b/tests/29-radius-vrf/29-radius-vrf.clab.yml
@@ -23,6 +23,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/30-l2tp-lns/30-l2tp-lns.clab.yml
+++ b/tests/30-l2tp-lns/30-l2tp-lns.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "1"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/31-l2tp-lac/31-l2tp-lac.clab.yml
+++ b/tests/31-l2tp-lac/31-l2tp-lac.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/32-ipoe-opdb-restore/32-ipoe-opdb-restore.clab.yml
+++ b/tests/32-ipoe-opdb-restore/32-ipoe-opdb-restore.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/33-pppoe-opdb-restore/33-pppoe-opdb-restore.clab.yml
+++ b/tests/33-pppoe-opdb-restore/33-pppoe-opdb-restore.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/34-cgnat-restart-idempotent/34-cgnat-restart-idempotent.clab.yml
+++ b/tests/34-cgnat-restart-idempotent/34-cgnat-restart-idempotent.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/35-ipoe-family-disabled/35-ipoe-family-disabled.clab.yml
+++ b/tests/35-ipoe-family-disabled/35-ipoe-family-disabled.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/36-aaa-empty-username/36-aaa-empty-username.clab.yml
+++ b/tests/36-aaa-empty-username/36-aaa-empty-username.clab.yml
@@ -23,6 +23,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/37-ha-graceful-switchover-ipoe/37-ha-graceful-switchover-ipoe.clab.yml
+++ b/tests/37-ha-graceful-switchover-ipoe/37-ha-graceful-switchover-ipoe.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 
@@ -39,6 +41,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng2/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/38-l2gw-static/38-l2gw-static.clab.yml
+++ b/tests/38-l2gw-static/38-l2gw-static.clab.yml
@@ -23,6 +23,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/39-l2gw-dynamic/39-l2gw-dynamic.clab.yml
+++ b/tests/39-l2gw-dynamic/39-l2gw-dynamic.clab.yml
@@ -23,6 +23,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/40-l2gw-packet-trigger/40-l2gw-packet-trigger.clab.yml
+++ b/tests/40-l2gw-packet-trigger/40-l2gw-packet-trigger.clab.yml
@@ -23,6 +23,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/40-l2gw-vxlan/40-l2gw-vxlan.clab.yml
+++ b/tests/40-l2gw-vxlan/40-l2gw-vxlan.clab.yml
@@ -28,6 +28,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/42-ipoe-vxlan-pwhe/42-ipoe-vxlan-pwhe.clab.yml
+++ b/tests/42-ipoe-vxlan-pwhe/42-ipoe-vxlan-pwhe.clab.yml
@@ -29,6 +29,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "2"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/43-pppoe-vxlan-pwhe/43-pppoe-vxlan-pwhe.clab.yml
+++ b/tests/43-pppoe-vxlan-pwhe/43-pppoe-vxlan-pwhe.clab.yml
@@ -29,6 +29,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "2"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/44-lac-vxlan-pwhe/44-lac-vxlan-pwhe.clab.yml
+++ b/tests/44-lac-vxlan-pwhe/44-lac-vxlan-pwhe.clab.yml
@@ -29,6 +29,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/45-ha-pwhe-ipoe/45-ha-pwhe-ipoe.clab.yml
+++ b/tests/45-ha-pwhe-ipoe/45-ha-pwhe-ipoe.clab.yml
@@ -32,6 +32,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "2"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
@@ -49,6 +51,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "2"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng2/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/46-l2gw-evpn/46-l2gw-evpn.clab.yml
+++ b/tests/46-l2gw-evpn/46-l2gw-evpn.clab.yml
@@ -31,6 +31,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "2"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/47-ipoe-evpn-pwhe/47-ipoe-evpn-pwhe.clab.yml
+++ b/tests/47-ipoe-evpn-pwhe/47-ipoe-evpn-pwhe.clab.yml
@@ -30,6 +30,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "2"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/48-pppoe-evpn-pwhe/48-pppoe-evpn-pwhe.clab.yml
+++ b/tests/48-pppoe-evpn-pwhe/48-pppoe-evpn-pwhe.clab.yml
@@ -30,6 +30,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "2"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/49-lac-evpn-pwhe/49-lac-evpn-pwhe.clab.yml
+++ b/tests/49-lac-evpn-pwhe/49-lac-evpn-pwhe.clab.yml
@@ -30,6 +30,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/50-ha-evpn-pwhe/50-ha-evpn-pwhe.clab.yml
+++ b/tests/50-ha-evpn-pwhe/50-ha-evpn-pwhe.clab.yml
@@ -32,6 +32,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "2"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
@@ -49,6 +51,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "2"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
         OSVBNG_RESPAWN: "true"
       binds:
         - config/bng2/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro

--- a/tests/51-ipoe-hqos-svlan/51-ipoe-hqos-svlan.clab.yml
+++ b/tests/51-ipoe-hqos-svlan/51-ipoe-hqos-svlan.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/52-pppoe-hqos-svlan/52-pppoe-hqos-svlan.clab.yml
+++ b/tests/52-pppoe-hqos-svlan/52-pppoe-hqos-svlan.clab.yml
@@ -24,6 +24,8 @@ topology:
       env:
         OSVBNG_WAIT_FOR_INTERFACES: "true"
         OSVBNG_NUM_INTERFACES: "3"
+        OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+        OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
       binds:
         - config/bng1/osvbng.yaml:/etc/osvbng/osvbng.yaml:ro
 

--- a/tests/common.robot
+++ b/tests/common.robot
@@ -9,7 +9,10 @@ Library             Process
 Library             Collections
 
 *** Variables ***
-${CLAB_BIN}             sudo containerlab
+# preserve-env carries the CI runner's per-slot core assignment through
+# sudo so containerlab can expand it in the topologies; unset locally,
+# where the ${VAR:=auto} defaults select the auto layout.
+${CLAB_BIN}             sudo --preserve-env=OSVBNG_LAB_WORKER_CORES,OSVBNG_LAB_CP_CORES containerlab
 ${runtime}              docker
 ${OSVBNG_API_PORT}      8080
 # 300 x 1s keeps the same 5-minute budget as the previous 60 x 5s but


### PR DESCRIPTION
## Problem

The auto CPU layout gives every lab total minus 3 pinned VPP workers, so five concurrent labs busy-poll about five times more threads than the box has cores and session bring-up starves probabilistically: which suites fail flips between sweeps (52 in 32056764011; 43 and 48 in 32066433335). Pinning every lab to the same two cores (#466, reverted in #467) concentrated the polling instead, and VPP cannot run unpinned workers, so the assignment has to come from the layer that knows the concurrency: the runner.

## Change

Each runner instance exports a disjoint three-core slot (workers 3N-2 to 3N-1, control plane 3N; five slots fill cores 1-15 of the 16-core box, core 0 stays for VPP main threads) through its .env file, written by the ansible role. Every test topology templates the two env vars with containerlab expansion, defaulting to the value auto, which ResolveCPULayout now honors as select-the-auto-layout: containerlab passes the unexpanded literal through when a variable is empty, so unset needs a non-empty sentinel. The deploy keyword carries the slot through sudo with preserve-env. Local runs are unchanged: no slot set, auto expands, auto layout resolves.

## Verification

Unit test for the auto sentinel and the slot override. Live on this box: slotted deploy renders corelist-workers 7-8 and CP core 9 in the container's dataplane.conf and cpu-layout.env; unslotted deploy renders the auto layout 1-21; a full suite 01 robot run passes with a slot exported end to end through the preserve-env chain. The runner .env files are already live on the box with the same values ansible now manages. Not verified: a full sweep on the slots; the next dispatch is the proof.