### PR TITLE
fix(ci): record the swept state on the rig, not in an actions variable

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,10 +7,17 @@
 # fix forward or revert before merging anything else, while the
 # failure still implicates at most a day of merges. The sweep is
 # skipped when nothing changed: the pair (osvbng HEAD, dataplane
-# provenance commit) is compared against the NIGHTLY_LAST repo
-# variable recorded by the previous successful sweep, so an
-# osvbng-vpp merge alone still triggers a run, since it changes what
-# is under test.
+# provenance commit) is compared against the state the previous
+# successful sweep recorded, so an osvbng-vpp merge alone still
+# triggers a run, since it changes what is under test.
+#
+# That state lives on the rig box, not in an Actions variable:
+# GITHUB_TOKEN cannot read or write repository variables (both return
+# 403, probed on this repo), there is no workflow permissions key
+# that grants it, and the read was masked by a fallback that made
+# every night look changed. The box that ran the sweep is also the
+# honest owner of the record. Losing the box loses the record, which
+# costs one extra full sweep - the safe direction.
 
 name: nightly
 
@@ -21,19 +28,40 @@ on:
 
 permissions:
   contents: read
-  actions: write
+
+env:
+  # The record the sweep writes and the next night compares against.
+  # Outside /var/log/osvbng-ci deliberately: that tree is pruned at
+  # 7 days, and a quiet week would delete the record.
+  STATE_FILE: /var/lib/osvbng-ci/nightly-last
 
 jobs:
+  # Runs on the rig because the record it reads is on the rig's disk.
+  # It claims a runner slot for seconds and takes no rig lock: it
+  # deploys nothing.
   changes:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, osvbng-metal]
     outputs:
       current: ${{ steps.check.outputs.current }}
       changed: ${{ steps.check.outputs.changed }}
       suites: ${{ steps.list.outputs.suites }}
     steps:
-      - uses: actions/checkout@v4
+      # Plain git for the same reason suite-run uses it: action
+      # tarballs come from codeload, which rate-limits this box.
+      - name: Checkout
+        run: |
+          git init -q .
+          sudo chown -R "$(id -u):$(id -g)" .
+          git remote remove origin 2>/dev/null || true
+          git remote add origin "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}"
+          git fetch -q --depth 1 origin "$GITHUB_SHA"
+          git checkout -q -f FETCH_HEAD
+          git clean -qfdx
+          git remote set-url origin "https://github.com/${{ github.repository }}"
+
       - id: list
         run: echo "suites=$(./scripts/list-qa-suites.sh --all)" >> "$GITHUB_OUTPUT"
+
       - id: check
         env:
           GH_TOKEN: ${{ github.token }}
@@ -42,11 +70,13 @@ jobs:
             --json body -q .body | grep -oE 'from [0-9a-f]{40}' | awk '{print $2}')
           test -n "$dp"
           current="${GITHUB_SHA}:${dp}"
-          last=$(gh variable get NIGHTLY_LAST --repo "$GITHUB_REPOSITORY" 2>/dev/null || echo none)
+          last=$(cat "$STATE_FILE" 2>/dev/null || echo none)
           echo "current=$current" >> "$GITHUB_OUTPUT"
+          echo "current: $current"
+          echo "last swept: $last"
           if [ "$current" = "$last" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "no changes since last successful sweep ($last), skipping"
+            echo "no changes since the last successful sweep, skipping"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
@@ -66,11 +96,12 @@ jobs:
   record:
     needs: [changes, run]
     if: needs.run.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, osvbng-metal]
     steps:
       - name: Record swept state
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
-          gh variable set NIGHTLY_LAST --repo "$GITHUB_REPOSITORY" \
-            --body "${{ needs.changes.outputs.current }}"
+          sudo install -d -m 0755 "$(dirname "$STATE_FILE")"
+          printf '%s\n' "${{ needs.changes.outputs.current }}" \
+            | sudo tee "$STATE_FILE" >/dev/null
+          sudo chmod 0644 "$STATE_FILE"
+          echo "recorded: $(cat "$STATE_FILE")"


### PR DESCRIPTION
## Problem

The nightly's record job fails: `gh variable set NIGHTLY_LAST` returns HTTP 403 Resource not accessible by integration (run 32069903182, after all 47 suites passed). GITHUB_TOKEN cannot manage Actions variables, and there is no workflow permissions key that grants it: the permissions block has no variables scope, and actions: write covers runs, artifacts and caches only. Probed on this repo with a throwaway push-triggered workflow: read and write both 403, and the read failed against a variable that exists, so it is the permission and not the value.

The read was worse than the write, because it was masked. `gh variable get ... || echo none` turned a permanent 403 into the string none, which never equals the current pair, so every night looked changed. Change detection has never worked in either direction since it was written: the skip path was dead code and the record path could not have run once.

## Change

The record moves to the rig box, at /var/lib/osvbng-ci/nightly-last, written by the record job and read by the changes job. Both jobs move to the self-hosted runner as a consequence; changes takes no rig lock, since it deploys nothing, and uses the same plain-git checkout as suite-run for the same codeload rate-limit reason. The path sits outside /var/log/osvbng-ci deliberately: that tree is pruned at 7 days and a quiet week would delete the record. The workflow drops actions: write, which only existed for the variable call.

The box that ran the sweep is the honest owner of the record, the same reasoning that moved the dataplane artifact handoff on-box in osvbng-vpp#20. Losing the box loses the record, which costs one extra full sweep: the safe direction.

## Verification

The 403 on read and write is proven by the probe run described above. The exact record and read commands were run on the rig as the runner user: the install, tee and chmod succeed under the runner's sudo rights and the file is readable without sudo (0644 root-owned). The state file is seeded with the pair sweep 32069903182 actually swept, so the first run of this workflow compares against real history rather than a cold start. Not verified end to end in CI yet: tonight's scheduled nightly exercises both jobs, and it will run a full sweep because main has moved since that sweep, which is the correct answer.

The vestigial NIGHTLY_LAST repo variable is removed separately; nothing can read it.