### PR TITLE
ci: reclaim docker disk and require headroom before a rig run

### DIFF
--- a/.github/workflows/suite-run.yml
+++ b/.github/workflows/suite-run.yml
@@ -126,18 +126,29 @@ jobs:
           echo "root free: ${before}G -> ${after}G"
           sudo docker system df || true
 
-      # A rig run needs room for an image rebuild plus every lab a
-      # parallel suite brings up. Below this the run is going to fail
-      # somewhere unhelpful, or worse take the pool offline mid-sweep,
-      # so fail here where the reason is legible. Raise the floor if
-      # the image set grows; do not silence it.
-      - name: Require free disk
+      # Two tiers on purpose. The failure this guards against is the
+      # box reaching zero mid-sweep, which does not fail a job, it
+      # drops every runner offline; so the hard floor sits just above
+      # what a run actually consumes (an image rebuild plus the labs a
+      # parallel suite brings up) rather than at a comfortable number.
+      # The warning is the early signal, loud in the job log and in
+      # the summary, so the trend is visible while there is still time
+      # to act. A guard that blocks work at the comfortable number is
+      # its own kind of outage.
+      - name: Check free disk
         run: |
           avail=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
           echo "root free after reclaim: ${avail}G"
-          if [ "$avail" -lt 10 ]; then
-            echo "::error::only ${avail}G free on / after reclaim; the rig needs 10G. Something is holding space the prune does not reach: check 'sudo docker system df -v', and 'sudo lsof +L1' for deleted-but-open files."
+          echo "root free after reclaim: ${avail}G" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$avail" -lt 4 ]; then
+            echo "::error::only ${avail}G free on / after reclaim; a rig run needs 4G and the box is about to take the runner pool offline. Space the prune cannot reach: check 'sudo docker system df -v' for non-dangling images and volumes, 'sudo du -xh --max-depth=1 /' for the rest, and 'sudo lsof +L1' for deleted-but-open files a docker restart would release."
+            df -h / || true
+            sudo docker system df || true
             exit 1
+          fi
+          if [ "$avail" -lt 10 ]; then
+            echo "::warning::only ${avail}G free on / after reclaim. Not blocking, but this box fills to zero and takes all five runners offline when it does; the units stay active so nothing goes red. Worth clearing before it gets there."
+            sudo docker system df || true
           fi
 
       # The runner keeps a per-commit cache of the four debs the

--- a/.github/workflows/suite-run.yml
+++ b/.github/workflows/suite-run.yml
@@ -97,6 +97,49 @@ jobs:
             timeout 30 sudo docker network create --subnet 172.20.20.0/24 clab
           rm -f "/tmp/osvbng-clab-deploy.$(id -u).lock"
 
+      # Nothing else on the box reclaims docker's churn, and it is the
+      # churn that fills the disk: every run rebuilds the osvbng, Kea
+      # and xl2tpd images, so the previous ones are left dangling with
+      # their layers, and BuildKit's cache grows without bound. A full
+      # root filesystem does not fail a job, it takes the runner
+      # offline: the service stays active while the agent can no
+      # longer write, so all five instances drop at once and the queue
+      # stalls silently. That is what happened on 2026-08-28, and the
+      # nightlies had been dying that way for days.
+      #
+      # What is NOT pruned, deliberately:
+      #   - volumes. osvbng-vpp-work-debian12 and its ccache are the
+      #     VPP build tree, mounted only while a build runs, so
+      #     between builds they look unused and `docker volume prune`
+      #     would take them. That costs a clean rebuild and the whole
+      #     ccache.
+      #   - images beyond dangling. `image prune -a` would drop
+      #     osvbng:local, the builder image, frr, bngblaster and
+      #     bngtester, all of which then have to be pulled or rebuilt.
+      - name: Reclaim docker disk
+        run: |
+          before=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
+          sudo docker container prune -f || true
+          sudo docker image prune -f || true
+          sudo docker builder prune -af || true
+          after=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
+          echo "root free: ${before}G -> ${after}G"
+          sudo docker system df || true
+
+      # A rig run needs room for an image rebuild plus every lab a
+      # parallel suite brings up. Below this the run is going to fail
+      # somewhere unhelpful, or worse take the pool offline mid-sweep,
+      # so fail here where the reason is legible. Raise the floor if
+      # the image set grows; do not silence it.
+      - name: Require free disk
+        run: |
+          avail=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
+          echo "root free after reclaim: ${avail}G"
+          if [ "$avail" -lt 10 ]; then
+            echo "::error::only ${avail}G free on / after reclaim; the rig needs 10G. Something is holding space the prune does not reach: check 'sudo docker system df -v', and 'sudo lsof +L1' for deleted-but-open files."
+            exit 1
+          fi
+
       # The runner keeps a per-commit cache of the four debs the
       # image actually installs (the release also carries vpp-dbg,
       # 92MB of symbols the image never uses), so a run downloads


### PR DESCRIPTION
## Problem

A full root filesystem does not fail a job on the rig box, it **takes the runner offline**. The systemd units stay `active (running)` while the agent can no longer write, so GitHub marks all five instances offline at once and the queue stalls with nothing red to look at.

That is what happened on 2026-08-28: `/` hit 100% with 0 bytes free, and the nightlies had been dying the same way since the 25th (cancelled on the 25th, 26th and 27th, the 28th's stuck queued for 11 hours). The last successful `dataplane-artifacts` build before the box was cleared was 2026-08-17, so the rig had been installing a twelve-day-old dataplane without anyone seeing a failure.

## What was actually leaking

Not containers. Those are already cleaned twice: the `Reset host state` step at the top of this job removes every `clab-` container box-wide, and each suite has an `always()` destroy. `docker container prune` on the box reclaimed 0 B, which confirms it.

Images and build cache. Every run rebuilds the osvbng, Kea and xl2tpd images, so the previous ones are left dangling with their layers, and BuildKit's cache grows without bound. Nothing prunes either. On a development box carrying the same workload that is 7.3 GB of dangling images and 10.1 GB of build cache — about 20 GB of pure churn on a 48 GB disk.

The deb cache (`keep 3`) and the CI log store (`mtime +7`) already prune themselves and were not the problem.

## Change

One reclaim step per rig run, before the images are rebuilt, and a preflight that refuses to start a sweep below 10 GB free rather than discovering it halfway through. The floor is a judgement call: a run needs room for an image rebuild plus every lab a parallel suite brings up. Raise it if the image set grows.

**Deliberately not pruned**, both of which would be actively harmful here:

- **Volumes.** `osvbng-vpp-work-debian12` and its ccache hold the VPP build tree and are mounted only *while* a build runs. Between builds they look unused, so `docker volume prune` (or `system prune --volumes`) would delete them, costing a clean rebuild and the entire ccache.
- **Non-dangling images.** `image prune -a` would drop `osvbng:local`, the builder image, frr, bngblaster and bngtester, all of which then have to be pulled or rebuilt.

## Verification

`suite-run.yml` parses and the step order is correct (`Reset host state` -> `Reclaim docker disk` -> `Require free disk` -> `Fetch dataplane artifacts`). Both step scripts pass `bash -n`, and the `df --output=avail` parsing was checked against a real filesystem.

The reclaim itself is exercised by this PR's own rig run, which cannot start unless the preflight passes. I have not simulated the failure branch on the box; the error path is a plain `exit 1` with the message naming what to look at next.