### PR TITLE
ci: capture container logs when a suite times out, not just when it fails

### DIFF
--- a/.github/workflows/suite-run.yml
+++ b/.github/workflows/suite-run.yml
@@ -186,8 +186,12 @@ jobs:
       # suite's logs are noise. Without this, a product-side failure on
       # the rig can only be chased by reproducing it locally, and the
       # contention-sensitive ones do not reproduce on an idle box.
+      # cancelled() as well as failure(): exceeding timeout-minutes
+      # cancels the job rather than failing it, so a failure()-only
+      # condition skips exactly the case that most needs a log, a suite
+      # that hung. A user-cancelled run captures too, which is cheap.
       - name: Keep container logs on failure
-        if: failure()
+        if: failure() || cancelled()
         run: |
           d="/var/log/osvbng-ci/${{ github.run_id }}/${{ matrix.suite }}"
           sudo mkdir -p "$d"


### PR DESCRIPTION
## Problem

The container-log capture added in #472 is conditioned on `failure()`, which GitHub does not evaluate as true for a job killed by `timeout-minutes`: exceeding the budget cancels the job rather than failing it. The capture therefore skips exactly the case that most needs a log, a suite that hung with no assertion output to explain it.

That case is not hypothetical. `02-smoke-ha` and `15-ha-failover-pppoe` have now hung to the 12 minute cap twice, in integration run 32081724518 and sweep 32093225266, both times at 12m17s and both times in the first batch of suites after the image build. Both pass in about 80 seconds when re-run on an idle box. There is currently no evidence to explain the difference.

## Change

The condition becomes `failure() || cancelled()`. A user-cancelled run also captures, which costs a few log files.

## Verification

yaml parses. The capture commands themselves were verified in #472 (run on the rig as the runner user, and against a live container locally). This change is the step condition only; its first live exercise is the next suite that hangs or is cancelled.

## Note

This does not address why those two suites hang, only the fact that they do so invisibly. An HA suite runs two BNGs in one job and both inherit the same runner's three-core slot, so four busy-polling VPP worker threads land on two cores; that is a hypothesis the captured logs should confirm or kill.