### PR TITLE
chore: add the work-item issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/.github/ISSUE_TEMPLATE/work-item.yml
@@ -1,0 +1,37 @@
+name: Work item
+description: A defect or task with a known start point, as filed from a review or an audit
+body:
+  - type: textarea
+    attributes:
+      label: Problem
+      description: What is wrong or missing, what it affects, and how that was established. Lead with the problem, not the fix.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Where
+      description: Files and lines at a named commit, or documents and sections. Line numbers drift, so name the symbol too.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Done when
+      description: The observable end state, not the steps. If other issues carry part of it, name them.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Verification
+      description: How the change is shown to work against reality (which suite, rig or test) and what is deliberately not verified.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Notes
+      description: What was already tried and what blocks it, dependencies, and links to the evidence (audit record, ADR, design note).
+    validations:
+      required: false


### PR DESCRIPTION
Issues filed from reviews and audits across the three osvbng repos already share one shape, Problem, Where, Done when, Verification, Notes (osvbng #480 to #502, osvbng-vpp #23 to #30, osvbng-context #27), but only by convention. osvbng's two issue forms are written for outside reporters (bug, feature) and do not fit a work item that starts from a known line and a signed-off decision; osvbng-vpp and osvbng-context have no forms at all, so a contributor has nothing to follow.

This adds the same `work-item.yml` issue form to each repo, beside the existing forms where there are any. Problem, Where, Done when and Verification are required; Notes holds what was tried, what blocks it, and the evidence link. The existing forms are unchanged and blank issues stay enabled.

Not verified: GitHub renders issue forms from the default branch only, so the chooser entry and field rendering are checked after merge. The YAML follows the issue-forms schema used by the existing bug and feature forms.
