### PR TITLE
docs(contributing): document the ci tiers, the rig, and suite invariants

### DIFF
--- a/docs/contributing/ci-and-review.md
+++ b/docs/contributing/ci-and-review.md
@@ -1,0 +1,224 @@
+# CI and Review
+
+This page describes what happens to a pull request after you open it:
+which checks run, where they run, and what a reviewer looks for. If you
+are adding an integration suite or changing the dataplane, the sections
+on suite invariants and on osvbng-vpp are the ones that will save you a
+round trip.
+
+## What runs on your pull request
+
+Two workflows run against a PR.
+
+**CI** runs on GitHub hosted runners: `make build`, the unit tests, and a
+changed-file summary. It is fast and it is the gate that fails most
+often, usually on a compile error in a package you did not expect to
+touch.
+
+**integration** runs on the project's self-hosted rig. It deploys the
+core suite set listed in `tests/ci-suites.txt`, currently fifteen
+containerlab topologies driven by BNG Blaster and Robot Framework,
+against an image built from your branch. It takes roughly twelve
+minutes when the rig is free.
+
+Linting is not in either workflow. Run `make lint` yourself before you
+push.
+
+!!! note "Fork pull requests wait for approval"
+    A PR from a fork executes your branch's code on the shared rig, so
+    its workflow runs land in the `action_required` state until a
+    maintainer approves them. Nothing is wrong with your PR when you see
+    that; it is waiting for a person. The same applies to every push you
+    make afterwards.
+
+## The three tiers
+
+| Tier | Trigger | Scope | Purpose |
+|------|---------|-------|---------|
+| Per-PR (`integration`) | every PR to `main` | core set from `tests/ci-suites.txt` | fast signal before merge |
+| Nightly (`nightly`) | 02:00 UTC, or manual dispatch | every suite `scripts/list-qa-suites.sh --all` generates, minus `tests/skip-suites.txt` | catch what the core set does not cover |
+| Release qualification | manual, before a release | the full matrix, repeated | shake out flakes before shipping |
+
+The per-PR set is a subset by choice, not by accident: suites fan out
+across the rig's runner slots in waves, so the full matrix costs about
+seven minutes more than the core set on an idle box, and considerably
+more when several PRs queue behind each other. The tradeoff is that a
+change to a subsystem outside the core set gets no integration signal on
+the PR itself. If your change touches one of those areas, run the
+relevant suite locally and say so in the PR.
+
+The nightly skips itself when nothing has changed. It compares the pair
+(osvbng `main` commit, dataplane provenance commit) against the record
+the last successful sweep wrote on the rig. A merge to osvbng-vpp alone
+still triggers a sweep, because it changes what is under test.
+
+## The rig
+
+One machine, five runner slots. Suite jobs across all tiers serialise on
+a shared concurrency group, so only one tier occupies the rig at a time
+and a second run queues rather than interleaving.
+
+Each runner slot owns a disjoint set of host CPUs, exported to the job as
+`OSVBNG_LAB_WORKER_CORES` and `OSVBNG_LAB_CP_CORES` and expanded into the
+topology by containerlab. Concurrent labs therefore never share a VPP
+polling core. Locally those variables are unset, the topologies default
+them to `auto`, and osvbng resolves its own layout from the host's core
+count.
+
+Robot output for every suite is copied to
+`/var/log/osvbng-ci/<run_id>/<suite>/` on the rig and kept for seven
+days. That copy, not an uploaded artifact, is the record: it survives a
+job that dies before its steps complete, which is exactly when you most
+want the `output.xml`.
+
+!!! warning "A suite killed at exactly twelve minutes reads as cancelled"
+    Each suite job carries a twelve minute budget (`suite_timeout`).
+    GitHub reports a job that exceeds its `timeout-minutes` as
+    **cancelled**, not failed, which looks like someone or something
+    interrupted the run. Check the job duration before hunting for an
+    external cause: twelve minutes on the nose is the timeout.
+
+## Running the suites yourself
+
+Build an image from your working tree and run one suite:
+
+```bash
+make docker-local
+./scripts/run-qa-tests.sh -r 1 -t 03-ipoe-local
+```
+
+`make docker-local` installs the dataplane from `docker/dataplane-debs/`
+when that directory holds debs, and falls back to the upstream fd.io
+packages plus the prebuilt plugins in `test-infra/vpp-plugins/` when it
+does not. To test against the same dataplane CI uses, stage the debs
+first:
+
+```bash
+for p in 'vpp_*.deb' 'vpp-plugin-core_*.deb' \
+         'vpp-plugin-dpdk_*.deb' 'libvppinfra_*.deb'; do
+  gh release download dataplane-latest -R veesix-networks/osvbng-vpp \
+    -p "$p" -D docker/dataplane-debs
+done
+```
+
+Drop `-t <suite>` to run the whole set. Robot's `output.xml` and
+`log.html` land in `tests/out/`.
+
+## Writing an integration suite
+
+New directories under `tests/` are picked up automatically by the
+nightly matrix, so a suite that is not yet reliable belongs in
+`tests/skip-suites.txt` with a reason, not merged as a red job. The
+per-PR set is the separate allowlist in `tests/ci-suites.txt`.
+
+Every topology carries a few invariants. Each exists because its absence
+caused a real failure that took hours to attribute:
+
+**Declare an IPv4-only management network.**
+
+```yaml
+mgmt:
+  ipv4-subnet: 172.20.20.0/24
+```
+
+Without an explicit subnet, containerlab creates a dual-stack management
+network, every node gets an IPv6 default route on `eth0`, and it races
+the route the test's own Router Advertisement installs. Subscriber
+originated IPv6 then leaves through management and dies, intermittently,
+in a way that looks like a dataplane bug.
+
+**Take the CPU slot from the environment.**
+
+```yaml
+env:
+  OSVBNG_DP_WORKER_CORES: "${OSVBNG_LAB_WORKER_CORES:=auto}"
+  OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
+```
+
+The `:=auto` default matters: containerlab passes the unexpanded literal
+through when a variable is empty, so "unset" has to arrive as a
+non-empty sentinel that osvbng understands. A topology without this
+grabs the auto layout on the rig, which sizes workers for a machine it
+does not own, and starves every lab running beside it.
+
+**Give shared network objects per-suite names.** Bridges, veth endpoint
+names and management subnets that collide across suites break whichever
+pair happens to run concurrently. If your topology uses static
+management addresses, give it its own `network:` name and subnet too.
+
+**Set `OSVBNG_RESPAWN: "true"`** on any node whose suite kills osvbngd,
+so the entrypoint supervises and restarts it instead of the container
+exiting.
+
+**Gate restart verification on the state file.** After restarting
+osvbngd, wait for `Wait For osvbng State Ready`, which polls
+`/run/osvbng/state` for `ready`. Do not rely on the "osvbng started
+successfully" log line alone: it survives from the previous boot, so a
+health check that greps the container log passes instantly while opdb
+recovery is still running, and the assertions that follow race it.
+
+**Stay inside twelve minutes**, including deploy, session establishment,
+any soak, and teardown. A suite that needs longer needs a deliberate
+decision about its budget, not a silent timeout.
+
+## What a reviewer looks for
+
+**The PR body states the problem first.** The house format is problem,
+then change, then verification, and the verification section says what
+was *not* covered as well as what was. A reviewer reads the problem
+statement to decide whether the change is the right shape; without it,
+review turns into archaeology.
+
+**Verification claims are reproducible.** "Suite 42 passes" is worth more
+with the run or the summary line behind it. If a claim rests on a live
+rig run, say which suites and how many times, particularly for anything
+that has flaked before.
+
+**Protocol code cites its source.** Behaviour that implements an RFC
+names the section, in the code comment as well as the PR. Recollection
+is not a source.
+
+**Generated bindings match the dataplane under test.** If your change
+regenerates `pkg/vpp/binapi/`, the message CRCs must match the plugin
+the rig actually runs. Compare against
+`/usr/share/vpp/api/plugins/<plugin>.api.json` in the built image; a
+mismatch means the API landed in osvbng-vpp after the pin moved, or the
+bindings were generated from an unmerged branch.
+
+**New suites carry the invariants above**, and the topology has been run,
+not just written.
+
+**Conflicts are resolved by the author.** `main` moves, and a stale
+branch that touches shared files (`tests/common.robot`,
+`internal/ipoe/restore.go`, the docs) will conflict. Rebase rather than
+leaving it for the person merging.
+
+## Changing the dataplane
+
+Plugin and VPP changes live in the `osvbng-vpp` repository, not here.
+The flow is:
+
+1. Open the PR against `osvbng-vpp`. Its build produces the deb set on
+   the rig, seeds the box's per-commit artifact cache, and mirrors the
+   debs to the rolling `dataplane-latest` prerelease with the source
+   commit in the release notes.
+2. If the change alters a `.api` file, regenerate the bindings in this
+   repository and open a separate PR here.
+3. Move the pin. `make bump-submodules` updates `vpp` and `context` to
+   their current `main` and stages the result; commit that as its own
+   focused PR. Pins move deliberately, so a checkout stays reproducible.
+
+Anything that is about VPP itself rather than about osvbng goes upstream
+to fd.io first, and lives in the patch queue only until it merges there.
+
+## Practical notes
+
+- Avoid opening or merging pull requests while a nightly sweep is
+  running. PR runs and the sweep share the rig's concurrency group, and
+  a run entering the queue can cancel one that is already executing.
+- `go vet ./...` reports one pre-existing failure in
+  `pkg/models/system`, a malformed struct tag that predates the current
+  test suite. It is unrelated to your change.
+- The plugin binaries committed under `test-infra/vpp-plugins/` are used
+  only by the upstream-package image path. When `docker/dataplane-debs/`
+  holds debs, the debs win and those binaries are ignored.

--- a/docs/contributing/ci-and-review.md
+++ b/docs/contributing/ci-and-review.md
@@ -39,13 +39,12 @@ push.
 | Nightly (`nightly`) | 02:00 UTC, or manual dispatch | every suite `scripts/list-qa-suites.sh --all` generates, minus `tests/skip-suites.txt` | catch what the core set does not cover |
 | Release qualification | manual, before a release | the full matrix, repeated | shake out flakes before shipping |
 
-The per-PR set is a subset by choice, not by accident: suites fan out
-across the rig's runner slots in waves, so the full matrix costs about
-seven minutes more than the core set on an idle box, and considerably
-more when several PRs queue behind each other. The tradeoff is that a
-change to a subsystem outside the core set gets no integration signal on
-the PR itself. If your change touches one of those areas, run the
-relevant suite locally and say so in the PR.
+The per-PR set is a subset by choice, not by accident: suites run several
+at a time, so the full matrix costs noticeably more wall clock than the
+core set, and more again when PRs queue behind each other. The tradeoff
+is that a change to a subsystem outside the core set gets no integration
+signal on the PR itself. If your change touches one of those areas, run
+the relevant suite locally and say so in the PR.
 
 The nightly skips itself when nothing has changed. It compares the pair
 (osvbng `main` commit, dataplane provenance commit) against the record
@@ -54,22 +53,24 @@ still triggers a sweep, because it changes what is under test.
 
 ## The rig
 
-One machine, five runner slots. Suite jobs across all tiers serialise on
-a shared concurrency group, so only one tier occupies the rig at a time
-and a second run queues rather than interleaving.
+Suites need nested virtualisation, VPP hugepages and real interface
+plumbing, so they run on project-maintained hardware rather than on
+hosted runners. Build and unit tests, and the jobs that coordinate a
+run, stay on hosted runners.
 
-Each runner slot owns a disjoint set of host CPUs, exported to the job as
-`OSVBNG_LAB_WORKER_CORES` and `OSVBNG_LAB_CP_CORES` and expanded into the
-topology by containerlab. Concurrent labs therefore never share a VPP
-polling core. Locally those variables are unset, the topologies default
-them to `auto`, and osvbng resolves its own layout from the host's core
-count.
+Capacity is finite and shared. Suite jobs across all tiers serialise on
+a concurrency group, so one tier occupies the rig at a time and a second
+run queues rather than interleaving. Several labs do run side by side,
+which is why a suite has to tolerate neighbours: CI assigns each
+concurrent lab its own CPU budget and passes it to the topology through
+the environment (see the invariant below), so labs never contend for the
+same VPP polling cores.
 
-Robot output for every suite is copied to
-`/var/log/osvbng-ci/<run_id>/<suite>/` on the rig and kept for seven
-days. That copy, not an uploaded artifact, is the record: it survives a
-job that dies before its steps complete, which is exactly when you most
-want the `output.xml`.
+Robot's `output.xml` and `log.html` for every suite, plus container logs
+from a failed one, are retained on the rig for a week. That retained copy
+is the record rather than an uploaded artifact, because it survives a job
+that dies before its steps finish, which is when you most want it. Ask a
+maintainer if you need the evidence from a red CI run.
 
 !!! warning "A suite killed at exactly twelve minutes reads as cancelled"
     Each suite job carries a twelve minute budget (`suite_timeout`).
@@ -135,11 +136,14 @@ env:
   OSVBNG_CP_CORES: "${OSVBNG_LAB_CP_CORES:=auto}"
 ```
 
-The `:=auto` default matters: containerlab passes the unexpanded literal
+CI sets those two variables to the budget it has allocated your lab. The
+`:=auto` default matters: containerlab passes the unexpanded literal
 through when a variable is empty, so "unset" has to arrive as a
-non-empty sentinel that osvbng understands. A topology without this
-grabs the auto layout on the rig, which sizes workers for a machine it
-does not own, and starves every lab running beside it.
+non-empty sentinel that osvbng understands, and `auto` is the value that
+tells it to size its own layout. Locally they are unset, so you get the
+auto layout and nothing changes. A topology that omits this takes the
+auto layout in CI too, sizing its dataplane for a machine it does not
+have to itself, and starves every lab running beside it.
 
 **Give shared network objects per-suite names.** Bridges, veth endpoint
 names and management subnets that collide across suites break whichever

--- a/docs/contributing/ci-and-review.md
+++ b/docs/contributing/ci-and-review.md
@@ -8,7 +8,8 @@ round trip.
 
 ## What runs on your pull request
 
-Two workflows run against a PR.
+Two workflows run against a PR: hosted checks, and the integration
+suites.
 
 **CI** runs on GitHub hosted runners: `make build`, the unit tests, and a
 changed-file summary. It is fast and it is the gate that fails most
@@ -16,13 +17,15 @@ often, usually on a compile error in a package you did not expect to
 touch.
 
 **integration** runs on the project's self-hosted rig. It deploys the
-core suite set listed in `tests/ci-suites.txt`, currently fifteen
-containerlab topologies driven by BNG Blaster and Robot Framework,
-against an image built from your branch. It takes roughly twelve
-minutes when the rig is free.
+core suite set listed in `tests/ci-suites.txt`, containerlab topologies
+driven by BNG Blaster and Robot Framework, against an image built from
+your branch. It is the slower of the two by a wide margin.
 
-Linting is not in either workflow. Run `make lint` yourself before you
-push.
+**lint** gates what your branch introduces, rather than the whole tree,
+so a finding it reports is one your change added. Run `make lint`
+locally before you push and you will not meet it. Note that a local
+`make lint` reports the repository's existing backlog as well as your
+own findings; CI scopes to the diff.
 
 !!! note "Fork pull requests wait for approval"
     A PR from a fork executes your branch's code on the shared rig, so
@@ -36,7 +39,7 @@ push.
 | Tier | Trigger | Scope | Purpose |
 |------|---------|-------|---------|
 | Per-PR (`integration`) | every PR to `main` | core set from `tests/ci-suites.txt` | fast signal before merge |
-| Nightly (`nightly`) | 02:00 UTC, or manual dispatch | every suite `scripts/list-qa-suites.sh --all` generates, minus `tests/skip-suites.txt` | catch what the core set does not cover |
+| Nightly (`nightly`) | scheduled daily, or manual dispatch | every suite `scripts/list-qa-suites.sh --all` generates, minus `tests/skip-suites.txt` | catch what the core set does not cover |
 | Release qualification | manual, before a release | the full matrix, repeated | shake out flakes before shipping |
 
 The per-PR set is a subset by choice, not by accident: suites run several
@@ -67,17 +70,18 @@ the environment (see the invariant below), so labs never contend for the
 same VPP polling cores.
 
 Robot's `output.xml` and `log.html` for every suite, plus container logs
-from a failed one, are retained on the rig for a week. That retained copy
+from a failed one, are retained on the rig for a limited window. That copy
 is the record rather than an uploaded artifact, because it survives a job
 that dies before its steps finish, which is when you most want it. Ask a
 maintainer if you need the evidence from a red CI run.
 
-!!! warning "A suite killed at exactly twelve minutes reads as cancelled"
-    Each suite job carries a twelve minute budget (`suite_timeout`).
-    GitHub reports a job that exceeds its `timeout-minutes` as
-    **cancelled**, not failed, which looks like someone or something
-    interrupted the run. Check the job duration before hunting for an
-    external cause: twelve minutes on the nose is the timeout.
+!!! warning "A timed-out suite reads as cancelled, not failed"
+    Each suite job carries a time budget, the `suite_timeout` input in
+    `.github/workflows/suite-run.yml`. GitHub reports a job that exceeds
+    its `timeout-minutes` as **cancelled**, which looks like someone or
+    something interrupted the run. Before hunting for an external cause,
+    compare the job's duration against that budget: a job that ran for
+    exactly the budget hit the timeout.
 
 ## Running the suites yourself
 
@@ -161,9 +165,9 @@ successfully" log line alone: it survives from the previous boot, so a
 health check that greps the container log passes instantly while opdb
 recovery is still running, and the assertions that follow race it.
 
-**Stay inside twelve minutes**, including deploy, session establishment,
-any soak, and teardown. A suite that needs longer needs a deliberate
-decision about its budget, not a silent timeout.
+**Stay inside the suite time budget**, including deploy, session
+establishment, any soak, and teardown. A suite that needs longer needs a
+deliberate decision about that budget, not a silent timeout.
 
 ## What a reviewer looks for
 

--- a/docs/contributing/guidelines.md
+++ b/docs/contributing/guidelines.md
@@ -9,15 +9,19 @@ When contributing to low-level protocol implementations (e.g., DHCP, PPPoE, RADI
 
 ## Testing Requirements
 
-CI runs build and unit tests on every PR using GitHub shared runners.
-Integration tests (containerlab + Robot Framework) run on a self-hosted
-runner only when changes are merged to main.
+CI runs build and unit tests on every PR using GitHub hosted runners. A
+core set of integration suites (containerlab + Robot Framework) also runs
+on the project's self-hosted rig for every PR, and the full matrix runs
+nightly against `main`. [CI and Review](ci-and-review.md) describes the
+tiers, the rig, and the invariants a new suite has to carry.
 
 ### Running integration tests locally
 
-GitHub shared runners cannot reliably run the integration suite due to
-nested QEMU virtualisation and resource constraints. Contributors must
-run integration tests locally before requesting a merge.
+GitHub hosted runners cannot run the integration suite due to nested
+virtualisation and resource constraints, which is why the rig exists. The
+per-PR tier covers a subset, so run the suites relevant to your change
+locally before requesting a merge, especially in areas the core set does
+not reach.
 
 Prerequisites:
 

--- a/docs/contributing/please_read_first.md
+++ b/docs/contributing/please_read_first.md
@@ -175,7 +175,7 @@ make test-report   # run tests with JUnit XML report in build/reports/
 
 **Integration tests** (`tests/`) use containerlab and robot framework to spin up a full osvbng instance with BNGBlaster subscribers, verifying end-to-end functionality across all supported features. They require Docker and take longer to run.
 
-CI runs build and unit tests on every PR using GitHub shared runners, and that is the only automated gate a PR has to clear. Integration tests run on a self-hosted runner only when changes are merged to main, so they never run against a PR. Linting is not in CI either, so run `make lint` yourself. Run the integration suites locally before requesting a merge; see [Contribution Guidelines](guidelines.md#running-integration-tests-locally).
+Every PR clears two automated gates: build and unit tests on GitHub hosted runners, and a core set of integration suites on the project's self-hosted rig. The full suite matrix runs nightly against `main` and again before a release. Linting is not in CI, so run `make lint` yourself. See [CI and Review](ci-and-review.md) for what each tier covers, and run the suites relevant to your change locally before requesting a merge; see [Contribution Guidelines](guidelines.md#running-integration-tests-locally).
 
 !!! note "Future: Hardware and QEMU testing"
     We plan to build physical and QEMU-based test infrastructure for throughput and subscriber scaling validation on minor and major releases.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,6 +116,7 @@ nav:
     - Getting Started: contributing/please_read_first.md
     - Commit Messages: contributing/commit-messages.md
     - Guidelines: contributing/guidelines.md
+    - CI and Review: contributing/ci-and-review.md
   - Roadmap:
     - Overview: roadmap/overview.md
     - Year 2026: roadmap/2026.md


### PR DESCRIPTION
## Problem

The contributor docs describe a CI model the project no longer runs. Both `please_read_first.md` and `guidelines.md` state that build and unit tests are the only gate a PR clears, and that integration tests run only after a merge to main, so they never run against a PR. Every PR now also clears a core set of integration suites on the self-hosted rig, with the full matrix nightly and again before a release. Nothing documents the rig, the tiers, or the invariants a new containerlab suite has to carry, so a contributor adding a suite has to rediscover them by failing.

## Change

A new page, CI and Review, covering what runs on a PR and where, the three tiers and why the per-PR set is deliberately a subset, how the rig allocates CPU slots and stores evidence, how to run suites locally against the same dataplane CI uses, the invariants a new suite must carry and the failure each one prevents, what a reviewer checks, and the osvbng-vpp and pin-bump flow. The two stale paragraphs are corrected to point at it, and it joins the nav.

The suite invariants are the section worth reviewing closest: the IPv4-only management network, the `:=auto` CPU slot templating, per-suite bridge and veth names, `OSVBNG_RESPAWN`, gating restart checks on the state file rather than the log line, and the twelve minute budget. Each is written with the failure it prevents, because each was learned from one.

## Verification

mkdocs.yml parses and the new page is in the nav. Prose only, no code or workflow changes. Every claim about CI behaviour is drawn from runs on this repository over the last day, including the timeout-reads-as-cancelled note and the fork-PR approval state.

## Not merged deliberately

Left open for maintainer review rather than self-merged.