### PR TITLE
fix(docker): treat the auto core sentinel as unset before taskset

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -155,7 +155,18 @@ ip netns exec dataplane /usr/lib/frr/frrinit.sh status || true
 
 echo "Starting osvbng..."
 
+# "auto" is the same sentinel osvbngd's CPU resolution understands: it
+# means "no explicit set, use the auto layout". The test topologies
+# always pass the variable and default it to auto, because containerlab
+# emits the unexpanded literal when a variable is empty, so an unset
+# slot arrives here as the string auto rather than as an empty value.
+# Taking it verbatim would run taskset -c auto, which fails to parse and
+# leaves osvbngd unstarted; the resolved layout osvbngd already computed
+# is what to pin to.
 RESOLVED_CP="${OSVBNG_CP_CORES:-$OSVBNG_RESOLVED_CP_CORES}"
+if [ "$RESOLVED_CP" = "auto" ]; then
+    RESOLVED_CP="$OSVBNG_RESOLVED_CP_CORES"
+fi
 
 start_osvbngd() {
     if [ -n "$RESOLVED_CP" ]; then


### PR DESCRIPTION
## Problem

Every suite run outside CI is broken on current main: osvbngd never starts, the health wait burns its full 300 retries, and every later assertion fails with curl exit 7. Introduced by #468.

The test topologies pass the core slot as `${OSVBNG_LAB_CP_CORES:=auto}` because containerlab emits the unexpanded literal when a variable is empty, so an unset slot has to arrive as a non-empty sentinel. osvbngd's CPU resolution understands `auto` and correctly resolves the auto layout, writing cp=22-23 into /run/osvbng/cpu-layout.env. The entrypoint does not: it takes OSVBNG_CP_CORES verbatim, so it runs `taskset -c auto osvbngd`, taskset exits with "failed to parse CPU list: auto", and the daemon is never launched.

CI missed it because the runners export real core numbers, so the sentinel never reaches taskset there; sweep 32069903182 went 47 of 47 green on exactly the code path that is broken locally. #468 verified that the auto path renders the right corelist in dataplane.conf, which is written by generate-external before osvbngd starts, and stopped one step short of verifying the daemon actually came up.

## Change

The entrypoint resolves the sentinel the same way osvbngd does: `auto` means no explicit set, so pin to the layout osvbngd already resolved rather than to the literal.

## Verification

Live on this box, both paths, same image: suite 01 passes with no slot set (auto path, previously dead) and passes with OSVBNG_LAB_WORKER_CORES=4-5 OSVBNG_LAB_CP_CORES=6 exported (slot path, what CI does). Confirmed the mechanism directly before the fix: `taskset -c auto /bin/true` fails in the container while cpu-layout.env holds the correctly resolved cp=22-23.