### PR TITLE
fix(cgnat): refuse pool config that crash-loops or silently misconfigures

### DIFF
--- a/docs/configuration/cgnat.md
+++ b/docs/configuration/cgnat.md
@@ -90,6 +90,13 @@ osvbng rejects the configuration at startup if:
 - An outside interface in any pool is also a subscriber access interface (subscriber and outside roles must not overlap on the same physical interface).
 - A pool's `outside-addresses` overlap with an IP address owned by a local interface (the BNG's own control-plane traffic would otherwise be intercepted by the NAT path).
 - A legacy top-level `outside_interface` or `outside_interfaces` field is set (the field moved into each pool block).
+- `port-range` is not `start-end`, starts at 0, or ends below its start.
+- The block size resolves to 0, or is wider than `port-range`, whether it comes from `block-size`, from `subscriber-ratio`, or from the default.
+- `mode`, `address-pooling` or `filtering` is not one of the values listed under [pool fields](#pool-fields). An unrecognised value used to fall back to the default, so a typo ran the pool in a mode nobody asked for.
+- An `inside-prefixes` entry is not an IPv4 CIDR, or an `outside-addresses` entry is not an IPv4 address or CIDR. An unparseable inside prefix used to be skipped when classifying a subscriber, which left them untranslated with nothing logged.
+- An `outside-addresses` prefix is wider than /16. The allocator holds one entry per address, each with its own block bitmap, so memory is linear in the size of the prefix: a /16 is about 65k entries, a /8 about 16M. A /16 is already around eight million port blocks at the default block size, so this refuses nothing a real pool needs. Split the pool if the outside space is genuinely larger.
+- An `excluded-addresses` entry is not a single IPv4 address or a /32. Both `10.0.0.1` and `10.0.0.1/32` are accepted and mean the same address.
+- Two pools claim overlapping `inside-prefixes` in a VRF they share, or claim the same outside address. Either way the pool a subscriber lands in would depend on map iteration order.
 
 ## Pools
 

--- a/internal/cgnat/pool.go
+++ b/internal/cgnat/pool.go
@@ -68,6 +68,13 @@ func (pm *PoolManager) ConfigurePool(name string, id uint32, cfg *cgnat.Pool) er
 	portStart := cfg.GetPortRangeStart()
 	portEnd := cfg.GetPortRangeEnd()
 	usablePorts := uint32(portEnd) - uint32(portStart) + 1
+	// Validate refuses every config that reaches here with a zero block size.
+	// This runs inside Component.Start, which the orchestrator calls with no
+	// recover, so returning an error is the only reportable failure: a divide
+	// by zero here is a boot loop that outlives every restart.
+	if blockSize == 0 {
+		return fmt.Errorf("pool %s: block size resolved to 0 for port range %d-%d", name, portStart, portEnd)
+	}
 	blocksPerAddr := usablePorts / uint32(blockSize)
 
 	var addresses []*outsideAddressState
@@ -86,9 +93,17 @@ func (pm *PoolManager) ConfigurePool(name string, id uint32, cfg *cgnat.Pool) er
 		}
 	}
 
-	excluded := make(map[string]bool)
+	// Both sides normalise through net.IP.String(), so "10.0.0.1" and
+	// "10.0.0.1/32" name the same address. Keying on the configured text
+	// meant one of those spellings matched nothing and the address was
+	// allocated anyway.
+	excluded := make(map[string]bool, len(cfg.ExcludedAddresses))
 	for _, ex := range cfg.ExcludedAddresses {
-		excluded[ex] = true
+		ip, err := cgnat.ParseExcludedAddress(ex)
+		if err != nil {
+			return fmt.Errorf("pool %s: invalid excluded address %s: %w", name, ex, err)
+		}
+		excluded[ip.String()] = true
 	}
 	for _, addr := range addresses {
 		if excluded[addr.IP.String()] {
@@ -563,6 +578,12 @@ func expandCIDR(cidr string) ([]net.IP, error) {
 	ones, bits := mask.Size()
 	if bits != 32 {
 		return nil, fmt.Errorf("only IPv4 supported")
+	}
+
+	// 1 << 32 wraps a uint32 to zero, which would return no addresses and
+	// leave the caller with an empty pool and no error to report.
+	if ones == 0 {
+		return nil, fmt.Errorf("prefix covers the whole address space")
 	}
 
 	count := uint32(1) << uint(bits-ones)

--- a/internal/cgnat/pool_test.go
+++ b/internal/cgnat/pool_test.go
@@ -153,3 +153,44 @@ func TestGetOrAllocate_ConcurrentSameSubscriber(t *testing.T) {
 		t.Fatalf("expected exactly 1 block allocated for subscriber after %d concurrent callers, got %d", N, len(mappings))
 	}
 }
+
+// ConfigurePool runs inside Component.Start, which the orchestrator calls
+// with no recover. Validate refuses a zero block size before it gets here;
+// this is the backstop that turns a boot loop into a reported error.
+func TestConfigurePool_ZeroBlockSizeIsAnErrorNotAPanic(t *testing.T) {
+	pm := NewPoolManager()
+	err := pm.ConfigurePool("p1", 1, &cgnat.Pool{
+		Mode:             "pba",
+		OutsideAddresses: []string{"203.0.113.0/28"},
+		SubscriberRatio:  65535,
+	})
+	if err == nil {
+		t.Fatal("expected an error for a pool whose block size resolves to 0")
+	}
+}
+
+// The allocator matches an exclusion against net.IP.String(), so a /32 in the
+// config has to exclude the same address a bare literal does.
+func TestConfigurePool_ExcludedAddressAcceptsCIDRSpelling(t *testing.T) {
+	for _, spelling := range []string{"203.0.113.1", "203.0.113.1/32"} {
+		pm := NewPoolManager()
+		if err := pm.ConfigurePool("p1", 1, &cgnat.Pool{
+			Mode:              "pba",
+			OutsideAddresses:  []string{"203.0.113.0/28"},
+			BlockSize:         512,
+			ExcludedAddresses: []string{spelling},
+		}); err != nil {
+			t.Fatalf("%s: %v", spelling, err)
+		}
+		ps := pm.pools["p1"]
+		var excluded bool
+		for _, addr := range ps.OutsideAddresses {
+			if addr.IP.String() == "203.0.113.1" {
+				excluded = addr.Excluded
+			}
+		}
+		if !excluded {
+			t.Fatalf("%s did not exclude 203.0.113.1", spelling)
+		}
+	}
+}

--- a/pkg/config/cgnat/cgnat.go
+++ b/pkg/config/cgnat/cgnat.go
@@ -4,15 +4,13 @@
 
 package cgnat
 
-import "fmt"
-
 type Config struct {
-	Standalone                bool             `json:"standalone,omitempty" yaml:"standalone,omitempty"`
-	LegacyOutsideInterfaces   []string         `json:"outside_interfaces,omitempty" yaml:"outside_interfaces,omitempty"`
-	LegacyOutsideInterface    *string          `json:"outside_interface,omitempty" yaml:"outside_interface,omitempty"`
-	Pools                     map[string]*Pool `json:"pools,omitempty" yaml:"pools,omitempty"`
-	Logging                   *LoggingConfig   `json:"logging,omitempty" yaml:"logging,omitempty"`
-	Reconcile                 *ReconcileConfig `json:"reconcile,omitempty" yaml:"reconcile,omitempty"`
+	Standalone              bool             `json:"standalone,omitempty" yaml:"standalone,omitempty"`
+	LegacyOutsideInterfaces []string         `json:"outside_interfaces,omitempty" yaml:"outside_interfaces,omitempty"`
+	LegacyOutsideInterface  *string          `json:"outside_interface,omitempty" yaml:"outside_interface,omitempty"`
+	Pools                   map[string]*Pool `json:"pools,omitempty" yaml:"pools,omitempty"`
+	Logging                 *LoggingConfig   `json:"logging,omitempty" yaml:"logging,omitempty"`
+	Reconcile               *ReconcileConfig `json:"reconcile,omitempty" yaml:"reconcile,omitempty"`
 }
 
 type ReconcileConfig struct {
@@ -42,41 +40,13 @@ func (r *ReconcileConfig) GetAllowPoolDisruption() bool {
 	return *r.AllowPoolDisruption
 }
 
-func (c *Config) Validate() error {
-	if c == nil {
-		return nil
-	}
-	if c.LegacyOutsideInterface != nil {
-		return fmt.Errorf("cgnat: outside_interface (string) has been replaced by per-pool outside_interfaces (list); move it under each pool block")
-	}
-	if len(c.LegacyOutsideInterfaces) > 0 {
-		return fmt.Errorf("cgnat: outside_interfaces at the top level has moved into each pool block; move 'outside_interfaces: [...]' under 'cgnat.pools.<name>.outside_interfaces' for each pool")
-	}
-	if c.Reconcile != nil && c.Reconcile.OnDivergence != "" &&
-		c.Reconcile.OnDivergence != "reconcile" &&
-		c.Reconcile.OnDivergence != "fail" {
-		return fmt.Errorf("cgnat: reconcile.on_divergence must be \"reconcile\" or \"fail\", got %q", c.Reconcile.OnDivergence)
-	}
-	for name, pool := range c.Pools {
-		if pool == nil {
-			continue
-		}
-		if len(pool.OutsideInterfaces) == 0 {
-			return fmt.Errorf("cgnat: pool %q: outside_interfaces is required", name)
-		}
-		seen := make(map[string]struct{}, len(pool.OutsideInterfaces))
-		for i, entry := range pool.OutsideInterfaces {
-			if entry == "" {
-				return fmt.Errorf("cgnat: pool %q: outside_interfaces[%d]: empty interface name", name, i)
-			}
-			if _, dup := seen[entry]; dup {
-				return fmt.Errorf("cgnat: pool %q: outside_interfaces: duplicate entry %q", name, entry)
-			}
-			seen[entry] = struct{}{}
-		}
-	}
-	return nil
-}
+// Defaults the getters below fall back to. Validate refuses any config where
+// these, or the values that replace them, resolve to an unusable block size.
+const (
+	defaultBlockSize      = 512
+	defaultPortRangeStart = 1024
+	defaultPortRangeEnd   = 65535
+)
 
 type Pool struct {
 	OutsideInterfaces        []string       `json:"outside_interfaces,omitempty" yaml:"outside_interfaces,omitempty"`
@@ -156,7 +126,7 @@ func (p *Pool) GetBlockSize() uint16 {
 		usable := p.GetPortRangeSize()
 		return uint16(usable / uint32(p.SubscriberRatio))
 	}
-	return 512
+	return defaultBlockSize
 }
 
 func (p *Pool) GetPortRangeStart() uint16 {
@@ -164,7 +134,7 @@ func (p *Pool) GetPortRangeStart() uint16 {
 		start, _ := parsePortRange(p.PortRange)
 		return start
 	}
-	return 1024
+	return defaultPortRangeStart
 }
 
 func (p *Pool) GetPortRangeEnd() uint16 {
@@ -172,7 +142,7 @@ func (p *Pool) GetPortRangeEnd() uint16 {
 		_, end := parsePortRange(p.PortRange)
 		return end
 	}
-	return 65535
+	return defaultPortRangeEnd
 }
 
 func (p *Pool) GetPortRangeSize() uint32 {
@@ -278,11 +248,13 @@ func (p *Pool) GetALGBitmask() uint8 {
 	return mask
 }
 
+// parsePortRange is the getters' view: the range if it parses, the default
+// otherwise. Validate has already refused anything that does not parse, so
+// the fallback is only reached by a Pool built in code rather than loaded.
 func parsePortRange(s string) (uint16, uint16) {
-	var start, end uint16
-	n, _ := fmt.Sscanf(s, "%d-%d", &start, &end)
-	if n == 2 {
-		return start, end
+	start, end, err := parsePortRangeStrict(s)
+	if err != nil {
+		return defaultPortRangeStart, defaultPortRangeEnd
 	}
-	return 1024, 65535
+	return start, end
 }

--- a/pkg/config/cgnat/validate.go
+++ b/pkg/config/cgnat/validate.go
@@ -1,0 +1,347 @@
+// Copyright 2026 The osvbng Authors
+// Licensed under the GNU General Public License v3.0 or later.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cgnat
+
+import (
+	"fmt"
+	"net"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Validate is the only gate between a config file and the component that
+// programs it (pkg/config/loader.go). Anything it lets through reaches
+// ConfigurePool inside Component.Start, which the orchestrator runs with no
+// recover: a panic there is a boot loop that survives every restart until
+// somebody edits the file by hand.
+//
+// The spellings below are the ones the dataplane implements, taken from the
+// plugin's .api enums and the pool table in docs/configuration/cgnat.md.
+// blacklist-mode and exhaustion-behavior are deliberately not checked: neither
+// has a consumer or a stated value set, so a spelling check here would be
+// inventing one. Refusing them outright belongs with the rest of the knobs
+// that parse and change nothing (osvbng#486).
+var (
+	poolModes       = []string{"pba", "deterministic"}
+	addressPoolings = []string{"paired", "arbitrary"}
+	filterings      = []string{"endpoint-independent", "endpoint-dependent"}
+)
+
+// The allocator holds one entry per outside address, each with its own block
+// bitmap, so a pool's memory is linear in the size of its prefixes: roughly
+// 6 MB for a /16, 1.7 GB for a /8, which does not survive boot. /16 is also
+// about eight million port blocks at the default block size, orders of
+// magnitude past what one BNG serves, so nothing an operator would really
+// configure is being refused here. Widening it means teaching the allocator
+// to hold ranges rather than addresses.
+const minOutsidePrefixLen = 16
+
+func (c *Config) Validate() error {
+	if c == nil {
+		return nil
+	}
+	if c.LegacyOutsideInterface != nil {
+		return fmt.Errorf("cgnat: outside_interface (string) has been replaced by per-pool outside_interfaces (list); move it under each pool block")
+	}
+	if len(c.LegacyOutsideInterfaces) > 0 {
+		return fmt.Errorf("cgnat: outside_interfaces at the top level has moved into each pool block; move 'outside_interfaces: [...]' under 'cgnat.pools.<name>.outside_interfaces' for each pool")
+	}
+	if c.Reconcile != nil && c.Reconcile.OnDivergence != "" &&
+		c.Reconcile.OnDivergence != "reconcile" &&
+		c.Reconcile.OnDivergence != "fail" {
+		return fmt.Errorf("cgnat: reconcile.on_divergence must be \"reconcile\" or \"fail\", got %q", c.Reconcile.OnDivergence)
+	}
+
+	// Pools are a map. Sort so a config with two faults always reports the
+	// same one and an operator's second run says what the first did.
+	names := make([]string, 0, len(c.Pools))
+	for name := range c.Pools {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		pool := c.Pools[name]
+		if pool == nil {
+			continue
+		}
+		if err := pool.validate(name); err != nil {
+			return err
+		}
+	}
+
+	return validateNoPoolOverlap(c, names)
+}
+
+func (p *Pool) validate(name string) error {
+	if len(p.OutsideInterfaces) == 0 {
+		return fmt.Errorf("cgnat: pool %q: outside_interfaces is required", name)
+	}
+	seen := make(map[string]struct{}, len(p.OutsideInterfaces))
+	for i, entry := range p.OutsideInterfaces {
+		if entry == "" {
+			return fmt.Errorf("cgnat: pool %q: outside_interfaces[%d]: empty interface name", name, i)
+		}
+		if _, dup := seen[entry]; dup {
+			return fmt.Errorf("cgnat: pool %q: outside_interfaces: duplicate entry %q", name, entry)
+		}
+		seen[entry] = struct{}{}
+	}
+
+	if err := validateEnum(name, "mode", p.Mode, poolModes); err != nil {
+		return err
+	}
+	if err := validateEnum(name, "address-pooling", p.AddressPooling, addressPoolings); err != nil {
+		return err
+	}
+	if err := validateEnum(name, "filtering", p.Filtering, filterings); err != nil {
+		return err
+	}
+
+	if err := p.validatePortsAndBlocks(name); err != nil {
+		return err
+	}
+
+	for i, prefix := range p.InsidePrefixes {
+		if _, err := ParseInsidePrefix(prefix.Prefix); err != nil {
+			// FindPoolForIP skips a prefix it cannot parse and returns no
+			// pool, so the subscriber comes up untranslated with nothing
+			// logged. Refuse it here instead.
+			return fmt.Errorf("cgnat: pool %q: inside-prefixes[%d]: %w", name, i, err)
+		}
+	}
+
+	for i, addr := range p.OutsideAddresses {
+		prefix, err := ParseOutsideAddress(addr)
+		if err != nil {
+			return fmt.Errorf("cgnat: pool %q: outside-addresses[%d]: %w", name, i, err)
+		}
+		if ones, _ := prefix.Mask.Size(); ones < minOutsidePrefixLen {
+			return fmt.Errorf("cgnat: pool %q: outside-addresses[%d]: %s is wider than /%d and would expand to %d allocator entries; split the pool if the outside space is really this large",
+				name, i, addr, minOutsidePrefixLen, uint64(1)<<uint(32-ones))
+		}
+	}
+
+	for i, addr := range p.ExcludedAddresses {
+		if _, err := ParseExcludedAddress(addr); err != nil {
+			return fmt.Errorf("cgnat: pool %q: excluded-addresses[%d]: %w", name, i, err)
+		}
+	}
+
+	return nil
+}
+
+func validateEnum(pool, field, value string, allowed []string) error {
+	if value == "" {
+		return nil
+	}
+	for _, a := range allowed {
+		if value == a {
+			return nil
+		}
+	}
+	return fmt.Errorf("cgnat: pool %q: %s must be one of %s, got %q",
+		pool, field, strings.Join(allowed, ", "), value)
+}
+
+// validatePortsAndBlocks refuses every input that makes GetBlockSize resolve
+// to zero, which ConfigurePool then divides the port range by.
+func (p *Pool) validatePortsAndBlocks(name string) error {
+	start, end := uint16(defaultPortRangeStart), uint16(defaultPortRangeEnd)
+	if p.PortRange != "" {
+		var err error
+		start, end, err = parsePortRangeStrict(p.PortRange)
+		if err != nil {
+			return fmt.Errorf("cgnat: pool %q: port-range: %w", name, err)
+		}
+	}
+	usable := uint32(end) - uint32(start) + 1
+
+	switch {
+	case p.BlockSize > 0:
+		if uint32(p.BlockSize) > usable {
+			return fmt.Errorf("cgnat: pool %q: block-size %d exceeds the %d ports in port-range %d-%d",
+				name, p.BlockSize, usable, start, end)
+		}
+	case p.SubscriberRatio > 0:
+		if uint32(p.SubscriberRatio) > usable {
+			return fmt.Errorf("cgnat: pool %q: subscriber-ratio %d exceeds the %d ports in port-range %d-%d, so the block size computes to 0",
+				name, p.SubscriberRatio, usable, start, end)
+		}
+	default:
+		if uint32(defaultBlockSize) > usable {
+			return fmt.Errorf("cgnat: pool %q: the default block-size %d exceeds the %d ports in port-range %d-%d; set block-size explicitly",
+				name, defaultBlockSize, usable, start, end)
+		}
+	}
+	return nil
+}
+
+// validateNoPoolOverlap refuses two pools claiming the same address.
+// FindPoolForIP walks the pool map, whose iteration order is random, and
+// returns the first prefix that contains the address, so an overlap picks a
+// different pool per call. Overlap within one pool is not ambiguous and is
+// left alone: a pool carries the same prefix in several VRFs in the
+// wholesale shape.
+func validateNoPoolOverlap(c *Config, names []string) error {
+	type claim struct {
+		pool   string
+		vrf    string
+		text   string
+		prefix *net.IPNet
+	}
+	var inside, outside []claim
+
+	for _, name := range names {
+		pool := c.Pools[name]
+		if pool == nil {
+			continue
+		}
+
+		for _, entry := range pool.InsidePrefixes {
+			prefix, err := ParseInsidePrefix(entry.Prefix)
+			if err != nil {
+				continue
+			}
+			for _, prev := range inside {
+				if prev.pool == name || !vrfsCanCollide(prev.vrf, entry.VRF) {
+					continue
+				}
+				if prefixesOverlap(prev.prefix, prefix) {
+					return fmt.Errorf("cgnat: pools %q and %q both claim inside prefix %s%s; a subscriber address in both selects a pool at random",
+						prev.pool, name, entry.Prefix, vrfNote(entry.VRF))
+				}
+			}
+			inside = append(inside, claim{pool: name, vrf: entry.VRF, text: entry.Prefix, prefix: prefix})
+		}
+
+		for _, addr := range pool.OutsideAddresses {
+			prefix, err := ParseOutsideAddress(addr)
+			if err != nil {
+				continue
+			}
+			for _, prev := range outside {
+				if prev.pool == name {
+					continue
+				}
+				if prefixesOverlap(prev.prefix, prefix) {
+					return fmt.Errorf("cgnat: pools %q and %q both claim outside address %s (also %s); one address cannot be allocated by two pools",
+						prev.pool, name, addr, prev.text)
+				}
+			}
+			outside = append(outside, claim{pool: name, text: addr, prefix: prefix})
+		}
+	}
+	return nil
+}
+
+// An empty VRF matches any VRF at classification time, so it collides with
+// every named one.
+func vrfsCanCollide(a, b string) bool {
+	return a == b || a == "" || b == ""
+}
+
+func vrfNote(vrf string) string {
+	if vrf == "" {
+		return ""
+	}
+	return fmt.Sprintf(" in vrf %q", vrf)
+}
+
+func prefixesOverlap(a, b *net.IPNet) bool {
+	return a.Contains(b.IP) || b.Contains(a.IP)
+}
+
+// ParseInsidePrefix accepts an IPv4 CIDR.
+func ParseInsidePrefix(s string) (*net.IPNet, error) {
+	_, prefix, err := net.ParseCIDR(strings.TrimSpace(s))
+	if err != nil {
+		return nil, fmt.Errorf("%q is not an IPv4 CIDR", s)
+	}
+	if prefix.IP.To4() == nil {
+		return nil, fmt.Errorf("%q is not IPv4", s)
+	}
+	return prefix, nil
+}
+
+// ParseOutsideAddress accepts a bare IPv4 address or an IPv4 CIDR, and
+// returns the prefix it covers. A bare address is a /32.
+func ParseOutsideAddress(s string) (*net.IPNet, error) {
+	t := strings.TrimSpace(s)
+	if ip := net.ParseIP(t); ip != nil {
+		ip4 := ip.To4()
+		if ip4 == nil {
+			return nil, fmt.Errorf("%q is not IPv4", s)
+		}
+		return &net.IPNet{IP: ip4, Mask: net.CIDRMask(32, 32)}, nil
+	}
+	_, prefix, err := net.ParseCIDR(t)
+	if err != nil {
+		return nil, fmt.Errorf("%q is not an IPv4 address or CIDR", s)
+	}
+	if prefix.IP.To4() == nil {
+		return nil, fmt.Errorf("%q is not IPv4", s)
+	}
+	return prefix, nil
+}
+
+// ParseExcludedAddress accepts a bare IPv4 address or a /32, and returns the
+// address. The allocator matches an exclusion against net.IP.String(), so
+// both spellings have to normalise to the same text or the entry never
+// matches anything and the address is handed out regardless.
+func ParseExcludedAddress(s string) (net.IP, error) {
+	t := strings.TrimSpace(s)
+	if ip := net.ParseIP(t); ip != nil {
+		ip4 := ip.To4()
+		if ip4 == nil {
+			return nil, fmt.Errorf("%q is not IPv4", s)
+		}
+		return ip4, nil
+	}
+	ip, prefix, err := net.ParseCIDR(t)
+	if err != nil {
+		return nil, fmt.Errorf("%q is not an IPv4 address", s)
+	}
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return nil, fmt.Errorf("%q is not IPv4", s)
+	}
+	if ones, _ := prefix.Mask.Size(); ones != 32 {
+		return nil, fmt.Errorf("%q must be a single address or a /32", s)
+	}
+	return ip4, nil
+}
+
+func parsePortRangeStrict(s string) (uint16, uint16, error) {
+	startText, endText, ok := strings.Cut(strings.TrimSpace(s), "-")
+	if !ok {
+		return 0, 0, fmt.Errorf("expected \"start-end\", got %q", s)
+	}
+	start, err := parsePort(startText)
+	if err != nil {
+		return 0, 0, fmt.Errorf("start: %w", err)
+	}
+	end, err := parsePort(endText)
+	if err != nil {
+		return 0, 0, fmt.Errorf("end: %w", err)
+	}
+	if start == 0 {
+		return 0, 0, fmt.Errorf("start must be 1 or higher")
+	}
+	if end < start {
+		return 0, 0, fmt.Errorf("end %d is below start %d", end, start)
+	}
+	return start, end, nil
+}
+
+func parsePort(s string) (uint16, error) {
+	t := strings.TrimSpace(s)
+	v, err := strconv.ParseUint(t, 10, 16)
+	if err != nil {
+		return 0, fmt.Errorf("%q is not a port number", t)
+	}
+	return uint16(v), nil
+}

--- a/pkg/config/cgnat/validate_test.go
+++ b/pkg/config/cgnat/validate_test.go
@@ -1,0 +1,286 @@
+// Copyright 2026 The osvbng Authors
+// Licensed under the GNU General Public License v3.0 or later.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cgnat
+
+import (
+	"strings"
+	"testing"
+)
+
+func poolWith(mutate func(*Pool)) *Pool {
+	p := &Pool{
+		Mode:              "pba",
+		OutsideInterfaces: []string{"eth2"},
+	}
+	mutate(p)
+	return p
+}
+
+func validatePool(p *Pool) error {
+	return (&Config{Pools: map[string]*Pool{"residential": p}}).Validate()
+}
+
+func expectRefused(t *testing.T, err error, want string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected the config to be refused, it validated cleanly")
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("expected an error mentioning %q, got %v", want, err)
+	}
+	if !strings.Contains(err.Error(), `"residential"`) && !strings.Contains(err.Error(), "pools") {
+		t.Fatalf("expected the pool name in the error, got %v", err)
+	}
+}
+
+// The reported boot loop: the block size truncates to zero and ConfigurePool
+// divides the port range by it inside Component.Start, which has no recover.
+func TestConfigValidate_SubscriberRatioWiderThanPortRange(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		ratio uint16
+		ports string
+	}{
+		{"default range", 65535, ""},
+		{"narrow range", 2000, "1024-2047"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := poolWith(func(p *Pool) {
+				p.SubscriberRatio = tc.ratio
+				p.PortRange = tc.ports
+			})
+			if got := p.GetBlockSize(); got != 0 {
+				t.Fatalf("fixture no longer reproduces a zero block size, got %d", got)
+			}
+			expectRefused(t, validatePool(p), "block size computes to 0")
+		})
+	}
+}
+
+func TestConfigValidate_BlockSizeWiderThanPortRange(t *testing.T) {
+	p := poolWith(func(p *Pool) {
+		p.BlockSize = 4096
+		p.PortRange = "1024-2047"
+	})
+	expectRefused(t, validatePool(p), "block-size 4096 exceeds")
+}
+
+func TestConfigValidate_DefaultBlockSizeWiderThanPortRange(t *testing.T) {
+	p := poolWith(func(p *Pool) { p.PortRange = "1024-1200" })
+	expectRefused(t, validatePool(p), "default block-size")
+}
+
+func TestConfigValidate_InvertedPortRange(t *testing.T) {
+	p := poolWith(func(p *Pool) { p.PortRange = "9000-1024" })
+	expectRefused(t, validatePool(p), "end 1024 is below start 9000")
+}
+
+func TestConfigValidate_MalformedPortRange(t *testing.T) {
+	for _, spec := range []string{"1024", "", "1024-70000", "abc-def", "0-1024"} {
+		p := poolWith(func(p *Pool) { p.PortRange = spec })
+		if spec == "" {
+			// An unset range is the default, not a fault.
+			if err := validatePool(p); err != nil {
+				t.Fatalf("unset port-range should validate, got %v", err)
+			}
+			continue
+		}
+		if err := validatePool(p); err == nil {
+			t.Fatalf("port-range %q should be refused", spec)
+		}
+	}
+}
+
+// A typo used to select the default silently: "determinstic" ran as PBA.
+func TestConfigValidate_EnumTypos(t *testing.T) {
+	for _, tc := range []struct {
+		field  string
+		mutate func(*Pool)
+	}{
+		{"mode", func(p *Pool) { p.Mode = "determinstic" }},
+		{"filtering", func(p *Pool) { p.Filtering = "endpoint-indepedent" }},
+		{"address-pooling", func(p *Pool) { p.AddressPooling = "pared" }},
+	} {
+		t.Run(tc.field, func(t *testing.T) {
+			expectRefused(t, validatePool(poolWith(tc.mutate)), tc.field+" must be one of")
+		})
+	}
+}
+
+func TestConfigValidate_EnumValuesTheDataplaneImplements(t *testing.T) {
+	p := poolWith(func(p *Pool) {
+		p.Mode = "deterministic"
+		p.Filtering = "endpoint-dependent"
+		p.AddressPooling = "arbitrary"
+	})
+	if err := validatePool(p); err != nil {
+		t.Fatalf("expected the implemented spellings to validate, got %v", err)
+	}
+}
+
+func TestConfigValidate_BadInsidePrefix(t *testing.T) {
+	p := poolWith(func(p *Pool) {
+		p.InsidePrefixes = []InsidePrefix{{Prefix: "100.64.0.0"}}
+	})
+	expectRefused(t, validatePool(p), "is not an IPv4 CIDR")
+}
+
+// One allocator entry per address: a /8 does not survive boot, and /0
+// additionally overflows the host count to zero addresses.
+func TestConfigValidate_OutsidePrefixTooWide(t *testing.T) {
+	for _, spec := range []string{"0.0.0.0/0", "10.0.0.0/8", "172.16.0.0/12"} {
+		p := poolWith(func(p *Pool) { p.OutsideAddresses = []string{spec} })
+		expectRefused(t, validatePool(p), "is wider than /16")
+	}
+}
+
+func TestConfigValidate_OutsidePrefixAtTheLimit(t *testing.T) {
+	for _, spec := range []string{"198.51.0.0/16", "203.0.113.0/28", "203.0.113.5"} {
+		p := poolWith(func(p *Pool) { p.OutsideAddresses = []string{spec} })
+		if err := validatePool(p); err != nil {
+			t.Fatalf("outside prefix %s should validate, got %v", spec, err)
+		}
+	}
+}
+
+func TestConfigValidate_BadOutsideAddress(t *testing.T) {
+	p := poolWith(func(p *Pool) { p.OutsideAddresses = []string{"203.0.113.256"} })
+	expectRefused(t, validatePool(p), "is not an IPv4 address or CIDR")
+}
+
+func TestConfigValidate_BadExcludedAddress(t *testing.T) {
+	p := poolWith(func(p *Pool) { p.ExcludedAddresses = []string{"203.0.113.0/28"} })
+	expectRefused(t, validatePool(p), "must be a single address or a /32")
+}
+
+// The allocator compares an exclusion against net.IP.String(); both spellings
+// have to reduce to that or the entry silently matches nothing.
+func TestParseExcludedAddress_BothSpellingsNormalise(t *testing.T) {
+	for _, spec := range []string{"10.0.0.1", "10.0.0.1/32"} {
+		ip, err := ParseExcludedAddress(spec)
+		if err != nil {
+			t.Fatalf("%q should parse, got %v", spec, err)
+		}
+		if ip.String() != "10.0.0.1" {
+			t.Fatalf("%q normalised to %q, want 10.0.0.1", spec, ip.String())
+		}
+	}
+}
+
+// FindPoolForIP walks the pool map in random order, so two pools claiming one
+// address answer differently per call.
+func TestConfigValidate_OverlappingInsidePrefixesAcrossPools(t *testing.T) {
+	cfg := &Config{Pools: map[string]*Pool{
+		"ispA": poolWith(func(p *Pool) {
+			p.InsidePrefixes = []InsidePrefix{{Prefix: "100.64.0.0/16"}}
+		}),
+		"ispB": poolWith(func(p *Pool) {
+			p.InsidePrefixes = []InsidePrefix{{Prefix: "100.64.1.0/24"}}
+		}),
+	}}
+	expectRefused(t, cfg.Validate(), "both claim inside prefix")
+}
+
+func TestConfigValidate_OverlappingInsidePrefixesNeedACommonVRF(t *testing.T) {
+	cfg := &Config{Pools: map[string]*Pool{
+		"ispA": poolWith(func(p *Pool) {
+			p.InsidePrefixes = []InsidePrefix{{Prefix: "100.64.0.0/16", VRF: "CUSTOMER-A"}}
+		}),
+		"ispB": poolWith(func(p *Pool) {
+			p.InsidePrefixes = []InsidePrefix{{Prefix: "100.64.0.0/16", VRF: "CUSTOMER-B"}}
+		}),
+	}}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("the same prefix in two VRFs is not ambiguous, got %v", err)
+	}
+}
+
+// An unset VRF matches any VRF at classification, so it collides with a
+// named one.
+func TestConfigValidate_UnsetVRFCollidesWithANamedOne(t *testing.T) {
+	cfg := &Config{Pools: map[string]*Pool{
+		"ispA": poolWith(func(p *Pool) {
+			p.InsidePrefixes = []InsidePrefix{{Prefix: "100.64.0.0/16"}}
+		}),
+		"ispB": poolWith(func(p *Pool) {
+			p.InsidePrefixes = []InsidePrefix{{Prefix: "100.64.0.0/16", VRF: "CUSTOMER-A"}}
+		}),
+	}}
+	expectRefused(t, cfg.Validate(), "both claim inside prefix")
+}
+
+// One pool carrying the same prefix in several VRFs is the wholesale shape
+// the VRF rig suite ships.
+func TestConfigValidate_SamePrefixTwiceInOnePool(t *testing.T) {
+	cfg := &Config{Pools: map[string]*Pool{
+		"residential": poolWith(func(p *Pool) {
+			p.InsidePrefixes = []InsidePrefix{
+				{Prefix: "100.64.0.0/24", VRF: "CUSTOMER-A"},
+				{Prefix: "100.64.0.0/24", VRF: "CUSTOMER-B"},
+			}
+			p.OutsideAddresses = []string{"203.0.113.0/28"}
+		}),
+	}}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected the shipped VRF pool shape to validate, got %v", err)
+	}
+}
+
+func TestConfigValidate_OverlappingOutsideAddressesAcrossPools(t *testing.T) {
+	cfg := &Config{Pools: map[string]*Pool{
+		"ispA": poolWith(func(p *Pool) { p.OutsideAddresses = []string{"203.0.113.0/28"} }),
+		"ispB": poolWith(func(p *Pool) { p.OutsideAddresses = []string{"203.0.113.4"} }),
+	}}
+	expectRefused(t, cfg.Validate(), "both claim outside address")
+}
+
+// The pool every CGNAT rig suite ships, so a refusal here would be a
+// regression against a config known to pass traffic.
+func TestConfigValidate_ShippedRigPoolValidates(t *testing.T) {
+	cfg := &Config{Pools: map[string]*Pool{
+		"residential": {
+			OutsideInterfaces:        []string{"eth2"},
+			Mode:                     "pba",
+			InsidePrefixes:           []InsidePrefix{{Prefix: "100.64.0.0/16"}},
+			OutsideAddresses:         []string{"203.0.113.0/28"},
+			BlockSize:                512,
+			MaxBlocksPerSubscriber:   2,
+			MaxSessionsPerSubscriber: 2000,
+			AddressPooling:           "paired",
+			Filtering:                "endpoint-independent",
+			Timeouts: &TimeoutConfig{
+				TCPEstablished: 7200,
+				TCPTransitory:  240,
+				UDP:            300,
+				ICMP:           60,
+			},
+		},
+	}}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected the shipped rig pool to validate, got %v", err)
+	}
+}
+
+// The wholesale example in docs/configuration/cgnat.md: one pool per ISP,
+// the same inside prefix in each ISP's own VRF, separate outside space.
+func TestConfigValidate_DocumentedWholesaleExample(t *testing.T) {
+	cfg := &Config{Pools: map[string]*Pool{
+		"ispA": {
+			OutsideInterfaces: []string{"bond0.100", "bond0.101"},
+			Mode:              "pba",
+			InsidePrefixes:    []InsidePrefix{{Prefix: "100.64.0.0/16", VRF: "ispA-inside"}},
+			OutsideAddresses:  []string{"203.0.113.0/24"},
+		},
+		"ispB": {
+			OutsideInterfaces: []string{"bond0.200", "bond0.201"},
+			Mode:              "pba",
+			InsidePrefixes:    []InsidePrefix{{Prefix: "100.64.0.0/16", VRF: "ispB-inside"}},
+			OutsideAddresses:  []string{"198.51.100.0/24"},
+		},
+	}}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected the documented wholesale example to validate, got %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

One plausible CGNAT pool value puts osvbngd into a boot loop. A `subscriber-ratio` wider than the port range truncates the computed block size to zero, and `ConfigurePool` divides the port range by it during startup reconcile. That runs inside `Component.Start`, which the orchestrator calls with no recover, so every boot dies the same way until somebody edits the file by hand. `Validate` was the only gate and it checked nothing numeric.

Six more gaps in the same pass, each of them an operator being told something that is not true:

- `port-range` accepted an end below its start, so `"9000-1024"` produced about four billion usable ports and a /24 of outside addresses asked for 256 MiB of bitmap.
- Nothing checked whether two pools claimed the same inside prefix or outside address. `FindPoolForIP` walks the pool map, whose iteration order is random, so an overlap picked a different pool per call.
- An unrecognised `mode`, `filtering` or `address-pooling` fell back to the default, so `determinstic` quietly ran the pool as PBA.
- An outside prefix was expanded one address at a time with no bound, and `/0` overflowed the host counter to zero addresses: a pool that silently had no capacity at all.
- An excluded address was matched as configured text against `net.IP.String()`, so `10.0.0.1/32` never matched anything and the address was handed out regardless.
- An unparseable inside prefix was skipped when classifying a subscriber, with nothing logged, leaving them untranslated.

## Change

`Validate` refuses each of the seven, naming the pool and the field, and iterates pools in sorted order so a config with two faults reports the same one every run. `ConfigurePool` returns an error rather than dividing by zero if one ever reaches it again, the excluded-address comparison normalises both spellings through `net.IP`, and `expandCIDR` reports the `/0` overflow instead of returning an empty list.

Two judgement calls worth reviewing.

**Outside prefixes are capped at /16**, which is a limit this change picks rather than one the design already had. The allocator holds one entry per address, each with its own block bitmap, so memory is linear in the prefix: roughly 6 MB for a /16 and 1.7 GB for a /8, which does not survive boot. A /16 is also around eight million port blocks at the default block size, so the cap refuses nothing a real pool needs. Widening it means teaching the allocator to hold ranges rather than addresses.

**`blacklist-mode` and `exhaustion-behavior` are deliberately not checked.** Neither has a consumer nor a stated value set, so a spelling check here would be inventing one. Refusing them belongs with the rest of the knobs that parse and change nothing (#486).

The accepted spellings come from the plugin's `.api` enums and the pool table in `docs/configuration/cgnat.md`, not from guesswork, and the docs' validation list is extended to match.

## Verification

Unit tests per refusal. The reported divide-by-zero fixture is asserted still to produce a zero block size, so the test fails if the getter changes underneath it, and removing the `ConfigurePool` guard was confirmed to panic with `integer divide by zero` rather than assumed.

All 63 `osvbng.yaml` files under `tests/` and `configs/` still load and validate. The documented wholesale example and the VRF suite's same-prefix-in-two-VRFs pool are both covered as regression tests, since the overlap rule had to allow them: overlap is only refused across pools, and only where the VRFs can match the same traffic. `make test` passes.

On the rig, a pool with `subscriber-ratio: 65535` panicked through `internal/cgnat/pool.go:71` up to `main.main` on the current code and the container restarted into the same failure. With this change the same config is refused at load:

```
Failed to generate external configs: load config: validate config: cgnat: pool "residential": subscriber-ratio 65535 exceeds the 64512 ports in port-range 1024-65535, so the block size computes to 0
```

Suite 08 then passes 14 of 14 with the validation in place, so no working CGNAT config is caught by it.

Not verified: the overlap and enum refusals were exercised by unit test only, not by booting a lab per case.