### PR TITLE
ci: keep container logs when a suite fails

### DIFF
--- a/.github/workflows/suite-run.yml
+++ b/.github/workflows/suite-run.yml
@@ -180,6 +180,22 @@ jobs:
       - name: Run ${{ matrix.suite }}
         run: ./scripts/run-qa-tests.sh -r ${{ inputs.runs }} -t ${{ matrix.suite }}
 
+      # Robot says which assertion failed; the daemon says why. This runs
+      # before the destroy below, while the lab still exists, because
+      # docker logs are gone with the containers. Failure only: a green
+      # suite's logs are noise. Without this, a product-side failure on
+      # the rig can only be chased by reproducing it locally, and the
+      # contention-sensitive ones do not reproduce on an idle box.
+      - name: Keep container logs on failure
+        if: failure()
+        run: |
+          d="/var/log/osvbng-ci/${{ github.run_id }}/${{ matrix.suite }}"
+          sudo mkdir -p "$d"
+          for c in $(sudo docker ps -a --filter "name=clab-" --format '{{.Names}}'); do
+            sudo sh -c "docker logs '$c' > '$d/$c.log' 2>&1" || true
+          done
+          sudo sh -c "docker ps -a --filter name=clab- > '$d/containers.txt'" || true
+
       # A cancelled job kills robot before its suite teardown but not
       # the root-owned sudo children, and an orphaned deploy holds
       # containerlab's locks against every later deploy of that lab.


### PR DESCRIPTION
## Problem

The rig's evidence store keeps Robot's output.xml and log.html, which say which assertion failed, and nothing that says why. Diagnosing a product-side failure then means reproducing it locally, and the failures that most need diagnosis are the contention-sensitive ones that do not reproduce on an idle box. Sweep 32091233399 failed 47-ipoe-evpn-pwhe with one session restored instead of two; the same suite then passed five consecutive local runs, and the daemon log that would have explained it was destroyed with the lab.

## Change

On failure only, before the destroy step, copy every clab container's docker logs and a container listing into the run's evidence directory. Ordering is load-bearing: the destroy step already runs before the existing evidence copy, so a capture placed alongside that copy would find no containers. Failure only, because a green suite's logs are noise and the store is pruned at seven days.

## Verification

The capture commands were run on the rig as the runner user (the account the jobs use) and write correctly under its sudo rights, and the docker logs form was exercised against a live container locally, producing the expected content. yaml parses, and the step order is now run, capture, destroy, keep-robot-output. The step is skipped on green runs by construction, so the next red suite is its first live exercise.